### PR TITLE
STCOM-20  Accordionate the Sections of User Details

### DIFF
--- a/ProxyPermissions.js
+++ b/ProxyPermissions.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Row, Col } from 'react-bootstrap';
 import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
 import Pluggable from '@folio/stripes-components/lib/Pluggable';
+import { Accordion } from '@folio/stripes-components/lib/Accordion';
 
 import { getFullName, getRowURL, getAnchoredRowFormatter } from './util';
 
@@ -27,11 +28,9 @@ const propTypes = {
       PUT: React.PropTypes.func.isRequired,
     }),
   }).isRequired,
-  displayHeading: PropTypes.bool,
-};
-
-const defaultProps = {
-  displayHeading: true,
+  expanded: PropTypes.bool,
+  onToggle: PropTypes.func,
+  accordionId: PropTypes.string.isRequired,
 };
 
 class ProxyPermissions extends React.Component {
@@ -104,72 +103,75 @@ class ProxyPermissions extends React.Component {
       Proxy: pr => getFullName(pr),
     };
 
-    return (<div>
-      { this.props.displayHeading &&
+    const { onToggle, accordionId, expanded } = this.props;
+
+    return (
+      <Accordion
+        open={expanded}
+        id={accordionId}
+        onToggle={onToggle}
+        label={
+          <h2>Proxy Permissions</h2>
+        }
+      >
         <Row>
-          <Col xs={5}>
-            <h3 className="marginTop0">Proxy Permissions</h3>
+          <Col xs={12}>
+            <MultiColumnList
+              id="list-sponsors"
+              formatter={sponsorFormatter}
+              rowFormatter={getAnchoredRowFormatter}
+              visibleColumns={['Sponsor']}
+              contentData={sponsors}
+              isEmptyMessage="No sponsors found"
+              onRowClick={this.onSelectRow}
+            />
           </Col>
         </Row>
-      }
-      <Row>
-        <Col xs={12}>
-          <MultiColumnList
-            id="list-sponsors"
-            formatter={sponsorFormatter}
-            rowFormatter={getAnchoredRowFormatter}
-            visibleColumns={['Sponsor']}
-            contentData={sponsors}
-            isEmptyMessage="No sponsors found"
-            onRowClick={this.onSelectRow}
-          />
-        </Col>
-      </Row>
-      <Row className="marginTopHalf">
-        <Col xs={12}>
-          <Pluggable
-            aria-haspopup="true"
-            type="find-user"
-            {...this.props}
-            dataKey="sponsors"
-            searchLabel="&#43; Add Sponsor"
-            searchButtonStyle="primary"
-            selectUser={this.addSponsor}
-            visibleColumns={['Name', 'Patron Group', 'Username', 'Barcode']}
-            disableUserCreation={disableUserCreation}
-          />
-        </Col>
-      </Row>
-      <hr />
-      <Row>
-        <Col xs={12}>
-          <MultiColumnList
-            id="list-proxies"
-            formatter={proxyFormatter}
-            rowFormatter={getAnchoredRowFormatter}
-            visibleColumns={['Proxy']}
-            contentData={proxies}
-            isEmptyMessage="No proxies found"
-            onRowClick={this.onSelectRow}
-          />
-        </Col>
-      </Row>
-      <Row className="marginTopHalf">
-        <Col xs={12}>
-          <Pluggable
-            aria-haspopup="true"
-            type="find-user"
-            {...this.props}
-            dataKey="proxies"
-            searchLabel="&#43; Add Proxy"
-            searchButtonStyle="primary"
-            selectUser={this.addProxy}
-            visibleColumns={['Name', 'Patron Group', 'Username', 'Barcode']}
-            disableUserCreation={disableUserCreation}
-          />
-        </Col>
-      </Row>
-    </div>);
+        <Row className="marginTopHalf">
+          <Col xs={12}>
+            <Pluggable
+              aria-haspopup="true"
+              type="find-user"
+              {...this.props}
+              dataKey="sponsors"
+              searchLabel="&#43; Add Sponsor"
+              searchButtonStyle="primary"
+              selectUser={this.addSponsor}
+              visibleColumns={['Name', 'Patron Group', 'Username', 'Barcode']}
+              disableUserCreation={disableUserCreation}
+            />
+          </Col>
+        </Row>
+        <hr />
+        <Row>
+          <Col xs={12}>
+            <MultiColumnList
+              id="list-proxies"
+              formatter={proxyFormatter}
+              rowFormatter={getAnchoredRowFormatter}
+              visibleColumns={['Proxy']}
+              contentData={proxies}
+              isEmptyMessage="No proxies found"
+              onRowClick={this.onSelectRow}
+            />
+          </Col>
+        </Row>
+        <Row className="marginTopHalf">
+          <Col xs={12}>
+            <Pluggable
+              aria-haspopup="true"
+              type="find-user"
+              {...this.props}
+              dataKey="proxies"
+              searchLabel="&#43; Add Proxy"
+              searchButtonStyle="primary"
+              selectUser={this.addProxy}
+              visibleColumns={['Name', 'Patron Group', 'Username', 'Barcode']}
+              disableUserCreation={disableUserCreation}
+            />
+          </Col>
+        </Row>
+      </Accordion>);
   }
 }
 

