### PR TITLE
Prepare Autocomplete for Bootstrap global css removal

### DIFF
--- a/lib/Autocomplete/Autocomplete.css
+++ b/lib/Autocomplete/Autocomplete.css
@@ -20,19 +20,67 @@
   border: 1px solid #acacac;
   font-size: 14px;
   color: #333;
+  width: 100%;
 }
 
 .autocomplete button {
   float: none;
   position: absolute;
-  top: -9px;
-  right: 0px;
+  top: 2px;
+  right: 5px;
   z-index: 100;
   opacity: 1;
+  -webkit-appearance: none;
+  padding: 0;
+  cursor: pointer;
+  background: 0 0;
+  border: 0;
 }
 
 .autocomplete button span {
-  font-size: 40px;
+  font-size: 20px;
   font-weight: 300;
   color: #999;
+}
+
+.autocomplete ul {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 160px;
+  padding: 5px 0;
+  margin: 2px 0 0;
+  font-size: 14px;
+  text-align: left;
+  list-style: none;
+  background-color: #fff;
+  -webkit-background-clip: padding-box;
+  background-clip: padding-box;
+  border: 1px solid #ccc;
+  border: 1px solid rgba(0,0,0,.15);
+  border-radius: 4px;
+  -webkit-box-shadow: 0 6px 12px rgba(0,0,0,.175);
+  box-shadow: 0 6px 12px rgba(0,0,0,.175);
+}
+
+.autocomplete li a {
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: 400;
+  line-height: 1.42857143;
+  color: #333;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.autocomplete li a {
+  &:hover,
+  &:focus {
+    text-decoration: none;
+    background-color: #f5f5f5;
+  }
 }


### PR DESCRIPTION
## Purpose
Removing Bootstrap's global CSS from `stripes-core` (https://github.com/folio-org/stripes-core/pull/61) breaks the `Autocomplete` component used for country selection in addresses.

This should unblock https://github.com/folio-org/stripes-core/pull/61, so we can move toward the intended font stack and surface other CSS that was leaning too heavily on the global Bootstrap styles.

## Approach
I copied over bits and pieces of Bootstrap CSS into the `Autocomplete` component's CSS as a stop-gap until there's an autocomplete component available in `stripes-components` up to FOLIO standards. Now the component is still functional without Bootstrap CSS, even though it will show the "Close" text previously hidden by a global `.sr-only` class.

## Screenshot
The `Autocomplete` component, with the contents of this PR and no global Bootstrap styles:

![thqoc2ibyc](https://user-images.githubusercontent.com/230597/32517317-a0f187fe-c3cb-11e7-9a58-2c4a1f86b2e2.gif)
