### PR TITLE
Use consistent language for 'no attribute found' messages. Fixes UX-115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Setup permissions for proxies. Fixes UIU-349.
 * Refine last updated metadata display. Fixes UIU-325.
 * Make FOLIO number read only. Fixes UIU-348.
+* Use consistent language for "no `<attribute>` found" messages. Fixes UX-115.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/lib/EditablePermissions/EditablePermissions.js
+++ b/lib/EditablePermissions/EditablePermissions.js
@@ -101,7 +101,7 @@ class EditablePermissions extends React.Component {
       <List
         items={fields}
         itemFormatter={listFormatter}
-        isEmptyMessage="This user has no permissions applied."
+        isEmptyMessage="No permissions found"
       />
     );
   }

--- a/lib/RenderPermissions/RenderPermissions.js
+++ b/lib/RenderPermissions/RenderPermissions.js
@@ -41,7 +41,7 @@ class RenderPermissions extends React.Component {
           return (a[key].toLowerCase() < b[key].toLowerCase() ? -1 : 1);
         })}
         itemFormatter={listFormatter}
-        isEmptyMessage="This user has no permissions applied."
+        isEmptyMessage="No permissions found"
       />
     );
   }


### PR DESCRIPTION
Use consistent language. Fixes [UX-115](https://issues.folio.org/browse/UX-115).