--- a/ProxyPermissions.js
+++ b/ProxyPermissions.js
@@ -27,6 +27,11 @@ const propTypes = {
       PUT: React.PropTypes.func.isRequired,
     }),
   }).isRequired,
+  displayHeading: PropTypes.bool,
+};
+
+const defaultProps = {
+  displayHeading: true,
 };
 
 class ProxyPermissions extends React.Component {
@@ -100,12 +105,13 @@ class ProxyPermissions extends React.Component {
     };
 
     return (<div>
-      <hr />
-      <Row>
-        <Col xs={5}>
-          <h3 className="marginTop0">Proxy Permissions</h3>
-        </Col>
-      </Row>
+      { this.props.displayHeading &&
+        <Row>
+          <Col xs={5}>
+            <h3 className="marginTop0">Proxy Permissions</h3>
+          </Col>
+        </Row>
+      }
       <Row>
         <Col xs={12}>
           <MultiColumnList

--- a/UserForm.js
+++ b/UserForm.js
@@ -173,6 +173,7 @@ class UserForm extends React.Component {
                   dateFormat="YYYY-MM-DD"
                   name="personal.dateOfBirth"
                   id="adduser_dateofbirth"
+                  backendDateStandard="YYYY-MM-DD"
                 />
                 {/* <Field
                   label="Type"

--- a/UserLoans.js
+++ b/UserLoans.js
@@ -14,6 +14,11 @@ class UserLoans extends React.Component {
     }),
     onClickViewOpenLoans: PropTypes.func.isRequired,
     onClickViewClosedLoans: PropTypes.func.isRequired,
+    displayHeading: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    displayHeading: true,
   };
 
   // "limit=1" on the openLoansCount and closedLoansCount fields is a hack
@@ -51,6 +56,7 @@ class UserLoans extends React.Component {
 
     return (
       <div>
+        { this.props.displayHeading && 
         <Row>
           <Col xs={7} sm={6}>
             <h3 className="marginTop0"><FormattedMessage id="ui-users.loans.title" /></h3>
@@ -61,6 +67,7 @@ class UserLoans extends React.Component {
             </div>
           </Col>
         </Row>
+        }
         <ul>
           <li><a id="clickable-viewcurrentloans" href="" onClick={this.props.onClickViewOpenLoans}>{ openLoansCount } <FormattedMessage id="ui-users.loans.openLoans" /></a></li>
           <li><a id="clickable-viewclosedloans" href="" onClick={this.props.onClickViewClosedLoans}>{ closedLoansCount } <FormattedMessage id="ui-users.loans.closedLoans" /></a></li>

--- a/UserLoans.js
+++ b/UserLoans.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
 import Button from '@folio/stripes-components/lib/Button';
+import { Accordion } from '@folio/stripes-components/lib/Accordion';
 
 class UserLoans extends React.Component {
   static propTypes = {
@@ -14,11 +14,9 @@ class UserLoans extends React.Component {
     }),
     onClickViewOpenLoans: PropTypes.func.isRequired,
     onClickViewClosedLoans: PropTypes.func.isRequired,
-    displayHeading: PropTypes.bool,
-  };
-
-  static defaultProps = {
-    displayHeading: true,
+    accordionId: PropTypes.string,
+    expanded: PropTypes.bool,
+    onToggle: PropTypes.func,
   };
 
   // "limit=1" on the openLoansCount and closedLoansCount fields is a hack
@@ -53,26 +51,25 @@ class UserLoans extends React.Component {
     const resources = this.props.resources;
     const openLoansCount = _.get(resources.openLoansCount, ['records', '0', 'totalRecords'], 0);
     const closedLoansCount = _.get(resources.closedLoansCount, ['records', '0', 'totalRecords'], 0);
+    const { expanded, onToggle, accordionId } = this.props;
 
     return (
-      <div>
-        { this.props.displayHeading && 
-        <Row>
-          <Col xs={7} sm={6}>
-            <h3 className="marginTop0"><FormattedMessage id="ui-users.loans.title" /></h3>
-          </Col>
-          <Col xs={5} sm={6}>
-            <div style={{ float: 'right' }}>
-              <Button id="clickable-viewfullhistory" align="end" bottomMargin0 onClick={this.props.onClickViewOpenLoans}>View Loans</Button>
-            </div>
-          </Col>
-        </Row>
+      <Accordion
+        open={expanded}
+        id={accordionId}
+        onToggle={onToggle}
+        label={
+          <h2 className="marginTop0"><FormattedMessage id="ui-users.loans.title" /></h2>
         }
+        displayWhenOpen={
+          <Button id="clickable-viewfullhistory" align="end" bottomMargin0 onClick={this.props.onClickViewOpenLoans}>View Loans</Button>
+        }
+      >
         <ul>
           <li><a id="clickable-viewcurrentloans" href="" onClick={this.props.onClickViewOpenLoans}>{ openLoansCount } <FormattedMessage id="ui-users.loans.openLoans" /></a></li>
           <li><a id="clickable-viewclosedloans" href="" onClick={this.props.onClickViewClosedLoans}>{ closedLoansCount } <FormattedMessage id="ui-users.loans.closedLoans" /></a></li>
         </ul>
-      </div>);
+      </Accordion>);
   }
 }
 

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -219,7 +219,7 @@ class ViewUser extends React.Component {
 
   handleSectionToggle({ id }) {
     this.setState((curState) => {
-      const newState = curState;
+      const newState = _.cloneDeep(curState);
       newState.sections[id] = !newState.sections[id];
       return newState;
     });

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -5,17 +5,13 @@ import queryString from 'query-string';
 import transitionToParams from '@folio/stripes-components/util/transitionToParams';
 import Pane from '@folio/stripes-components/lib/Pane';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
-import Button from '@folio/stripes-components/lib/Button';
 import KeyValue from '@folio/stripes-components/lib/KeyValue';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
-import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
 import Icon from '@folio/stripes-components/lib/Icon';
 import Layer from '@folio/stripes-components/lib/Layer';
 import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import IfInterface from '@folio/stripes-components/lib/IfInterface';
-import DropdownMenu from '@folio/stripes-components/lib/DropdownMenu';
 import { Accordion } from '@folio/stripes-components/lib/Accordion';
-import { Dropdown } from 'react-bootstrap';
 
 import UserForm from './UserForm';
 import UserPermissions from './UserPermissions';
@@ -83,12 +79,12 @@ class ViewUser extends React.Component {
       viewLoanActionsHistoryMode: false,
       selectedLoan: {},
       lastUpdate: null,
-      accordionSections: {
-        'user_info': true,
-        'user_addresses': true,
-        'user_loans': true,
-        'user_proxy': true,
-        'user_perms': true,
+      sections: {
+        infoSection: true,
+        addressSection: true,
+        loansSection: true,
+        proxySection: true,
+        permissionsSection: true,
       },
     };
     this.onClickEditUser = this.onClickEditUser.bind(this);
@@ -107,12 +103,8 @@ class ViewUser extends React.Component {
     this.onClickCloseLoanActionsHistory = this.onClickCloseLoanActionsHistory.bind(this);
     this.onAddressesUpdate = this.onAddressesUpdate.bind(this);
     this.transitionToParams = transitionToParams.bind(this);
-    this.onToggleSection = this.onToggleSection.bind(this);
-    this.handleAddAddress = this.handleAddAddress.bind(this);
 
-    // refs for accordion actions...
-    this.addressesSection = null;
-    this.permsSection = null;
+    this.handleSectionToggle = this.handleSectionToggle.bind(this);
   }
 
   // EditUser Handlers
@@ -225,23 +217,15 @@ class ViewUser extends React.Component {
     return new Date(dateToShow).toLocaleString(this.props.stripes.locale);
   }
 
-  onToggleSection({id}){
+  handleSectionToggle({ id }) {
     this.setState((curState) => {
       const newState = curState;
-      newState.accordionSections[id] = !curState.accordionSections[id];
+      newState.sections[id] = !newState.sections[id];
       return newState;
     });
   }
 
-  handleAddAddress(){
-    if(this.addressesSection) {
-      this.addressesSection.addressList.handleAddNew();
-    }
-  }
-
   render() {
-    const dueDate = new Date(Date.parse('2014-11-12')).toLocaleDateString(this.props.stripes.locale);
-    const fineHistory = [{ 'Due Date': dueDate, Amount: '34.23', Status: 'Unpaid' }];
     const { resources, location } = this.props;
     const query = location.search ? queryString.parse(location.search) : {};
     const user = this.getUser();
@@ -269,174 +253,149 @@ class ViewUser extends React.Component {
 
     return (
       <Pane id="pane-userdetails" defaultWidth={this.props.paneWidth} paneTitle="User Details" lastMenu={detailMenu} dismissible onClose={this.props.onClose}>
-        <Accordion 
-          label={<h2>Information</h2>} 
-          id='user_info' 
-          onToggle={this.onToggleSection} 
-          open={this.state.accordionSections['user_info']} 
-          
+        <Accordion
+          open={this.state.sections.infoSection}
+          id="infoSection"
+          onToggle={this.handleSectionToggle}
+          label={<h2>{_.get(user, ['personal', 'lastName'], '')}, {_.get(user, ['personal', 'firstName'], '')} {_.get(user, ['personal', 'middleName'], '')}</h2>}
         >
-        <Row>
-          <Col xs={7} >
-            <Row>
-              <Col xs={12}>
-                <h3>{_.get(user, ['personal', 'lastName'], '')}, {_.get(user, ['personal', 'firstName'], '')} {_.get(user, ['personal', 'middleName'], '')}</h3>
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Username" value={_.get(user, ['username'], '')} />
-              </Col>
-            </Row>
-            <br />
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Status" value={userStatus} />
-              </Col>
-            </Row>
-            <br />
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Email" value={_.get(user, ['personal', 'email'], '')} />
-              </Col>
-            </Row>
-            <br />
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Phone" value={_.get(user, ['personal', 'phone'], '')} />
-              </Col>
-            </Row>
-            <br />
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Mobile phone" value={_.get(user, ['personal', 'mobilePhone'], '')} />
-              </Col>
-            </Row>
-            <br />
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Preferred contact" value={preferredContact.desc} />
-              </Col>
-            </Row>
-            <br />
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Date of birth" value={(_.get(user, ['personal', 'dateOfBirth'], '')) ? new Date(Date.parse(_.get(user, ['personal', 'dateOfBirth'], ''))).toLocaleDateString(this.props.stripes.locale) : ''} />
-              </Col>
-            </Row>
-          </Col>
-          <Col xs={5} >
-            <Row>
-              <Col xs={12}>
-                <img className="floatEnd" src="http://placehold.it/175x175" role="presentation" />
-              </Col>
-            </Row>
-            <br />
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Date enrolled" value={(_.get(user, ['enrollmentDate'], '')) ? new Date(Date.parse(_.get(user, ['enrollmentDate'], ''))).toLocaleDateString(this.props.stripes.locale) : ''} />
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Expiration date" value={(_.get(user, ['expirationDate'], '')) ? new Date(Date.parse(_.get(user, ['expirationDate'], ''))).toLocaleDateString(this.props.stripes.locale) : ''} />
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Open date" value={(_.get(user, ['createdDate'], '')) ? new Date(Date.parse(_.get(user, ['createdDate'], ''))).toLocaleString(this.props.stripes.locale) : ''} />
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Record last updated" value={this.dateLastUpdated(user)} />
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Bar code" value={_.get(user, ['barcode'], '')} />
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="FOLIO record number" value={_.get(user, ['id'], '')} />
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="External System ID" value={_.get(user, ['externalSystemId'], '')} />
-              </Col>
-            </Row>
-            <br />
-            <Row>
-              <Col xs={12}>
-                <KeyValue label="Patron group" value={patronGroup.group} />
-              </Col>
-            </Row>
-          </Col>
-        </Row>
+          <Row>
+            <Col xs={7} >
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Username" value={_.get(user, ['username'], '')} />
+                </Col>
+              </Row>
+              <br />
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Status" value={userStatus} />
+                </Col>
+              </Row>
+              <br />
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Email" value={_.get(user, ['personal', 'email'], '')} />
+                </Col>
+              </Row>
+              <br />
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Phone" value={_.get(user, ['personal', 'phone'], '')} />
+                </Col>
+              </Row>
+              <br />
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Mobile phone" value={_.get(user, ['personal', 'mobilePhone'], '')} />
+                </Col>
+              </Row>
+              <br />
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Preferred contact" value={preferredContact.desc} />
+                </Col>
+              </Row>
+              <br />
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Date of birth" value={(_.get(user, ['personal', 'dateOfBirth'], '')) ? new Date(Date.parse(_.get(user, ['personal', 'dateOfBirth'], ''))).toLocaleDateString(this.props.stripes.locale) : ''} />
+                </Col>
+              </Row>
+            </Col>
+            <Col xs={5} >
+              <Row>
+                <Col xs={12}>
+                  <img className="floatEnd" src="http://placehold.it/175x175" role="presentation" />
+                </Col>
+              </Row>
+              <br />
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Date enrolled" value={(_.get(user, ['enrollmentDate'], '')) ? new Date(Date.parse(_.get(user, ['enrollmentDate'], ''))).toLocaleDateString(this.props.stripes.locale) : ''} />
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Expiration date" value={(_.get(user, ['expirationDate'], '')) ? new Date(Date.parse(_.get(user, ['expirationDate'], ''))).toLocaleDateString(this.props.stripes.locale) : ''} />
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Open date" value={(_.get(user, ['createdDate'], '')) ? new Date(Date.parse(_.get(user, ['createdDate'], ''))).toLocaleString(this.props.stripes.locale) : ''} />
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Record last updated" value={this.dateLastUpdated(user)} />
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Bar code" value={_.get(user, ['barcode'], '')} />
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="FOLIO record number" value={_.get(user, ['id'], '')} />
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="External System ID" value={_.get(user, ['externalSystemId'], '')} />
+                </Col>
+              </Row>
+              <br />
+              <Row>
+                <Col xs={12}>
+                  <KeyValue label="Patron group" value={patronGroup.group} />
+                </Col>
+              </Row>
+            </Col>
+          </Row>
         </Accordion>
-        <Accordion 
-          label={<h2>Addresses</h2>} 
-          id='user_addresses' 
-          onToggle={this.onToggleSection} 
-          open={this.state.accordionSections['user_addresses']}
-          displayWhenOpen={<Button onClick={this.handleAddAddress}>Add Address</Button>}
-        >
         <UserAddresses
           onUpdate={this.onAddressesUpdate}
           addressTypes={this.props.addressTypes}
           addresses={addresses}
-          ref={(ref)=>{this.addressesSection = ref;}}
-          displayHeading={false}
+          expanded={this.state.sections.addressSection}
+          onToggle={this.handleSectionToggle}
+          accordionId="addressSection"
         />
-        </Accordion>
-        <Accordion 
-          label={<h2>Loans</h2>} 
-          id='user_loans' 
-          onToggle={this.onToggleSection} 
-          open={this.state.accordionSections['user_loans']}
-          displayWhenOpen={<Button onClick={this.onClickViewOpenLoans}>View Loans</Button>}
-        >
-          <IfPermission perm="circulation.loans.collection.get">
-            <IfInterface name="circulation" version="2.1">
-              <this.connectedUserLoans
-                onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
-                onClickViewOpenLoans={this.onClickViewOpenLoans}
-                onClickViewClosedLoans={this.onClickViewClosedLoans}
-                displayHeading={false}
-                {...this.props}
-              />
-            </IfInterface>
-          </IfPermission>
-        </Accordion>
-        <Accordion label={<h2>Proxy Permissions</h2>} id='user_proxy' onToggle={this.onToggleSection} open={this.state.accordionSections['user_proxy']}>
-          <this.connectedProxyPermissions 
-            user={user} 
-            stripes={this.props.stripes} 
-            match={this.props.match} 
-            displayHeading={false}
-            {...this.props} 
-          />
-        </Accordion>
-        <Accordion 
-          label={<h2>Permissions</h2>} 
-          id='user_perms' 
-          onToggle={this.onToggleSection} 
-          open={this.state.accordionSections['user_perms']}
-        >
-          <IfPermission perm="perms.users.get">
-            <IfInterface name="permissions" version="4.0">
-              <this.connectedUserPermissions 
-                stripes={this.props.stripes}
-                match={this.props.match}
-                displayHeading={false}
-                ref={(ref) => {this.permsSection = ref;}}
-                {...this.props} 
-              />
-            </IfInterface>
-          </IfPermission>
-        </Accordion>
+        <IfPermission perm="circulation.loans.collection.get">
+          <IfInterface name="circulation" version="2.1">
+            <this.connectedUserLoans
+              onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
+              onClickViewOpenLoans={this.onClickViewOpenLoans}
+              onClickViewClosedLoans={this.onClickViewClosedLoans}
+              expanded={this.state.sections.loansSection}
+              onToggle={this.handleSectionToggle}
+              accordionId="loansSection"
+              {...this.props}
+            />
+          </IfInterface>
+        </IfPermission>
+        <this.connectedProxyPermissions
+          user={user}
+          stripes={this.props.stripes}
+          match={this.props.match}
+          expanded={this.state.sections.proxySection}
+          onToggle={this.handleSectionToggle}
+          accordionId="proxySection"
+          {...this.props}
+        />
+        <IfPermission perm="perms.users.get">
+          <IfInterface name="permissions" version="4.0">
+            <this.connectedUserPermissions
+              stripes={this.props.stripes}
+              match={this.props.match}
+              expanded={this.state.sections.permissionsSection}
+              onToggle={this.handleSectionToggle}
+              accordionId="permissionsSection"
+              {...this.props}
+            />
+          </IfInterface>
+        </IfPermission>
         <Layer isOpen={query.layer ? query.layer === 'edit' : false} label="Edit User Dialog">
           <UserForm
             initialValues={userFormData}

--- a/lib/RenderPermissions/RenderPermissions.js
+++ b/lib/RenderPermissions/RenderPermissions.js
@@ -1,12 +1,13 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col, Dropdown } from 'react-bootstrap';
+import { Dropdown } from 'react-bootstrap';
 import DropdownMenu from '@folio/stripes-components/lib/DropdownMenu';
 import Button from '@folio/stripes-components/lib/Button';
 import Icon from '@folio/stripes-components/lib/Icon';
 import List from '@folio/stripes-components/lib/List';
 import IfPermission from '@folio/stripes-components/lib/IfPermission';
+import { Accordion } from '@folio/stripes-components/lib/Accordion';
 
 import PermissionList from '../PermissionList';
 import css from './RenderPermissions.css';
@@ -27,12 +28,10 @@ class RenderPermissions extends React.Component {
         listInvisiblePerms: PropTypes.bool,
       }).isRequired,
     }).isRequired,
-    displayHeading: PropTypes.bool,
+    accordionId: PropTypes.string,
+    expanded: PropTypes.bool,
+    onToggle: PropTypes.func,
   };
-
-  static defaultProps = {
-    displayHeading: true,
-  }
 
   constructor(props) {
     super(props);
@@ -46,7 +45,6 @@ class RenderPermissions extends React.Component {
     this.onToggleAddPermDD = this.onToggleAddPermDD.bind(this);
     this.isPermAvailable = this.isPermAvailable.bind(this);
     this.addPermissionHandler = this.addPermissionHandler.bind(this);
-
   }
 
   onChangeSearch(e) {
@@ -78,6 +76,8 @@ class RenderPermissions extends React.Component {
   }
 
   render() {
+    const { accordionId, expanded, onToggle } = this.props;
+
     if (!this.props.stripes.hasPerm(this.props.permToRead))
       return null;
 
@@ -109,50 +109,39 @@ class RenderPermissions extends React.Component {
     );
 
     return (
-      <div style={{ marginBottom: '1rem' }}>        
-        <Row>
-        { this.props.displayHeading && 
-          <Col xs={5}>
-            <h3 className="marginTop0">{this.props.heading}</h3>
-          </Col>
-        } 
-          {/* <Col xs={4} sm={3}>
-            <TextField
-              rounded
-              endControl={<Button buttonStyle="fieldControl"><Icon icon='clearX'/></Button>}
-              startControl={<Icon icon='search'/>}
-              placeholder="Search"
-              fullWidth
-              />
-          </Col>*/}
-          <Col xs={this.props.displayHeading ? 7 : 12}>
-            <IfPermission perm={this.props.permToModify}>
-              <Dropdown
-                id="AddPermissionDropdown"
-                style={{ float: 'right' }}
-                pullRight
-                open={this.state ? this.state.addPermissionOpen : false}
+      <Accordion
+        open={expanded}
+        id={accordionId}
+        onToggle={onToggle}
+        label={
+          <h2 className="marginTop0">{this.props.heading}</h2>
+        }
+        displayWhenOpen={(
+          <IfPermission perm={this.props.permToModify}>
+            <Dropdown
+              id="AddPermissionDropdown"
+              style={{ float: 'right' }}
+              pullRight
+              open={this.state ? this.state.addPermissionOpen : false}
+              onToggle={this.onToggleAddPermDD}
+            >
+              <Button align="end" bottomMargin0 bsRole="toggle" aria-haspopup="true">&#43; Add Permission</Button>
+              <DropdownMenu
+                bsRole="menu"
+                width="40em"
+                aria-label="available permissions"
                 onToggle={this.onToggleAddPermDD}
-              >
-                <Button align="end" bottomMargin0 bsRole="toggle" aria-haspopup="true">&#43; Add Permission</Button>
-                <DropdownMenu
-                  bsRole="menu"
-                  width="40em"
-                  aria-label="available permissions"
-                  onToggle={this.onToggleAddPermDD}
-                >{permissionsDD}</DropdownMenu>
-              </Dropdown>
-            </IfPermission>
-          </Col>
-        </Row>
-         
-        <br />
+              >{permissionsDD}</DropdownMenu>
+            </Dropdown>
+          </IfPermission>
+          )}
+      >
         <List
           items={this.props.listedPermissions || []}
           itemFormatter={listFormatter}
           isEmptyMessage="This user has no permissions applied."
         />
-      </div>
+      </Accordion>
     );
   }
 }

