### PR TITLE
UIU-305 Add tooltip on disabled renew button

### DIFF
--- a/lib/OpenLoans/OpenLoans.js
+++ b/lib/OpenLoans/OpenLoans.js
@@ -193,13 +193,20 @@ class OpenLoans extends React.Component {
   renderSubHeader() {
     const checkedLoans = this.state.checkedLoans;
 
+    let stringToolTip = "Renew";
+    let isDisabled = _.size(checkedLoans) === 0;
+    
+    if (isDisabled) {
+      stringToolTip = "Multiple loans can be processed at the same time. Please select loans first.";
+    }
+    
     return (
       <Row>
         <Col xs={2}>
           <Label>{this.props.loans.length} Records found</Label>
         </Col>
         <Col xs={10}>
-          <Button id="renew-all" disabled={_.size(checkedLoans) === 0} onClick={this.renewAll}>Renew</Button>
+          <Button id="renew-all" disabled={isDisabled} title={stringToolTip} onClick={this.renewAll}>Renew</Button>
         </Col>
       </Row>
     );


### PR DESCRIPTION
Explain to the user why the Renew button is disabled (no loans selected) with a rollover tooltip.
Using plain html title= attribute for tooltips.