### PR TITLE
Stcom 71 expand all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Path URLs, permission calls, and credentials now use UUID instead of username where appropriate. Fixes UIU-172.
+* Expand/Collapse All button integrated for accordions on the user detail page. Fulfills STCOM-71.
 
 ## 2.11.0 (IN PROGRESS)
 

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -11,7 +11,7 @@ import Icon from '@folio/stripes-components/lib/Icon';
 import Layer from '@folio/stripes-components/lib/Layer';
 import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import IfInterface from '@folio/stripes-components/lib/IfInterface';
-import { Accordion } from '@folio/stripes-components/lib/Accordion';
+import { Accordion, ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
 
 import UserForm from './UserForm';
 import UserPermissions from './UserPermissions';
@@ -105,6 +105,7 @@ class ViewUser extends React.Component {
     this.transitionToParams = transitionToParams.bind(this);
 
     this.handleSectionToggle = this.handleSectionToggle.bind(this);
+    this.handleExpandAll = this.handleExpandAll.bind(this);
   }
 
   // EditUser Handlers
@@ -225,6 +226,14 @@ class ViewUser extends React.Component {
     });
   }
 
+  handleExpandAll(obj) {
+    this.setState((curState) => {
+      const newState = _.cloneDeep(curState);
+      newState.sections = obj;
+      return newState;
+    });
+  }
+
   render() {
     const { resources, location } = this.props;
     const query = location.search ? queryString.parse(location.search) : {};
@@ -253,6 +262,7 @@ class ViewUser extends React.Component {
 
     return (
       <Pane id="pane-userdetails" defaultWidth={this.props.paneWidth} paneTitle="User Details" lastMenu={detailMenu} dismissible onClose={this.props.onClose}>
+        <Row end="xs"><Col xs><ExpandAllButton accordionStatus={this.state.sections} onToggle={this.handleExpandAll} /></Col></Row>
         <Accordion
           open={this.state.sections.infoSection}
           id="infoSection"

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "eslint-plugin-react": "^6.4.1"
   },
   "dependencies": {
-    "@folio/stripes-components": "^1.7.0",
+    "@folio/stripes-components": "^1.8.0",
     "@folio/stripes-form": "^0.8.0",
     "@folio/util-notes": "^0.2.0",
     "classnames": "^2.2.5",


### PR DESCRIPTION
This PR adds an 'expand all' button above the `<Accordion>`s on in the View User page.  The button label will dynamically change depending on the majority state of the accordions. If more accordions are closed, it becomes 'expand all', if more are open, 'collapse all'.

This PR also bumps deps on Stripes-components to 1.8.0