### PR TITLE
UIU-242 read-only address section - pass 'editable' prop through to AddressList component

### DIFF
--- a/lib/UserAddresses/UserAddresses.js
+++ b/lib/UserAddresses/UserAddresses.js
@@ -15,6 +15,7 @@ class UserAddresses extends React.Component {
     onToggle: PropTypes.func,
     expanded: PropTypes.bool,
     accordionId: PropTypes.string,
+    editable: PropTypes.bool,
   };
 
   constructor(props) {
@@ -75,8 +76,8 @@ class UserAddresses extends React.Component {
       expanded={this.props.expanded}
       onToggle={this.props.onToggle}
       accordionId={this.props.accordionId}
-      canEdit
-      canDelete
+      canEdit={this.props.editable}
+      canDelete={this.props.editable}
     />);
   }
 }


### PR DESCRIPTION
expose 'editable' prop in UserAddresses.js. Since this prop **is not** passed in the ViewUser component, addresses will become read-only there. They will remain editable in the user 'edit' view.