### PR TITLE
Stripes 289

### DIFF
--- a/UserPermissions.js
+++ b/UserPermissions.js
@@ -2,14 +2,7 @@ import _ from 'lodash';
 // We have to remove node_modules/react to avoid having multiple copies loaded.
 // eslint-disable-next-line import/no-unresolved
 import React, { PropTypes } from 'react';
-import { Row, Col, Dropdown } from 'react-bootstrap';
-import DropdownMenu from '@folio/stripes-components/lib/DropdownMenu';
-import Button from '@folio/stripes-components/lib/Button';
-import Icon from '@folio/stripes-components/lib/Icon';
-import List from '@folio/stripes-components/lib/List';
-import IfPermission from '@folio/stripes-components/lib/IfPermission';
-import ListDropdown from './lib/ListDropdown';
-import css from './UserPermissions.css';
+import RenderPermissions from './lib/RenderPermissions';
 
 const propTypes = {
   stripes: PropTypes.shape({
@@ -55,6 +48,7 @@ class UserPermissions extends React.Component {
 
     this.onToggleAddPermDD = this.onToggleAddPermDD.bind(this);
     this.addPermission = this.addPermission.bind(this);
+    this.removePermission = this.removePermission.bind(this);
     this.onChangeSearch = this.onChangeSearch.bind(this);
     this.isPermAvailable = this.isPermAvailable.bind(this);
   }
@@ -78,6 +72,7 @@ class UserPermissions extends React.Component {
   }
 
   removePermission(perm) {
+    console.log(this.props);
     this.props.mutator.userPermissions.DELETE(perm, this.props.viewUserProps, perm.permissionName);
   }
 
@@ -92,65 +87,21 @@ class UserPermissions extends React.Component {
   }
 
   render() {
+
     const { userPermissions } = this.props.data;
 
-    if (!this.props.stripes.hasPerm('perms.users.read'))
-      return null;
-
-    const permissionsDD = (
-      <ListDropdown
-        items={_.filter(this.props.availablePermissions, this.isPermAvailable)}
-        onClickItem={this.addPermission}
-        onChangeSearch={this.onChangeSearch}
-      />
-    );
-
-    const listFormatter = item => (
-      <li key={item.permissionName} >
-        {!item.displayName ? item.permissionName : item.displayName}
-        <Button
-          buttonStyle="fieldControl"
-          align="end"
-          type="button"
-          onClick={() => this.removePermission(item)}
-          aria-label={`Remove Permission: ${item.permissionName}`}
-          title="Remove Permission"
-        >
-          <IfPermission {...this.props} perm="perms.users.delete">
-            <Icon icon="hollowX" iconClassName={css.removePermissionIcon} iconRootClass={css.removePermissionButton} />
-          </IfPermission>
-        </Button>
-      </li>
-    );
-
-    return (
-      <div style={{ marginBottom: '1rem' }}>
-        <hr />
-        <Row>
-          <Col xs={5}>
-            <h3 className="marginTop0">User permissions</h3>
-          </Col>
-          {/* <Col xs={4} sm={3}>
-            <TextField
-              rounded
-              endControl={<Button buttonStyle="fieldControl"><Icon icon='clearX'/></Button>}
-              startControl={<Icon icon='search'/>}
-              placeholder="Search"
-              fullWidth
-              />
-          </Col>*/}
-          <Col xs={7}>
-            <IfPermission {...this.props} perm="perms.users.modify">
-              <Dropdown open={this.state.addPermissionOpen} pullRight onToggle={this.onToggleAddPermDD} id="AddPermissionDropdown" style={{ float: 'right' }}>
-                <Button align="end" bottomMargin0 bsRole="toggle" aria-haspopup="true">&#43; Add Permission</Button>
-                <DropdownMenu bsRole="menu" onToggle={this.onToggleAddPermDD} aria-label="available permissions" width="40em">{permissionsDD}</DropdownMenu>
-              </Dropdown>
-            </IfPermission>
-          </Col>
-        </Row>
-        <List itemFormatter={listFormatter} items={userPermissions || []} isEmptyMessage="This user has no permissions applied." />
-      </div>
-    );
+    return (<RenderPermissions 
+              {...this.props}
+              heading="User permissions" 
+              isPermAvailable={this.isPermAvailable} 
+              addPermission={this.addPermission} 
+              onChangeSearch={this.onChangeSearch} 
+              removePermission={this.removePermission} 
+              state={this.state} 
+              onToggleAddPermDD={this.onToggleAddPermDD}
+              userPermissions={userPermissions}
+           ></RenderPermissions>);
+      
   }
 }
 

--- a/UserPermissions.js
+++ b/UserPermissions.js
@@ -40,50 +40,18 @@ class UserPermissions extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {
-      addPermissionOpen: false,
-      searchTerm: '',
-      // handling active Permissions in state for presentation purposes only.
-    };
 
-    this.onToggleAddPermDD = this.onToggleAddPermDD.bind(this);
     this.addPermission = this.addPermission.bind(this);
     this.removePermission = this.removePermission.bind(this);
-    this.onChangeSearch = this.onChangeSearch.bind(this);
-    this.isPermAvailable = this.isPermAvailable.bind(this);
-  }
 
-  onToggleAddPermDD() {
-    const isOpen = this.state.addPermissionOpen;
-    this.setState({
-      addPermissionOpen: !isOpen,
-    });
-  }
-
-  onChangeSearch(e) {
-    const searchTerm = e.target.value;
-    this.setState({ searchTerm });
   }
 
   addPermission(perm) {
-    this.props.mutator.userPermissions.POST(perm, this.props.viewUserProps).then(() => {
-      this.onToggleAddPermDD();
-    });
+    this.props.mutator.userPermissions.POST(perm, this.props.viewUserProps);
   }
 
   removePermission(perm) {
-    console.log(this.props);
     this.props.mutator.userPermissions.DELETE(perm, this.props.viewUserProps, perm.permissionName);
-  }
-
-  isPermAvailable(perm) {
-    const permInUse = _.some(this.props.data.userPermissions, perm);
-
-    // This should be replaced with proper search when possible.
-    const nameToCompare = !perm.displayName ? perm.permissionName.toLowerCase() : perm.displayName.toLowerCase();
-    const permNotFiltered = _.includes(nameToCompare, this.state.searchTerm.toLowerCase());
-
-    return !permInUse && permNotFiltered;
   }
 
   render() {
@@ -92,14 +60,10 @@ class UserPermissions extends React.Component {
 
     return (<RenderPermissions 
               {...this.props}
-              heading="User permissions" 
-              isPermAvailable={this.isPermAvailable} 
+              heading="User Permissions" 
               addPermission={this.addPermission} 
-              onChangeSearch={this.onChangeSearch} 
               removePermission={this.removePermission} 
-              state={this.state} 
-              onToggleAddPermDD={this.onToggleAddPermDD}
-              userPermissions={userPermissions}
+              listedPermissions={userPermissions}
            ></RenderPermissions>);
       
   }

--- a/lib/RenderPermissions/RenderPermissions.css
+++ b/lib/RenderPermissions/RenderPermissions.css
@@ -1,4 +1,3 @@
-
 .removePermissionButton{
   & .removePermissionIcon{
     fill: #999;
@@ -10,4 +9,3 @@
     }
   }
 }
-

--- a/lib/RenderPermissions/RenderPermissions.js
+++ b/lib/RenderPermissions/RenderPermissions.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import css from './RenderPermissions.css';
+import ListDropdown from '../ListDropdown';
+import { Row, Col, Dropdown } from 'react-bootstrap';
+import DropdownMenu from '@folio/stripes-components/lib/DropdownMenu';
+import Button from '@folio/stripes-components/lib/Button';
+import Icon from '@folio/stripes-components/lib/Icon';
+import List from '@folio/stripes-components/lib/List';
+import IfPermission from '../IfPermission';
+
+function RenderPermissions(props) {
+
+	if (!props.stripes.hasPerm('perms.users.read'))
+      return null;
+
+	const permissionsDD = (
+   		<ListDropdown
+        	items={_.filter(props.availablePermissions, props.isPermAvailable)}
+        	onClickItem={props.addPermission}
+        	onChangeSearch={props.onChangeSearch}
+      	/>
+    );
+
+	const listFormatter = item => (
+      <li key={item.permissionName} >
+        {!item.displayName ? item.permissionName : item.displayName}
+        <Button
+          buttonStyle="fieldControl"
+          align="end"
+          type="button"
+          onClick={() => props.removePermission(item)}
+          aria-label={`Remove Permission: ${item.permissionName}`}
+          title="Remove Permission"
+        >
+          <IfPermission {...props} perm="perms.users.delete">
+            <Icon icon="hollowX" iconClassName={css.removePermissionIcon} iconRootClass={css.removePermissionButton} />
+          </IfPermission>
+        </Button>
+      </li>
+    );
+    
+  return(
+   	<div style={{ marginBottom: '1rem' }}>
+        <hr />
+        <Row>
+          <Col xs={5}>
+            <h3 className="marginTop0">{props.heading}</h3>
+          </Col>
+          {/* <Col xs={4} sm={3}>
+            <TextField
+              rounded
+              endControl={<Button buttonStyle="fieldControl"><Icon icon='clearX'/></Button>}
+              startControl={<Icon icon='search'/>}
+              placeholder="Search"
+              fullWidth
+              />
+          </Col>*/}
+          <Col xs={7}>
+            <IfPermission {...props} perm="perms.users.modify">
+              <Dropdown open={props.state.addPermissionOpen} pullRight onToggle={props.onToggleAddPermDD} id="AddPermissionDropdown" style={{ float: 'right' }}>
+                <Button align="end" bottomMargin0 bsRole="toggle" aria-haspopup="true">&#43; Add Permission</Button>
+                <DropdownMenu bsRole="menu" onToggle={props.onToggleAddPermDD} aria-label="available permissions" width="40em">{permissionsDD}</DropdownMenu>
+              </Dropdown>
+            </IfPermission>
+          </Col>
+        </Row>
+        <List itemFormatter={listFormatter} items={props.userPermissions || []} isEmptyMessage="This user has no permissions applied." />
+    </div>
+  );
+}
+
+export default RenderPermissions;

--- a/lib/RenderPermissions/RenderPermissions.js
+++ b/lib/RenderPermissions/RenderPermissions.js
@@ -6,67 +6,114 @@ import DropdownMenu from '@folio/stripes-components/lib/DropdownMenu';
 import Button from '@folio/stripes-components/lib/Button';
 import Icon from '@folio/stripes-components/lib/Icon';
 import List from '@folio/stripes-components/lib/List';
-import IfPermission from '../IfPermission';
+import IfPermission from '@folio/stripes-components/lib/IfPermission';
 
-function RenderPermissions(props) {
+class RenderPermissions extends React.Component {
 
-	if (!props.stripes.hasPerm('perms.users.read'))
-      return null;
+	 constructor(props) {
+	 	super(props);
 
-	const permissionsDD = (
-   		<ListDropdown
-        	items={_.filter(props.availablePermissions, props.isPermAvailable)}
-        	onClickItem={props.addPermission}
-        	onChangeSearch={props.onChangeSearch}
-      	/>
-    );
+	 	this.state = {
+	      addPermissionOpen: false,
+	      searchTerm: '',
+	    };
 
-	const listFormatter = item => (
-      <li key={item.permissionName} >
-        {!item.displayName ? item.permissionName : item.displayName}
-        <Button
-          buttonStyle="fieldControl"
-          align="end"
-          type="button"
-          onClick={() => props.removePermission(item)}
-          aria-label={`Remove Permission: ${item.permissionName}`}
-          title="Remove Permission"
-        >
-          <IfPermission {...props} perm="perms.users.delete">
-            <Icon icon="hollowX" iconClassName={css.removePermissionIcon} iconRootClass={css.removePermissionButton} />
-          </IfPermission>
-        </Button>
-      </li>
-    );
-    
-  return(
-   	<div style={{ marginBottom: '1rem' }}>
-        <hr />
-        <Row>
-          <Col xs={5}>
-            <h3 className="marginTop0">{props.heading}</h3>
-          </Col>
-          {/* <Col xs={4} sm={3}>
-            <TextField
-              rounded
-              endControl={<Button buttonStyle="fieldControl"><Icon icon='clearX'/></Button>}
-              startControl={<Icon icon='search'/>}
-              placeholder="Search"
-              fullWidth
-              />
-          </Col>*/}
-          <Col xs={7}>
-            <IfPermission {...props} perm="perms.users.modify">
-              <Dropdown open={props.state.addPermissionOpen} pullRight onToggle={props.onToggleAddPermDD} id="AddPermissionDropdown" style={{ float: 'right' }}>
-                <Button align="end" bottomMargin0 bsRole="toggle" aria-haspopup="true">&#43; Add Permission</Button>
-                <DropdownMenu bsRole="menu" onToggle={props.onToggleAddPermDD} aria-label="available permissions" width="40em">{permissionsDD}</DropdownMenu>
-              </Dropdown>
-            </IfPermission>
-          </Col>
-        </Row>
-        <List itemFormatter={listFormatter} items={props.userPermissions || []} isEmptyMessage="This user has no permissions applied." />
-    </div>
-  );
+	    this.onChangeSearch = this.onChangeSearch.bind(this);
+	 	this.onToggleAddPermDD = this.onToggleAddPermDD.bind(this);
+	 	this.isPermAvailable = this.isPermAvailable.bind(this);
+	 	this.addPermissionHandler = this.addPermissionHandler.bind(this);
+
+	 }
+
+	  onChangeSearch(e) {
+	    const searchTerm = e.target.value;
+	    this.setState({ searchTerm });
+	  }
+
+	 isPermAvailable(perm) {
+
+	    const permInUse = _.some(this.props.listedPermissions?this.props.listedPermissions:[], perm);
+
+	    // This should be replaced with proper search when possible.
+	    const nameToCompare = !perm.displayName ? perm.permissionName.toLowerCase() : perm.displayName.toLowerCase();
+	    const permNotFiltered = _.includes(nameToCompare, this.state.searchTerm.toLowerCase());
+
+	    return !permInUse && permNotFiltered;
+	}
+
+	onToggleAddPermDD() {
+	    const isOpen = this.state.addPermissionOpen;
+	    this.setState({
+	      addPermissionOpen: !isOpen,
+	    });
+	}
+
+	addPermissionHandler(perm) {
+		this.props.addPermission(perm);  
+		this.onToggleAddPermDD();
+	}
+
+	render() {
+
+		if (!this.props.stripes.hasPerm('perms.users.read'))
+	      return null;
+
+		const permissionsDD = (
+	   		<ListDropdown
+	        	items={_.filter(this.props.availablePermissions, this.isPermAvailable)}
+	        	onClickItem={this.addPermissionHandler}
+	        	onChangeSearch={this.onChangeSearch}
+	      	/>
+	    );
+
+		const listFormatter = item => (
+	      <li key={item.permissionName} >
+	        {!item.displayName ? item.permissionName : item.displayName}
+	        <Button
+	          buttonStyle="fieldControl"
+	          align="end"
+	          type="button"
+	          onClick={() => this.props.removePermission(item)}
+	          aria-label={`Remove Permission: ${item.permissionName}`}
+	          title="Remove Permission"
+	        >
+	          <IfPermission {...this.props} perm="perms.users.delete">
+	            <Icon icon="hollowX" iconClassName={css.removePermissionIcon} iconRootClass={css.removePermissionButton} />
+	          </IfPermission>
+	        </Button>
+	      </li>
+	    );
+	    
+	  	return(
+		   	<div style={{ marginBottom: '1rem' }}>
+		        <hr />
+		        <Row>
+		          <Col xs={5}>
+		            <h3 className="marginTop0">{this.props.heading}</h3>
+		          </Col>
+		          {/* <Col xs={4} sm={3}>
+		            <TextField
+		              rounded
+		              endControl={<Button buttonStyle="fieldControl"><Icon icon='clearX'/></Button>}
+		              startControl={<Icon icon='search'/>}
+		              placeholder="Search"
+		              fullWidth
+		              />
+		          </Col>*/}
+		          <Col xs={7}>
+		            <IfPermission {...this.props} perm="perms.users.modify">
+		              <Dropdown open={this.state?this.state.addPermissionOpen:false} pullRight onToggle={this.onToggleAddPermDD} id="AddPermissionDropdown" style={{ float: 'right' }}>
+		                <Button align="end" bottomMargin0 bsRole="toggle" aria-haspopup="true">&#43; Add Permission</Button>
+		                <DropdownMenu bsRole="menu" onToggle={this.onToggleAddPermDD} aria-label="available permissions" width="40em">{permissionsDD}</DropdownMenu>
+		              </Dropdown>
+		            </IfPermission>
+		          </Col>
+		        </Row>
+		        <br/>
+		        <List itemFormatter={listFormatter} items={this.props.listedPermissions || []} isEmptyMessage="This user has no permissions applied." />
+		    </div>
+		);
+    }
 }
 
 export default RenderPermissions;

--- a/lib/RenderPermissions/index.js
+++ b/lib/RenderPermissions/index.js
@@ -1,0 +1,1 @@
+export { default } from './RenderPermissions';


### PR DESCRIPTION
This PR addresses the concerns in [STRIPES-289](https://issues.folio.org/browse/STRIPES-289).

It separates out the presentation aspects of UserPermissions into a new component: RenderPermissions. All of the stripes-connect aspects of the permission management functionality are conducted in UserPermissions and then passed down into RenderPermissions. This should allow RenderPermissions to be reused in other contexts. (i.e. [LIBAPP-83](https://issues.folio.org/browse/LIBAPP-83)) 