### PR TITLE
Restoring user search results when query is empty

### DIFF
--- a/Users.js
+++ b/Users.js
@@ -84,10 +84,14 @@ class Users extends Component {
   }
 
   onChangeSearch(e) {
+
     const term = e.target.value;
+    const transitionLoc = term === "" ?  this.props.location.pathname : `${this.props.location.pathname}?query=${term}`;     
+
     console.log('User searched:', term, 'at', this.props.location.pathname);
     this.setState({ searchTerm: term });
-    this.context.router.transitionTo(`${this.props.location.pathname}?query=${term}`);
+    this.context.router.transitionTo(transitionLoc);
+
   }
 
   onClearSearch() {


### PR DESCRIPTION
This is a smaller PR which only restores the initial state of the search list when the search box has been cleared using the backspace button.