### PR TITLE
Add .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.DS_Store
+*.swp
+*.swo
+node_modules
+yarn.lock
+


### PR DESCRIPTION
Without an .npmignore file, npm publish creates one from the .gitignore file by default.