### PR TITLE
Libapp 83

### DIFF
--- a/UserPermissions.js
+++ b/UserPermissions.js
@@ -13,13 +13,14 @@ import css from './UserPermissions.css';
 
 const propTypes = {
   stripes: PropTypes.shape({
-    hasPerm: PropTypes.func.isRequired,
-  }).isRequired,
+      hasPerm: PropTypes.func.isRequired,
+    }).isRequired,
+  sectionHeading: PropTypes.string,
   availablePermissions: PropTypes.arrayOf(PropTypes.object),
-  usersPermissions: PropTypes.arrayOf(PropTypes.object),
-  viewUserProps: PropTypes.shape({
+  setPermissions: PropTypes.arrayOf(PropTypes.object),
+  parentProps: PropTypes.shape({
     mutator: PropTypes.shape({
-      usersPermissions: PropTypes.shape({
+      setPermissions: PropTypes.shape({
         POST: PropTypes.func.isRequired,
         DELETE: PropTypes.func.isRequired,
       }),
@@ -55,17 +56,18 @@ class UserPermissions extends React.Component {
   }
 
   addPermission(perm) {
-    this.props.viewUserProps.mutator.usersPermissions.POST(perm, this.props.viewUserProps).then(() => {
+    this.props.parentProps.mutator.setPermissions.POST(perm, this.props.parentProps).then(() => {
       this.onToggleAddPermDD();
     });
   }
 
   removePermission(perm) {
-    this.props.viewUserProps.mutator.usersPermissions.DELETE(perm, this.props.viewUserProps, perm.permissionName);
+    console.log(this.props);
+    this.props.parentProps.mutator.setPermissions.DELETE(perm, this.props.parentProps, perm.permissionName);
   }
 
   isPermAvailable(perm) {
-    const permInUse = _.some(this.props.usersPermissions, perm);
+    const permInUse = _.some(this.props.setPermissions, perm);
 
     // This should be replaced with proper search when possible.
     const nameToCompare = !perm.displayName ? perm.permissionName.toLowerCase() : perm.displayName.toLowerCase();
@@ -75,10 +77,10 @@ class UserPermissions extends React.Component {
   }
 
   render() {
-    const { usersPermissions } = this.props;
+    const { setPermissions } = this.props;
 
-    if (!this.props.stripes.hasPerm('perms.users.read'))
-      return null;
+    //if (!this.props.stripes.hasPerm('perms.users.read'))
+      //return null;
 
     const permissionsDD = (
       <ListDropdown
@@ -99,9 +101,9 @@ class UserPermissions extends React.Component {
           aria-label={`Remove Permission: ${item.permissionName}`}
           title="Remove Permission"
         >
-          <IfPermission {...this.props} perm="perms.users.delete">
+          {/* <IfPermission {...this.props} perm="perms.users.delete"> */}
             <Icon icon="hollowX" iconClassName={css.removePermissionIcon} iconRootClass={css.removePermissionButton} />
-          </IfPermission>
+          {/* </IfPermission> */}
         </Button>
       </li>
     );
@@ -111,7 +113,7 @@ class UserPermissions extends React.Component {
         <hr />
         <Row>
           <Col xs={5}>
-            <h3 className="marginTop0">User permissions</h3>
+            <h3 className="marginTop0">{this.props.sectionHeading}</h3>
           </Col>
           {/* <Col xs={4} sm={3}>
             <TextField
@@ -123,15 +125,15 @@ class UserPermissions extends React.Component {
               />
           </Col>*/}
           <Col xs={7}>
-            <IfPermission {...this.props} perm="perms.users.modify">
+            {/* <IfPermission {...this.props} perm="perms.users.modify"> */}
               <Dropdown open={this.state.addPermissionOpen} pullRight onToggle={this.onToggleAddPermDD} id="AddPermissionDropdown" style={{ float: 'right' }}>
                 <Button align="end" bottomMargin0 bsRole="toggle" aria-haspopup="true">&#43; Add Permission</Button>
                 <DropdownMenu bsRole="menu" onToggle={this.onToggleAddPermDD} aria-label="available permissions" width="40em">{permissionsDD}</DropdownMenu>
               </Dropdown>
-            </IfPermission>
+            {/* </IfPermission> */}
           </Col>
         </Row>
-        <List itemFormatter={listFormatter} items={usersPermissions || []} isEmptyMessage="This user has no permissions applied." />
+        <List itemFormatter={listFormatter} items={setPermissions || []} isEmptyMessage="This user has no permissions applied." />
       </div>
     );
   }

--- a/UserPermissions.js
+++ b/UserPermissions.js
@@ -58,6 +58,9 @@ class UserPermissions extends React.Component {
     return (<RenderPermissions
       {...this.props}
       heading="User Permissions"
+      permToRead="perms.users"
+      permToDelete="perms.users"
+      permToModify="perms.users"
       addPermission={this.addPermission}
       removePermission={this.removePermission}
       availablePermissions={availablePermissions}

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -191,9 +191,9 @@ class ViewUser extends Component {
         </Row>
         <MultiColumnList fullWidth contentData={fineHistory} />
         <hr />
-        {/*<this.connectedUserLoans onClickViewLoansHistory={this.onClickViewLoansHistory} {...this.props} />*/}
+        <this.connectedUserLoans onClickViewLoansHistory={this.onClickViewLoansHistory} {...this.props} />
         {!this.props.stripes.hasPerm('perms.users.read') ? null :
-        <this.connectedUserPermissions stripes={this.props.stripes} match={this.props.match} {...this.props} />
+          <this.connectedUserPermissions stripes={this.props.stripes} match={this.props.match} {...this.props} />
         }
         <Layer isOpen={this.state.editUserMode} label="Edit User Dialog">
           <UserForm

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -119,7 +119,7 @@ class ViewUser extends Component {
 
     if (!users || users.length === 0 || !userid) return <div />;
 
-    if (!this.props.stripes.hasPerm('users.read.basic')) {
+    if (!this.props.stripes.hasPerm('users.read')) {
       return (<div>
         <h2>Permission Error</h2>
         <p>Sorry - your user permissions do not allow access to this page.</p>
@@ -191,7 +191,7 @@ class ViewUser extends Component {
         </Row>
         <MultiColumnList fullWidth contentData={fineHistory} />
         <hr />
-        <this.connectedUserLoans onClickViewLoansHistory={this.onClickViewLoansHistory} {...this.props} />
+        {/*<this.connectedUserLoans onClickViewLoansHistory={this.onClickViewLoansHistory} {...this.props} />*/}
         {!this.props.stripes.hasPerm('perms.users.read') ? null :
         <this.connectedUserPermissions stripes={this.props.stripes} match={this.props.match} {...this.props} />
         }

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -192,9 +192,7 @@ class ViewUser extends Component {
         <MultiColumnList fullWidth contentData={fineHistory} />
         <hr />
         <this.connectedUserLoans onClickViewLoansHistory={this.onClickViewLoansHistory} {...this.props} />
-        {!this.props.stripes.hasPerm('perms.users.read') ? null :
-          <this.connectedUserPermissions stripes={this.props.stripes} match={this.props.match} {...this.props} />
-        }
+        <this.connectedUserPermissions stripes={this.props.stripes} match={this.props.match} {...this.props} />
         <Layer isOpen={this.state.editUserMode} label="Edit User Dialog">
           <UserForm
             initialValues={_.merge(user, { available_patron_groups: this.props.data.patronGroups })}

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -209,7 +209,7 @@ class ViewUser extends Component {
         <hr />
         <this.connectedUserLoans onClickViewLoansHistory={this.onClickViewLoansHistory} {...this.props} />
         {!this.props.stripes.hasPerm('perms.users.read') ? null :
-        <UserPermissions availablePermissions={availablePermissions} usersPermissions={usersPermissions} viewUserProps={this.props} stripes={this.props.stripes} />
+        <UserPermissions availablePermissions={availablePermissions} setPermissions={usersPermissions} sectionHeading="User Permissions" parentProps={this.props} stripes={this.props.stripes} />
         }
         <Layer isOpen={this.state.editUserMode} label="Edit User Dialog">
           <UserForm

--- a/lib/RenderPermissions/RenderPermissions.js
+++ b/lib/RenderPermissions/RenderPermissions.js
@@ -54,8 +54,8 @@ class RenderPermissions extends React.Component {
 	}
 
 	render() {
-
-		if (!this.props.stripes.hasPerm('perms.users.read'))
+		
+		if (!this.props.stripes.hasPerm(this.props.permToRead))
 	      return null;
 
 		const permissionsDD = (
@@ -77,7 +77,7 @@ class RenderPermissions extends React.Component {
 	          aria-label={`Remove Permission: ${item.permissionName}`}
 	          title="Remove Permission"
 	        >
-	          <IfPermission {...this.props} perm="perms.users.delete">
+	          <IfPermission {...this.props} perm={this.props.permToDelete}>
 	            <Icon icon="hollowX" iconClassName={css.removePermissionIcon} iconRootClass={css.removePermissionButton} />
 	          </IfPermission>
 	        </Button>
@@ -101,7 +101,7 @@ class RenderPermissions extends React.Component {
 		              />
 		          </Col>*/}
 		          <Col xs={7}>
-		            <IfPermission {...this.props} perm="perms.users.modify">
+		            <IfPermission {...this.props} perm={this.props.permToModify}>
 		              <Dropdown open={this.state?this.state.addPermissionOpen:false} pullRight onToggle={this.onToggleAddPermDD} id="AddPermissionDropdown" style={{ float: 'right' }}>
 		                <Button align="end" bottomMargin0 bsRole="toggle" aria-haspopup="true">&#43; Add Permission</Button>
 		                <DropdownMenu bsRole="menu" onToggle={this.onToggleAddPermDD} aria-label="available permissions" width="40em">{permissionsDD}</DropdownMenu>

--- a/lib/RenderPermissions/RenderPermissions.js
+++ b/lib/RenderPermissions/RenderPermissions.js
@@ -55,8 +55,8 @@ class RenderPermissions extends React.Component {
 
 	render() {
 
-		if (!this.props.stripes.hasPerm('perms.users.read'))
-	      return null;
+		//if (!this.props.stripes.hasPerm('perms.users.read'))
+	      //return null;
 
 		const permissionsDD = (
 	   		<ListDropdown
@@ -77,9 +77,9 @@ class RenderPermissions extends React.Component {
 	          aria-label={`Remove Permission: ${item.permissionName}`}
 	          title="Remove Permission"
 	        >
-	          <IfPermission {...this.props} perm="perms.users.delete">
+	          {/*<IfPermission {...this.props} perm="perms.users.delete">*/}
 	            <Icon icon="hollowX" iconClassName={css.removePermissionIcon} iconRootClass={css.removePermissionButton} />
-	          </IfPermission>
+	          {/*</IfPermission>*/}
 	        </Button>
 	      </li>
 	    );
@@ -101,12 +101,12 @@ class RenderPermissions extends React.Component {
 		              />
 		          </Col>*/}
 		          <Col xs={7}>
-		            <IfPermission {...this.props} perm="perms.users.modify">
+		            {/*<IfPermission {...this.props} perm="perms.users.modify">*/}
 		              <Dropdown open={this.state?this.state.addPermissionOpen:false} pullRight onToggle={this.onToggleAddPermDD} id="AddPermissionDropdown" style={{ float: 'right' }}>
 		                <Button align="end" bottomMargin0 bsRole="toggle" aria-haspopup="true">&#43; Add Permission</Button>
 		                <DropdownMenu bsRole="menu" onToggle={this.onToggleAddPermDD} aria-label="available permissions" width="40em">{permissionsDD}</DropdownMenu>
 		              </Dropdown>
-		            </IfPermission>
+		            {/*</IfPermission>*/}
 		          </Col>
 		        </Row>
 		        <br/>

--- a/lib/RenderPermissions/RenderPermissions.js
+++ b/lib/RenderPermissions/RenderPermissions.js
@@ -55,8 +55,8 @@ class RenderPermissions extends React.Component {
 
 	render() {
 
-		//if (!this.props.stripes.hasPerm('perms.users.read'))
-	      //return null;
+		if (!this.props.stripes.hasPerm('perms.users.read'))
+	      return null;
 
 		const permissionsDD = (
 	   		<ListDropdown
@@ -77,9 +77,9 @@ class RenderPermissions extends React.Component {
 	          aria-label={`Remove Permission: ${item.permissionName}`}
 	          title="Remove Permission"
 	        >
-	          {/*<IfPermission {...this.props} perm="perms.users.delete">*/}
+	          <IfPermission {...this.props} perm="perms.users.delete">
 	            <Icon icon="hollowX" iconClassName={css.removePermissionIcon} iconRootClass={css.removePermissionButton} />
-	          {/*</IfPermission>*/}
+	          </IfPermission>
 	        </Button>
 	      </li>
 	    );
@@ -101,12 +101,12 @@ class RenderPermissions extends React.Component {
 		              />
 		          </Col>*/}
 		          <Col xs={7}>
-		            {/*<IfPermission {...this.props} perm="perms.users.modify">*/}
+		            <IfPermission {...this.props} perm="perms.users.modify">
 		              <Dropdown open={this.state?this.state.addPermissionOpen:false} pullRight onToggle={this.onToggleAddPermDD} id="AddPermissionDropdown" style={{ float: 'right' }}>
 		                <Button align="end" bottomMargin0 bsRole="toggle" aria-haspopup="true">&#43; Add Permission</Button>
 		                <DropdownMenu bsRole="menu" onToggle={this.onToggleAddPermDD} aria-label="available permissions" width="40em">{permissionsDD}</DropdownMenu>
 		              </Dropdown>
-		            {/*</IfPermission>*/}
+		            </IfPermission>
 		          </Col>
 		        </Row>
 		        <br/>

--- a/settings/PermissionSet.js
+++ b/settings/PermissionSet.js
@@ -7,25 +7,18 @@ import RenderPermissions from '../lib/RenderPermissions';
 class PermissionSet extends React.Component {
 
   static propTypes = {
-    stripes: PropTypes.shape({
-      hasPerm: PropTypes.func.isRequired,
-    }).isRequired,
     data: PropTypes.shape({
       availablePermissions: PropTypes.arrayOf(PropTypes.object),
-    }).isRequired
+    }).isRequired,
   };
 
   static manifest = Object.freeze({
-     availablePermissions: {
+    availablePermissions: {
       type: 'okapi',
       records: 'permissions',
-      path: 'perms/permissions?length=100&query=(mutable=false)'
-    }
+      path: 'perms/permissions?length=100&query=(mutable=false)',
+    },
   });
-
-  constructor(props) {
-    super(props);
-  }
 
   render() {
     return (<RenderPermissions

--- a/settings/PermissionSet.js
+++ b/settings/PermissionSet.js
@@ -10,6 +10,10 @@ class PermissionSet extends React.Component {
     data: PropTypes.shape({
       availablePermissions: PropTypes.arrayOf(PropTypes.object),
     }).isRequired,
+    addPermission: PropTypes.func.isRequired,
+    removePermission: PropTypes.func.isRequired,
+    availablePermissions: PropTypes.func.isRequired,
+    selectedSet: PropTypes.object.isRequired,
   };
 
   static manifest = Object.freeze({

--- a/settings/PermissionSet.js
+++ b/settings/PermissionSet.js
@@ -1,0 +1,42 @@
+// We have to remove node_modules/react to avoid having multiple copies loaded.
+// eslint-disable-next-line import/no-unresolved
+import React, { PropTypes } from 'react';
+import { connect } from '@folio/stripes-connect'; // eslint-disable-line
+import RenderPermissions from '../lib/RenderPermissions';
+
+class PermissionSet extends React.Component {
+
+  static propTypes = {
+    stripes: PropTypes.shape({
+      hasPerm: PropTypes.func.isRequired,
+    }).isRequired,
+    data: PropTypes.shape({
+      availablePermissions: PropTypes.arrayOf(PropTypes.object),
+    }).isRequired
+  };
+
+  static manifest = Object.freeze({
+     availablePermissions: {
+      type: 'okapi',
+      records: 'permissions',
+      path: 'perms/permissions?length=100&query=(mutable=false)'
+    }
+  });
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (<RenderPermissions
+      {...this.props}
+      heading="Contains"
+      addPermission={this.props.addPermission}
+      removePermission={this.props.removePermission}
+      availablePermissions={this.props.data.availablePermissions}
+      listedPermissions={this.props.selectedSet.subPermissions}
+    />);
+  }
+}
+
+export default connect(PermissionSet, '@folio/users');

--- a/settings/PermissionSetDetails.js
+++ b/settings/PermissionSetDetails.js
@@ -1,5 +1,5 @@
-import React, {PropTypes} from 'react';
-
+import React, { Component, PropTypes } from 'react';
+import { connect } from '@folio/stripes-connect'; // eslint-disable-line
 import Pane from '@folio/stripes-components/lib/Pane';
 import Textfield from '@folio/stripes-components/lib/TextField';
 import TextArea from '@folio/stripes-components/lib/TextArea';
@@ -8,18 +8,30 @@ import {Field, reducer as formReducer, reduxForm} from 'redux-form'; // eslint-d
 
 import UserPermissions from '../UserPermissions';
 
-const propTypes = {
-  initialValues: PropTypes.object,
-};
+class PermissionSetDetails extends Component {
 
-class PermissionSetDetails extends React.Component {
+  static propTypes = {
+    initialValues: PropTypes.object,
+    data: PropTypes.shape({
+      availablePermissions: PropTypes.arrayOf(PropTypes.object)
+    })
+  };
+
+  static manifest = Object.freeze({
+    availablePermissions: {
+      type: 'okapi',
+      records: 'permissions',
+      path: 'perms/permissions?length=100'
+    }
+  });
+
   constructor(props) {
     super(props);
   }
 
   render() {
-
-    const selectedSet = this.props.selectedSet;
+    console.log(this.props);
+    const { data: { availablePermissions }, selectedSet } = this.props;
     
     return (
       <Pane paneTitle={"Permission Set "+selectedSet.title} defaultWidth="fill" >
@@ -29,16 +41,14 @@ class PermissionSetDetails extends React.Component {
             <Field label="Title" name="title" id="permissionset_title" component={Textfield} required fullWidth rounded />
             <Field label="Description" name="description" id="permissionset_description" component={TextArea} required fullWidth rounded />
           </section>
-          <UserPermissions sectionHeading="Contains" availablePermissions={[]} />
+          <UserPermissions sectionHeading="Contains" availablePermissions={availablePermissions} />
         </form>
       </Pane>
     );
   }
 }
 
-PermissionSetDetails.propTypes = propTypes;
-
 export default reduxForm({
   form: 'permissionSetForm',
   enableReinitialize: true
-})(PermissionSetDetails);
+})(connect(PermissionSetDetails, '@folio/users'));

--- a/settings/PermissionSetDetails.js
+++ b/settings/PermissionSetDetails.js
@@ -11,6 +11,9 @@ import UserPermissions from '../UserPermissions';
 class PermissionSetDetails extends Component {
 
   static propTypes = {
+    stripes: PropTypes.shape({
+      hasPerm: PropTypes.func.isRequired,
+    }).isRequired,
     initialValues: PropTypes.object,
     data: PropTypes.shape({
       availablePermissions: PropTypes.arrayOf(PropTypes.object)
@@ -21,7 +24,16 @@ class PermissionSetDetails extends Component {
     availablePermissions: {
       type: 'okapi',
       records: 'permissions',
-      path: 'perms/permissions?length=100'
+      // DELETE: {
+      //   pk: 'permissionName',
+      //   path: 'perms/users/:{username}/permissions',
+      // },
+      // GET: {
+      //   path: 'perms/users/:{username}/permissions?full=true',
+      // },
+      GET: {
+        path: 'perms/permissions?length=100&query=(mutable=false)'
+      }
     }
   });
 
@@ -30,18 +42,17 @@ class PermissionSetDetails extends Component {
   }
 
   render() {
-    console.log(this.props);
     const { data: { availablePermissions }, selectedSet } = this.props;
-    
+    console.log(this);
     return (
-      <Pane paneTitle={"Permission Set "+selectedSet.title} defaultWidth="fill" >
+      <Pane paneTitle={"Permission Set "+selectedSet.permissionName} defaultWidth="fill" >
         <form>
           <section>
             <h2 style={{ marginTop: '0' }}>About</h2>
-            <Field label="Title" name="title" id="permissionset_title" component={Textfield} required fullWidth rounded />
+            <Field label="Title" name="permissionName" id="permissionName" component={Textfield} required fullWidth rounded />
             <Field label="Description" name="description" id="permissionset_description" component={TextArea} required fullWidth rounded />
           </section>
-          <UserPermissions sectionHeading="Contains" availablePermissions={availablePermissions} />
+          <UserPermissions sectionHeading="Contains" setPermissions={selectedSet.subPermissions} availablePermissions={availablePermissions} parentProps={this.props} stripes={this.props.stripes} />
         </form>
       </Pane>
     );

--- a/settings/PermissionSetDetails.js
+++ b/settings/PermissionSetDetails.js
@@ -18,23 +18,15 @@ class PermissionSetDetails extends Component {
     initialValues: PropTypes.object
   };
 
-  static manifest = Object.freeze({
-     availablePermissions: {
-      type: 'okapi',
-      records: 'permissions',
-      PUT: {
-        pk: 'id',
-        path: 'perms/permissions/'
-      }
-    }
-  });
-
   constructor(props) {
     super(props);
+    
     this.validateSet = this.validateSet.bind(this);
     this.saveSet = this.saveSet.bind(this);
     this.beginDelete = this.beginDelete.bind(this);
     this.confirmDeleteSet = this.confirmDeleteSet.bind(this);
+    this.addPermission = this.addPermission.bind(this);
+    this.removePermission = this.removePermission.bind(this);
 
     this.state = {
       confirmDelete: false,
@@ -59,7 +51,6 @@ class PermissionSetDetails extends Component {
   }
 
   confirmDeleteSet(confirmation) {
-
     if(confirmation) {
       this.props.parentMutator.permissionSets.DELETE(this.props.selectedSet).then(()=>{
         this.props.clearSelection();
@@ -69,7 +60,17 @@ class PermissionSetDetails extends Component {
         confirmDelete: false,
       });
     }
-    
+  }
+
+  addPermission(perm) {
+    this.state.selectedSet.subPermissions.push(perm);
+    this.saveSet();
+  }
+
+  removePermission(perm) {
+    const selectedSetSubPermissions = this.state.selectedSet.subPermissions;
+    selectedSetSubPermissions.splice(selectedSetSubPermissions.indexOf(perm), 1);
+    this.saveSet();
   }
 
   render() {
@@ -77,6 +78,7 @@ class PermissionSetDetails extends Component {
     return (
       <Pane paneTitle={"Permission Set "+selectedSet.displayName?selectedSet.displayName:selectedSet.permissionName} defaultWidth="fill" >
         <form>
+        
           <section>
             <h2 style={{ marginTop: '0' }}>About</h2>
             <Field label="Title" name="displayName" id="displayName" component={Textfield} required fullWidth rounded validate={this.validateSet} onBlur={this.saveSet} />
@@ -88,7 +90,15 @@ class PermissionSetDetails extends Component {
              <Button title="Confirm Delete Permission Set" onClick={()=>{this.confirmDeleteSet(true)}} > Confirm </Button>
               <Button title="Cancel Delete Permission Set" onClick={()=>{this.confirmDeleteSet(false)}}> Cancel </Button>
           </div>}
-          <PermissionSet selectedSet="selectedSet" stripes={this.props.stripes} {...this.props} />
+
+          <PermissionSet 
+            addPermission={this.addPermission}
+            removePermission={this.removePermission}
+            selectedSet="selectedSet" 
+            stripes={this.props.stripes} 
+            {...this.props} 
+          />
+          
         </form>
       </Pane>
     );

--- a/settings/PermissionSetDetails.js
+++ b/settings/PermissionSetDetails.js
@@ -6,7 +6,7 @@ import TextArea from '@folio/stripes-components/lib/TextArea';
 
 import {Field, reducer as formReducer, reduxForm} from 'redux-form';
 
-import UserPermissions from '../UserPermissions';
+import PermissionSet from './PermissionSet';
 
 class PermissionSetDetails extends Component {
 
@@ -52,7 +52,7 @@ class PermissionSetDetails extends Component {
             <Field label="Title" name="permissionName" id="permissionName" component={Textfield} required fullWidth rounded />
             <Field label="Description" name="description" id="permissionset_description" component={TextArea} required fullWidth rounded />
           </section>
-          <UserPermissions sectionHeading="Contains" setPermissions={selectedSet.subPermissions} availablePermissions={availablePermissions} parentProps={this.props} stripes={this.props.stripes} />
+          <PermissionSet availablePermissions={availablePermissions} parentProps={this.props} stripes={this.props.stripes} {...this.props} />
         </form>
       </Pane>
     );

--- a/settings/PermissionSetDetails.js
+++ b/settings/PermissionSetDetails.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 
 import Pane from '@folio/stripes-components/lib/Pane';
 import Textfield from '@folio/stripes-components/lib/TextField';
@@ -8,27 +8,37 @@ import {Field, reducer as formReducer, reduxForm} from 'redux-form'; // eslint-d
 
 import UserPermissions from '../UserPermissions';
 
+const propTypes = {
+  initialValues: PropTypes.object,
+};
+
 class PermissionSetDetails extends React.Component {
   constructor(props) {
     super(props);
   }
 
   render() {
+
+    const selectedSet = this.props.selectedSet;
+    
     return (
-      <Pane paneTitle="Patron Groups" defaultWidth="fill" >
+      <Pane paneTitle={"Permission Set "+selectedSet.title} defaultWidth="fill" >
         <form>
           <section>
             <h2 style={{ marginTop: '0' }}>About</h2>
-            <Field label="Title" name="title" id="permissionset_title" component={Textfield} required fullWidth />
-            <Field label="Description" name="description" id="permissionset_description" component={TextArea} required fullWidth />
+            <Field label="Title" name="title" id="permissionset_title" component={Textfield} required fullWidth rounded />
+            <Field label="Description" name="description" id="permissionset_description" component={TextArea} required fullWidth rounded />
           </section>
-          <UserPermissions availablePermissions={[]} />
+          <UserPermissions sectionHeading="Contains" availablePermissions={[]} />
         </form>
       </Pane>
     );
   }
 }
 
+PermissionSetDetails.propTypes = propTypes;
+
 export default reduxForm({
   form: 'permissionSetForm',
+  enableReinitialize: true
 })(PermissionSetDetails);

--- a/settings/PermissionSetDetails.js
+++ b/settings/PermissionSetDetails.js
@@ -27,7 +27,7 @@ class PermissionSetDetails extends Component {
     this.confirmDeleteSet = this.confirmDeleteSet.bind(this);
     this.addPermission = this.addPermission.bind(this);
     this.removePermission = this.removePermission.bind(this);
-
+    
     this.state = {
       confirmDelete: false,
     };

--- a/settings/PermissionSetDetails.js
+++ b/settings/PermissionSetDetails.js
@@ -94,7 +94,10 @@ class PermissionSetDetails extends Component {
           <PermissionSet 
             addPermission={this.addPermission}
             removePermission={this.removePermission}
-            selectedSet="selectedSet" 
+            selectedSet="selectedSet"
+            permToRead="perms.permissions"
+            permToDelete="perms.permissions"
+            permToModify="perms.permissions" 
             stripes={this.props.stripes} 
             {...this.props} 
           />

--- a/settings/PermissionSets.js
+++ b/settings/PermissionSets.js
@@ -8,17 +8,16 @@ import NavList from '@folio/stripes-components/lib/NavList';
 import NavListSection from '@folio/stripes-components/lib/NavListSection';
 import PermissionSetDetails from './PermissionSetDetails';
 
-
 class PermissionSets extends React.Component {
   constructor(props) {
     super(props);
 
     // 'Manager' just for example...
     this.state = {
-      selectedSet: 'Manager',
+      selectedSet: null,
       permissionSets: [
-        { id: '1', title: 'Manager' },
-        { id: '2', title: 'Cataloger' },
+        { id: '1', title: 'Manager', description: 'Permissions for Manager'},
+        { id: '2', title: 'Cataloger', description: 'Permissions for Cataloger'},
       ],
     };
 
@@ -30,7 +29,11 @@ class PermissionSets extends React.Component {
     e.preventDefault();
     const href = e.target.href;
     const setTitle = href.substring(href.indexOf('#') + 1);
-    this.setState({ selectedSet: setTitle });
+    let selectedSet = null;
+    _.forEach(this.state.permissionSets, function(set) {
+      if(set.title===setTitle) selectedSet=set; 
+    });
+    this.setState({ selectedSet: selectedSet });
   }
 
   createNewPermissionSet() {
@@ -41,7 +44,7 @@ class PermissionSets extends React.Component {
     sets.push(newSetObject);
     this.setState({
       permissionSets: sets,
-      selectedSet: newSetObject.title,
+      selectedSet: newSetObject,
     });
   }
 
@@ -62,12 +65,12 @@ class PermissionSets extends React.Component {
       <Paneset nested>
         <Pane defaultWidth="20%" lastMenu={PermissionsSetsLastMenu}>
           <NavList>
-            <NavListSection activeLink={`#${this.state.selectedSet}`}>
+            <NavListSection activeLink={this.state.selectedSet?`#${this.state.selectedSet.title}`:''}>
               {RenderedPermissionSets}
             </NavListSection>
           </NavList>
         </Pane>
-        <PermissionSetDetails />
+        {this.state.selectedSet && <PermissionSetDetails initialValues={this.state.selectedSet} selectedSet={this.state.selectedSet} />}
       </Paneset>
     );
   }

--- a/settings/PermissionSets.js
+++ b/settings/PermissionSets.js
@@ -24,14 +24,12 @@ class PermissionSets extends Component {
     permissionSets: {
       type: 'okapi',
       records: 'permissions',
-      // DELETE: {
-      //   pk: 'permissionName',
-      //   path: 'perms/permissions',
-      // },
-      // POST: {
-      //   pk: 'permissionName',
-      //   path: 'perms/permissions',
-      // },
+      DELETE: {
+        path: 'perms/permissions',
+      },
+      POST: {
+        path: 'perms/permissions',
+      },
       GET: {
         path: 'perms/permissions?length=100&expandSubs=true&query=(mutable=true)'
       },
@@ -49,6 +47,7 @@ class PermissionSets extends Component {
 
     this.onSelectSet = this.onSelectSet.bind(this);
     this.createNewPermissionSet = this.createNewPermissionSet.bind(this);
+    this.clearSelection = this.clearSelection.bind(this);
   }
 
   onSelectSet(e) {
@@ -63,14 +62,18 @@ class PermissionSets extends Component {
   }
 
   createNewPermissionSet() {
-    const sets = this.state.permissionSets;
-    let nextSetID = parseInt(sets[sets.length - 1].id, 10);
-    nextSetID += 1;
-    const newSetObject = { id: nextSetID.toString(), title: 'Untitled Permission Set' };
-    sets.push(newSetObject);
+
+    this.props.mutator.permissionSets.POST({
+      mutable:true
+    }).then(()=>{
+      this.clearSelection();
+    });
+ 
+  }
+
+  clearSelection() {
     this.setState({
-      permissionSets: sets,
-      selectedSet: newSetObject,
+      selectedSet: null,
     });
   }
 
@@ -79,7 +82,7 @@ class PermissionSets extends Component {
     const { data: { permissionSets } } = this.props;
 
     const RenderedPermissionSets = this.props.data.permissionSets?this.props.data.permissionSets.map(
-      set => <a data-id={set.id} key={set.id} href={`#${set.permissionName}`} onClick={this.onSelectSet}>{set.permissionName}</a>,
+      set => <a data-id={set.id} key={set.id} href={`#${set.permissionName}`} onClick={this.onSelectSet}>{set.displayName?set.displayName:"Untitles permission set"}</a>,
     ):[];
 
     const PermissionsSetsLastMenu = (
@@ -99,7 +102,7 @@ class PermissionSets extends Component {
             </NavListSection>
           </NavList>
         </Pane>
-        {this.state.selectedSet && <PermissionSetDetails stripes={this.props.stripes} initialValues={this.state.selectedSet} selectedSet={this.state.selectedSet} />}
+        {this.state.selectedSet && <PermissionSetDetails parentMutator={this.props.mutator} clearSelection={this.clearSelection} stripes={this.props.stripes} initialValues={this.state.selectedSet} selectedSet={this.state.selectedSet} />}
       </Paneset>
     );
   }

--- a/settings/PermissionSets.js
+++ b/settings/PermissionSets.js
@@ -19,6 +19,13 @@ class PermissionSets extends Component {
     data: PropTypes.shape({
       permissionSets: PropTypes.arrayOf(PropTypes.object),
     }).isRequired,
+    mutator: PropTypes.shape({
+      permissionSets: PropTypes.shape({
+        POST: PropTypes.func,
+        DELETE: PropTypes.func,
+        GET: PropTypes.func,
+      }),
+    }).isRequired,
   };
 
   static manifest = Object.freeze({
@@ -59,7 +66,9 @@ class PermissionSets extends Component {
     _.forEach(this.props.data.permissionSets, (set) => {
       if (set.permissionName === permissionName) selectedSet = set;
     });
-    this.setState({ selectedSet: selectedSet });
+    this.setState({ 
+      selectedSet: selectedSet, 
+    });
   }
 
   createNewPermissionSet() {
@@ -77,9 +86,9 @@ class PermissionSets extends Component {
   }
 
   render() {
-    const RenderedPermissionSets = this.props.data.permissionSets?this.props.data.permissionSets.map(
-      set => <a data-id={set.id} key={set.id} href={`#${set.permissionName}`} onClick={this.onSelectSet}>{set.displayName?set.displayName:"Untitled Permission Set"}</a>,
-    ):[];
+    const RenderedPermissionSets = this.props.data.permissionSets ? this.props.data.permissionSets.map(
+      set => <a data-id={set.id} key={set.id} href={`#${set.permissionName}`} onClick={this.onSelectSet}>{set.displayName ? set.displayName:'Untitled Permission Set'}</a>,
+    ) : [];
 
     const PermissionsSetsLastMenu = (
       <PaneMenu>
@@ -93,7 +102,7 @@ class PermissionSets extends Component {
       <Paneset nested>
         <Pane defaultWidth="20%" lastMenu={PermissionsSetsLastMenu}>
           <NavList>
-            <NavListSection activeLink={this.state.selectedSet?`#${this.state.selectedSet.title}`:''}>
+            <NavListSection activeLink={this.state.selectedSet ? `#${this.state.selectedSet.title}` : ''}>
               {RenderedPermissionSets}
             </NavListSection>
           </NavList>

--- a/settings/PermissionSets.js
+++ b/settings/PermissionSets.js
@@ -31,7 +31,7 @@ class PermissionSets extends Component {
         path: 'perms/permissions',
       },
       GET: {
-        path: 'perms/permissions?length=100&expandSubs=true&query=(mutable=true)'
+        path: 'perms/permissions?length=100&query=(mutable=true)'
       },
       path: 'perms/permissions'
     }

--- a/settings/PermissionSets.js
+++ b/settings/PermissionSets.js
@@ -82,7 +82,7 @@ class PermissionSets extends Component {
     const { data: { permissionSets } } = this.props;
 
     const RenderedPermissionSets = this.props.data.permissionSets?this.props.data.permissionSets.map(
-      set => <a data-id={set.id} key={set.id} href={`#${set.permissionName}`} onClick={this.onSelectSet}>{set.displayName?set.displayName:"Untitles permission set"}</a>,
+      set => <a data-id={set.id} key={set.id} href={`#${set.permissionName}`} onClick={this.onSelectSet}>{set.displayName?set.displayName:"Untitled Permission Set"}</a>,
     ):[];
 
     const PermissionsSetsLastMenu = (

--- a/settings/PermissionSets.js
+++ b/settings/PermissionSets.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import _ from 'lodash';
 import { connect } from '@folio/stripes-connect'; // eslint-disable-line
 
 import Paneset from '@folio/stripes-components/lib/Paneset';
@@ -17,7 +18,7 @@ class PermissionSets extends Component {
     }).isRequired,
     data: PropTypes.shape({
       permissionSets: PropTypes.arrayOf(PropTypes.object),
-    })
+    }).isRequired,
   };
 
   static manifest = Object.freeze({
@@ -31,10 +32,10 @@ class PermissionSets extends Component {
         path: 'perms/permissions',
       },
       GET: {
-        path: 'perms/permissions?length=100&query=(mutable=true)'
+        path: 'perms/permissions?length=100&query=(mutable=true)',
       },
-      path: 'perms/permissions'
-    }
+      path: 'perms/permissions',
+    },
   });
 
   constructor(props) {
@@ -55,20 +56,18 @@ class PermissionSets extends Component {
     const href = e.target.href;
     const permissionName = href.substring(href.indexOf('#') + 1);
     let selectedSet = null;
-    _.forEach(this.props.data.permissionSets, function(set) {
-      if(set.permissionName===permissionName) selectedSet=set; 
+    _.forEach(this.props.data.permissionSets, (set) => {
+      if (set.permissionName === permissionName) selectedSet = set;
     });
     this.setState({ selectedSet: selectedSet });
   }
 
   createNewPermissionSet() {
-
     this.props.mutator.permissionSets.POST({
-      mutable:true
-    }).then(()=>{
+      mutable: true,
+    }).then(() => {
       this.clearSelection();
     });
- 
   }
 
   clearSelection() {
@@ -78,9 +77,6 @@ class PermissionSets extends Component {
   }
 
   render() {
-
-    const { data: { permissionSets } } = this.props;
-
     const RenderedPermissionSets = this.props.data.permissionSets?this.props.data.permissionSets.map(
       set => <a data-id={set.id} key={set.id} href={`#${set.permissionName}`} onClick={this.onSelectSet}>{set.displayName?set.displayName:"Untitled Permission Set"}</a>,
     ):[];
@@ -108,4 +104,4 @@ class PermissionSets extends Component {
   }
 }
 
-export default connect(PermissionSets, '@folio/users')
+export default connect(PermissionSets, '@folio/users');

--- a/settings/index.js
+++ b/settings/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
 
 import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
@@ -9,6 +9,13 @@ import PermissionSets from './PermissionSets';
 import PatronGroupsSettings from './PatronGroupsSettings';
 
 class UsersSettings extends React.Component {
+
+  static propTypes = {
+    stripes: PropTypes.shape({
+      hasPerm: PropTypes.func.isRequired,
+    }).isRequired  
+  };
+
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
This is a feature complete PR for [LIBAPP-83](https://issues.folio.org/browse/LIBAPP-83).

The DELETE of permissions was implemented as a button on the permission details pane. This is not consistent with the prototype, but the drop down which housed the delete button in the prototype is not yet implemented in stripes.

[STRIPES-301](https://issues.folio.org/browse/STRIPES-301) is a bug that remains and is related to the RenderPermssions component not showing up in the permission set pane if the user does not have perms.user based permissions. This should be addressed, as it is not desired behavior.