### PR TITLE
disable delete of non-empty patron groups. Fixes UIU-364

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Use consistent language for "no `<attribute>` found" messages. Fixes UX-115.
 * Hide proxy section if user lacks sufficient permission to see it. Fixes UIU-363.
 * Add Save button to user settings. Fixes UIU-354.
+* Disable deletion of in-use patron groups. Fixes UIU-364.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -145,9 +145,17 @@ class PatronGroupsSettings extends React.Component {
   render() {
     if (!this.props.resources.groups) return <div />;
 
+    // If a suppressor returns true, the control for that action will not appear
     const suppressor = {
-      // If a suppressor returns true, the control for that action will not appear
-      delete: () => true,
+      delete: (item) => {
+        const usersPerGroup = (this.props.resources.usersPerGroup || {}).other || {};
+        let suppressDelete = [];
+        if (_.has(usersPerGroup, ['resultInfo', 'facets'])) {
+          const groupCounts = _.get(usersPerGroup, ['resultInfo', 'facets', 0, 'facetValues'], []);
+          suppressDelete = _.map(groupCounts, 'value');
+        }
+        return !!(_.includes(suppressDelete, item.id));
+      },
       edit: () => false,
     };
 


### PR DESCRIPTION
Fixes [UIU-364](https://issues.folio.org/browse/UIU-364) using the really nice `suppressor: { delete: (item ) => ..., edit: (item) => ...}` interface @mkuklis and @JohnC-80 implemented in `EditableList`. So easy. 