### PR TITLE
Quick fix: Moved notes icon

### DIFF
--- a/ViewUser.js
+++ b/ViewUser.js
@@ -306,12 +306,6 @@ class ViewUser extends React.Component {
     const proxies = this.props.getProxies();
 
     const detailMenu = (<PaneMenu>
-      <IconButton
-        icon="comment"
-        id="clickable-show-notes"
-        style={{ visibility: !user ? 'hidden' : 'visible' }}
-        onClick={this.props.notesToggle} title="Show Notes"
-      />
       <IfPermission perm="users.item.put">
         <IconButton
           icon="edit"
@@ -321,6 +315,12 @@ class ViewUser extends React.Component {
           title="Edit User"
         />
       </IfPermission>
+      <IconButton
+        icon="comment"
+        id="clickable-show-notes"
+        style={{ visibility: !user ? 'hidden' : 'visible' }}
+        onClick={this.props.notesToggle} title="Show Notes"
+      />
     </PaneMenu>);
 
     if (!user) return (


### PR DESCRIPTION
Moved notes to the end of the details pane PaneHeader (should be consistent across all apps)