### PR TITLE
sync package.json's Notes dep with that in Users.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
   "dependencies": {
     "@folio/stripes-components": "^1.7.0",
     "@folio/stripes-form": "^0.8.0",
-    "@folio/util-notes": "^0.1.0",
+    "@folio/util-notes": "^0.2.0",
     "classnames": "^2.2.5",
     "dateformat": "^2.0.0",
     "hashcode": "^1.0.3",


### PR DESCRIPTION
Since Users.js uses the Notes 0.2.0 API, package.json better require the
Notes 0.2.0 API.