### PR TITLE
Fix incorrect propType for parentResources.query.filters

### DIFF
--- a/lib/SearchAndSort/SearchAndSort.js
+++ b/lib/SearchAndSort/SearchAndSort.js
@@ -68,7 +68,7 @@ class SearchAndSort extends React.Component {
     disableRecordCreation: PropTypes.bool,
     parentResources: PropTypes.shape({
       query: PropTypes.shape({
-        filters: PropTypes.object.isRequired,
+        filters: PropTypes.string.isRequired,
       }),
       resultCount: PropTypes.number,
       records: PropTypes.shape({


### PR DESCRIPTION
Yes. A pull-request, with all the attendant song-and-dance, in order to change a plainly incorrect "object" to "string". Because "quality". I guess I'll go and make a cup of tea while I wait for the tests to run before I can merge. La la la, quality!