--- a/lib/RenderPermissions/RenderPermissions.js
+++ b/lib/RenderPermissions/RenderPermissions.js
@@ -27,7 +27,12 @@ class RenderPermissions extends React.Component {
         listInvisiblePerms: PropTypes.bool,
       }).isRequired,
     }).isRequired,
+    displayHeading: PropTypes.bool,
   };
+
+  static defaultProps = {
+    displayHeading: true,
+  }
 
   constructor(props) {
     super(props);
@@ -41,6 +46,7 @@ class RenderPermissions extends React.Component {
     this.onToggleAddPermDD = this.onToggleAddPermDD.bind(this);
     this.isPermAvailable = this.isPermAvailable.bind(this);
     this.addPermissionHandler = this.addPermissionHandler.bind(this);
+
   }
 
   onChangeSearch(e) {
@@ -103,12 +109,13 @@ class RenderPermissions extends React.Component {
     );
 
     return (
-      <div style={{ marginBottom: '1rem' }}>
-        <hr />
+      <div style={{ marginBottom: '1rem' }}>        
         <Row>
+        { this.props.displayHeading && 
           <Col xs={5}>
             <h3 className="marginTop0">{this.props.heading}</h3>
           </Col>
+        } 
           {/* <Col xs={4} sm={3}>
             <TextField
               rounded
@@ -118,7 +125,7 @@ class RenderPermissions extends React.Component {
               fullWidth
               />
           </Col>*/}
-          <Col xs={7}>
+          <Col xs={this.props.displayHeading ? 7 : 12}>
             <IfPermission perm={this.props.permToModify}>
               <Dropdown
                 id="AddPermissionDropdown"
@@ -138,6 +145,7 @@ class RenderPermissions extends React.Component {
             </IfPermission>
           </Col>
         </Row>
+         
         <br />
         <List
           items={this.props.listedPermissions || []}

--- a/lib/UserAddresses/UserAddresses.js
+++ b/lib/UserAddresses/UserAddresses.js
@@ -13,12 +13,15 @@ class UserAddresses extends React.Component {
     addresses: PropTypes.arrayOf(PropTypes.object),
     addressTypes: PropTypes.arrayOf(PropTypes.object),
     onUpdate: PropTypes.func,
+    displayHeading: PropTypes.bool,
   };
 
   constructor(props) {
     super(props);
     this.onUpdate = this.onUpdate.bind(this);
     this.onDelete = this.onDelete.bind(this);
+
+    this.addressList = null;
   }
 
   onUpdate(addr) {
@@ -63,11 +66,13 @@ class UserAddresses extends React.Component {
     };
 
     return (<AddressList
+      ref={(ref)=>{this.addressList = ref;}}
       onUpdate={this.onUpdate}
       onCreate={this.onUpdate}
       onDelete={this.onDelete}
       fieldComponents={addressFields}
       addresses={this.props.addresses}
+      displayHeading={this.props.displayHeading}
       canEdit
       canDelete
     />);

--- a/lib/UserAddresses/UserAddresses.js
+++ b/lib/UserAddresses/UserAddresses.js
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import AddressList from '@folio/stripes-components/lib/structures/AddressFieldGroup/AddressList';
 import Select from '@folio/stripes-components/lib/Select';
-
 import Autocomplete from '../Autocomplete';
 import { countriesOptions } from '../../data/countries';
 import { toAddressTypeOptions } from '../../converters/address_type';
@@ -13,7 +12,9 @@ class UserAddresses extends React.Component {
     addresses: PropTypes.arrayOf(PropTypes.object),
     addressTypes: PropTypes.arrayOf(PropTypes.object),
     onUpdate: PropTypes.func,
-    displayHeading: PropTypes.bool,
+    onToggle: PropTypes.func,
+    expanded: PropTypes.bool,
+    accordionId: PropTypes.string,
   };
 
   constructor(props) {
@@ -66,13 +67,14 @@ class UserAddresses extends React.Component {
     };
 
     return (<AddressList
-      ref={(ref)=>{this.addressList = ref;}}
       onUpdate={this.onUpdate}
       onCreate={this.onUpdate}
       onDelete={this.onDelete}
       fieldComponents={addressFields}
       addresses={this.props.addresses}
-      displayHeading={this.props.displayHeading}
+      expanded={this.props.expanded}
+      onToggle={this.props.onToggle}
+      accordionId={this.props.accordionId}
       canEdit
       canDelete
     />);


### PR DESCRIPTION
This touched the components in the View User page, performing a bit of surgery on each to get the accordions wired up to eventually have them persist on a local resource.

Before I went through this step I attempted to keep the Accordions at the top, wrapping the components - but the design requires the accordion headers to contain buttons that interact with the sub-sections - and show/hide these buttons based on the open or closed status of the accordion. There isn't any good non-hacky way for a parent to reach in and use the code that's already present in a child component (only props, themselves) so I just ended up incorporating the Accordions themselves into the components, passing in the appropriate props to control them from ViewUser...

In addition to this, the AddressList component of stripes-components has also been modified... this branch alone will still render working components, you'd just see that the Address section is not affected.

Special credit goes to Zak Burke for echoing some of my sentiments over this process in cartoon-form: https://mainlynorfolk.info/john.kirkpatrick/images/large/farsideaccordion.jpg