### PR TITLE
UIU 243 read-only proxy section

### DIFF
--- a/ProxyPermissions.js
+++ b/ProxyPermissions.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Row, Col } from 'react-bootstrap';
 import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
 import Pluggable from '@folio/stripes-components/lib/Pluggable';
+import Button from '@folio/stripes-components/lib/Button';
 import { Accordion } from '@folio/stripes-components/lib/Accordion';
 
 import Badge from './lib/Badge';
@@ -32,6 +33,8 @@ const propTypes = {
   expanded: PropTypes.bool,
   onToggle: PropTypes.func,
   accordionId: PropTypes.string.isRequired,
+  // if `editable` is true, component will be in 'edit' mode. (read-only by default)
+  editable: PropTypes.bool, 
 };
 
 class ProxyPermissions extends React.Component {
@@ -131,6 +134,7 @@ class ProxyPermissions extends React.Component {
             />
           </Col>
         </Row>
+        { this.props.editable && 
         <Row className="marginTopHalf">
           <Col xs={12}>
             <Pluggable
@@ -146,6 +150,7 @@ class ProxyPermissions extends React.Component {
             />
           </Col>
         </Row>
+        }
         <hr />
         <Row>
           <Col xs={12}>
@@ -160,6 +165,7 @@ class ProxyPermissions extends React.Component {
             />
           </Col>
         </Row>
+        { this.props.editable && 
         <Row className="marginTopHalf">
           <Col xs={12}>
             <Pluggable
@@ -175,6 +181,7 @@ class ProxyPermissions extends React.Component {
             />
           </Col>
         </Row>
+        }
       </Accordion>);
   }
 }

--- a/ProxyPermissions.js
+++ b/ProxyPermissions.js
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import { Row, Col } from 'react-bootstrap';
 import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
 import Pluggable from '@folio/stripes-components/lib/Pluggable';
-import Button from '@folio/stripes-components/lib/Button';
 import { Accordion } from '@folio/stripes-components/lib/Accordion';
-
 import Badge from './lib/Badge';
 import { getFullName, getRowURL, getAnchoredRowFormatter } from './util';
 

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -393,6 +393,7 @@ class ViewUser extends React.Component {
           expanded={this.state.sections.proxySection}
           onToggle={this.handleSectionToggle}
           accordionId="proxySection"
+          editable
           {...this.props}
         />
         <IfPermission perm="perms.users.get">


### PR DESCRIPTION
Adds the `editable` prop to the Proxy Permissions component and flips it 'on' in ViewUsers - once the section is incorporated into the UserForm, we can remove the prop from ViewUsers, and set it in the form.