### PR TITLE
Use `<ControlledVocab>` from stripes-smart-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix renew date. Fixes UIU-252.
 * `editable` prop added to `<RenderPermissions>` component to facilitate UIU-244.
 * When `config.showPerms` is true, show the True Names of users' permissions as well as available permissions. Fixes UIU-262.
+* Use `<ControlledVocab>` from stripes-smart-components instead of `<AuthorityList>` from stripes-components. See STSMACOM-6. Requires util-notes v0.3.0. Fixes UIU-267.
 
 ## [2.10.1](https://github.com/folio-org/ui-users/tree/v2.10.1) (2017-09-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.10.0...v2.10.1)

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
   "dependencies": {
     "@folio/stripes-components": "^1.8.0",
     "@folio/stripes-form": "^0.8.0",
-    "@folio/util-notes": "^0.2.0",
+    "@folio/util-notes": "^0.3.0",
     "classnames": "^2.2.5",
     "hashcode": "^1.0.3",
     "isomorphic-fetch": "^2.2.1",

--- a/settings/AddressTypesSettings.js
+++ b/settings/AddressTypesSettings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ControlledVocab from '@folio/stripes-smart-components/lib/ControlledVocab';
+import ControlledVocab from '@folio/util-notes/lib/ControlledVocab';
 
 class AddressTypesSettings extends React.Component {
   static propTypes = {

--- a/settings/AddressTypesSettings.js
+++ b/settings/AddressTypesSettings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import AuthorityList from '@folio/stripes-components/lib/AuthorityList';
+import ControlledVocab from '@folio/stripes-smart-components/lib/ControlledVocab';
 
 class AddressTypesSettings extends React.Component {
   static propTypes = {
@@ -11,12 +11,12 @@ class AddressTypesSettings extends React.Component {
 
   constructor(props) {
     super(props);
-    this.connectedAuthorityList = props.stripes.connect(AuthorityList);
+    this.connectedControlledVocab = props.stripes.connect(ControlledVocab);
   }
 
   render() {
     return (
-      <this.connectedAuthorityList
+      <this.connectedControlledVocab
         {...this.props}
         baseUrl="addresstypes"
         records="addressTypes"

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import AuthorityList from '@folio/stripes-components/lib/AuthorityList';
+import ControlledVocab from '@folio/stripes-smart-components/lib/ControlledVocab';
 
 class PatronGroupsSettings extends React.Component {
   static propTypes = {
@@ -11,12 +11,12 @@ class PatronGroupsSettings extends React.Component {
 
   constructor(props) {
     super(props);
-    this.connectedAuthorityList = props.stripes.connect(AuthorityList);
+    this.connectedControlledVocab = props.stripes.connect(ControlledVocab);
   }
 
   render() {
     return (
-      <this.connectedAuthorityList
+      <this.connectedControlledVocab
         {...this.props}
         baseUrl="groups"
         records="usergroups"

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ControlledVocab from '@folio/stripes-smart-components/lib/ControlledVocab';
+import ControlledVocab from '@folio/util-notes/lib/ControlledVocab';
 
 class PatronGroupsSettings extends React.Component {
   static propTypes = {


### PR DESCRIPTION
Allows us to use <ControlledVocab>