### PR TITLE
Tidy 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 * Refactor async user validator. Fixes UIU-302.
 * All network communication is now done through stripes-connect, and `fetch` is unused. Fixes UIU-304.
 * Break out core search/sort functionality into re-usable `<SearchAndSort>` component. Fixes UIU-278.
-* Generalise <SearchAndSort> by moving all user-specific functionality out of it. Fixes UIU-299.
+* Generalise `<SearchAndSort>` by moving all user-specific functionality out of it. Fixes UIU-299.
 * Rewire proxy selection with the new `proxiesfor` endpoint. Fixes UIU-292.
 
 ## [2.10.1](https://github.com/folio-org/ui-users/tree/v2.10.1) (2017-09-05)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 
 buildNPM {
   publishModDescriptor = 'yes'
-}  
+}


### PR DESCRIPTION
Escape angle brackets in Markdown.
Otherwise `<Foo>` names are rendered invisible.