### PR TITLE
display user loan count (regression). Fixes UIU-308

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Display permission count when section is collapsed on user form. Fixes UIU-331.
 * Display permission count when section is collapsed on user details. Fixes UIU-332.
 * Display proxy count when section is collapsed on user form. Fixes UIU-330.
+* Display user loan count (regression). Fixes UIU-308.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/lib/ViewSections/UserLoans/UserLoans.js
+++ b/lib/ViewSections/UserLoans/UserLoans.js
@@ -29,19 +29,19 @@ class UserLoans extends React.Component {
       type: 'okapi',
       records: 'loans',
       GET: {
-        path: 'circulation/loans?query=(userId=:{userid})&limit=100',
+        path: 'circulation/loans?query=(userId=:{id})&limit=100',
       },
     },
     openLoansCount: {
       type: 'okapi',
       GET: {
-        path: 'circulation/loans?query=(userId=:{userid} and status.name<>Closed)&limit=1',
+        path: 'circulation/loans?query=(userId=:{id} and status.name<>Closed)&limit=1',
       },
     },
     closedLoansCount: {
       type: 'okapi',
       GET: {
-        path: 'circulation/loans?query=(userId=:{userid} and status.name=Closed)&limit=1',
+        path: 'circulation/loans?query=(userId=:{id} and status.name=Closed)&limit=1',
       },
     },
     userid: {},


### PR DESCRIPTION
A named URL parameter changed from "userid" to "id" as a result of
refactoring this module to use stripes-smart-components' SearchAndSort,
causing code that relied on the previous name to fail.