### PR TITLE
No need to pass parsed URL query into <SearchAndSort>

### DIFF
--- a/Users.js
+++ b/Users.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import queryString from 'query-string';
 import uuid from 'uuid';
 import makeQueryFunction from '@folio/stripes-components/util/makeQueryFunction';
 import ViewUser from './ViewUser';
@@ -156,7 +155,6 @@ class Users extends React.Component {
 
   render() {
     const props = this.props;
-    const urlQuery = queryString.parse(props.location.search || '');
     const patronGroups = (props.resources.patronGroups || {}).records || [];
     const initialPath = (_.get(packageInfo, ['stripes', 'home']) ||
                          _.get(packageInfo, ['stripes', 'route']));
@@ -183,7 +181,6 @@ class Users extends React.Component {
       resultCountIncrement={RESULT_COUNT_INCREMENT}
       viewRecordComponent={ViewUser}
       editRecordComponent={UserForm}
-      urlQuery={urlQuery}
       visibleColumns={['Status', 'Name', 'Barcode', 'Patron Group', 'Username', 'Email']}
       resultsFormatter={resultsFormatter}
       onSelectRow={this.props.onSelectRow}

--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -53,7 +53,6 @@ class SearchAndSort extends React.Component {
     resultCountIncrement: PropTypes.number.isRequired,
     viewRecordComponent: PropTypes.func.isRequired,
     editRecordComponent: PropTypes.func.isRequired, // eslint-disable-line react/no-unused-prop-types
-    urlQuery: PropTypes.object.isRequired,
     visibleColumns: PropTypes.arrayOf(
       PropTypes.string,
     ),
@@ -123,7 +122,7 @@ class SearchAndSort extends React.Component {
       initiallySelected = { id };
     }
 
-    const urlQuery = this.props.urlQuery;
+    const urlQuery = queryString.parse(props.location.search || '');
     this.state = {
       filters: initialFilterState(this.props.filterConfig, urlQuery.filters),
       selectedItem: initiallySelected,
@@ -230,7 +229,7 @@ class SearchAndSort extends React.Component {
     this.log('action', 'clicked "close new record"');
 
     const p = this.props;
-    const parsed = Object.assign({}, p.urlQuery);
+    const parsed = queryString.parse(p.location.search || '');
     _.unset(parsed, 'layer');
     p.history.push(`${p.location.pathname}?${queryString.stringify(parsed)}`);
   }
@@ -285,7 +284,8 @@ class SearchAndSort extends React.Component {
 
 
   render() {
-    const { parentResources, urlQuery, filterConfig, moduleName, newRecordPerms, viewRecordPerms, objectName } = this.props;
+    const { parentResources, filterConfig, moduleName, newRecordPerms, viewRecordPerms, objectName } = this.props;
+    const urlQuery = queryString.parse(this.props.location.search || '');
     const stripes = this.context.stripes;
     const objectNameUC = _.upperFirst(objectName);
     const records = (parentResources.records || {}).records || [];


### PR DESCRIPTION
Since that utility component was already using the react-router props
for other reasons, it makes sense to also have it extract and parse
the query when it needs to. This simplifies the API to
`<SearchAndSort>`.

Another part of UIU-299.