### PR TITLE
UIU-264 Patron group CRUD headers

### DIFF
--- a/lib/RenderPatronGroup/RenderPatronGroupLastUpdated.js
+++ b/lib/RenderPatronGroup/RenderPatronGroupLastUpdated.js
@@ -1,24 +1,15 @@
-import _ from 'lodash';
+import get from 'lodash/get';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Col } from 'react-flexbox-grid';
 
 class RenderPatronGroupLastUpdated extends React.Component {
 
   static propTypes = {
     item: PropTypes.object.isRequired,
+    users: PropTypes.object.isRequired,
+    groups: PropTypes.object.isRequired,
     gloss: PropTypes.string.isRequired,
-    additionalFields: PropTypes.object.isRequired,
   };
-
-  static defaultProps = {};
-
-  static manifest = Object.freeze({});
-
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
 
   getLastUpdated() {
     let value;
@@ -33,7 +24,7 @@ class RenderPatronGroupLastUpdated extends React.Component {
   }
 
   getGroup() {
-    const groups = _.get(this.props.additionalFields, 'lastUpdated.inheritedProps.resources.groups.records', []);
+    const groups = get(this.props.groups, 'records', []);
     let group;
     for (const g of groups) {
       if (g.id === this.props.item.id) {
@@ -47,7 +38,7 @@ class RenderPatronGroupLastUpdated extends React.Component {
   getUser(group) {
     let user;
     if (group && group.metadata) {
-      const users = _.get(this.props.additionalFields, 'lastUpdated.inheritedProps.resources.users.records', []);
+      const users = get(this.props.users, 'records', []);
       for (const u of users) {
         if (u.id === group.metadata.updatedByUserId) {
           user = u;
@@ -59,7 +50,8 @@ class RenderPatronGroupLastUpdated extends React.Component {
   }
 
   ready() {
-    return this.props.additionalFields.lastUpdated && this.props.item.id;
+    const { users, item } = this.props;
+    return users && users.hasLoaded && item.id;
   }
 
   buildValue(user, group) {
@@ -76,7 +68,8 @@ class RenderPatronGroupLastUpdated extends React.Component {
   }
 
   render() {
-    return (<Col key={this.props.gloss} xs>{this.getLastUpdated()}</Col>);
+    const value = this.getLastUpdated();
+    return (<div key={this.props.gloss} title={value}>{value}</div>);
   }
 }
 

--- a/lib/RenderPatronGroup/RenderPatronGroupLastUpdated.js
+++ b/lib/RenderPatronGroup/RenderPatronGroupLastUpdated.js
@@ -64,7 +64,7 @@ class RenderPatronGroupLastUpdated extends React.Component {
     const year = date.getFullYear();
     const month = date.getMonth();
     const day = date.getDate();
-    return [year, month < 10 ? `0${month}` : month, day < 10 ? `0${day}` : day].join('-');
+    return [year, month < 10 ? `0${month + 1}` : month + 1, day < 10 ? `0${day}` : day].join('-');
   }
 
   render() {

--- a/lib/RenderPatronGroup/RenderPatronGroupNumberOfUsers.js
+++ b/lib/RenderPatronGroup/RenderPatronGroupNumberOfUsers.js
@@ -1,24 +1,14 @@
-import _ from 'lodash';
+import get from 'lodash/get';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Col } from 'react-flexbox-grid';
 
 class RenderPatronGroupNumberOfUsers extends React.Component {
 
   static propTypes = {
     item: PropTypes.object.isRequired,
     gloss: PropTypes.string.isRequired,
-    additionalFields: PropTypes.object.isRequired,
+    usersPerGroup: PropTypes.object.isRequired,
   };
-
-  static defaultProps = {};
-
-  static manifest = Object.freeze({});
-
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
 
   getNumberOfPatrons() {
     let count = 0;
@@ -29,7 +19,7 @@ class RenderPatronGroupNumberOfUsers extends React.Component {
   }
 
   getFacetCount() {
-    const facets = _.get(this.props.additionalFields, 'numberOfUsers.inheritedProps.resources.usersPerGroup.other.resultInfo.facets[0].facetValues', []);
+    const facets = get(this.props.usersPerGroup, 'other.resultInfo.facets[0].facetValues', []);
     let count = 0;
     for (const facet of facets) {
       if (facet.value === this.props.item.id) {
@@ -41,12 +31,13 @@ class RenderPatronGroupNumberOfUsers extends React.Component {
   }
 
   ready() {
-    const hasLoaded = _.get(this.props.additionalFields, 'numberOfUsers.inheritedProps.resources.usersPerGroup.hasLoaded', false);
-    return hasLoaded && this.props.item.id;
+    const { usersPerGroup, item } = this.props;
+    return usersPerGroup && usersPerGroup.hasLoaded && item.id;
   }
 
   render() {
-    return (<Col key={this.props.gloss} xs>{this.getNumberOfPatrons()}</Col>);
+    const value = this.getNumberOfPatrons();
+    return (<div key={this.props.gloss} title={value}>{value}</div>);
   }
 
 }

--- a/settings/AddressTypesSettings.js
+++ b/settings/AddressTypesSettings.js
@@ -25,6 +25,7 @@ class AddressTypesSettings extends React.Component {
         columnMapping={{ addressType: 'Address Type', desc: 'Description' }}
         itemTemplate={{ addressType: 'string', id: 'string', desc: 'string' }}
         nameKey="addressType"
+        addButtonId="clickable-add-addressType"
       />
     );
   }

--- a/settings/AddressTypesSettings.js
+++ b/settings/AddressTypesSettings.js
@@ -22,7 +22,7 @@ class AddressTypesSettings extends React.Component {
         records="addressTypes"
         label="Address Types"
         visibleFields={['addressType', 'desc']}
-        columnMapping={{'addressType': 'Type', 'desc': 'Description'}}
+        columnMapping={{ addressType: 'Address Type', desc: 'Description' }}
         itemTemplate={{ addressType: 'string', id: 'string', desc: 'string' }}
         nameKey="addressType"
       />

--- a/settings/AddressTypesSettings.js
+++ b/settings/AddressTypesSettings.js
@@ -25,7 +25,7 @@ class AddressTypesSettings extends React.Component {
         columnMapping={{ addressType: 'Address Type', desc: 'Description' }}
         itemTemplate={{ addressType: 'string', id: 'string', desc: 'string' }}
         nameKey="addressType"
-        addButtonId="clickable-add-addressType"
+        id="addresstypes"
       />
     );
   }

--- a/settings/AddressTypesSettings.js
+++ b/settings/AddressTypesSettings.js
@@ -22,6 +22,7 @@ class AddressTypesSettings extends React.Component {
         records="addressTypes"
         label="Address Types"
         visibleFields={['addressType', 'desc']}
+        columnMapping={{'addressType': 'Type', 'desc': 'Description'}}
         itemTemplate={{ addressType: 'string', id: 'string', desc: 'string' }}
         nameKey="addressType"
       />

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -11,7 +11,10 @@ import { RenderPatronGroupLastUpdated, RenderPatronGroupNumberOfUsers } from '..
 class PatronGroupsSettings extends React.Component {
 
   static propTypes = {
-    stripes: PropTypes.shape({
+    // The stripes prop will probably get used eventually, so
+    // it's probably best to leave it there.
+    // eslint-disable-next-line
+    stripes: PropTypes.shape({  
       connect: PropTypes.func.isRequired,
     }).isRequired,
     resources: PropTypes.shape({

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -72,8 +72,6 @@ class PatronGroupsSettings extends React.Component {
 
   constructor(props) {
     super(props);
-    this.connectedPatronGroupLastUpdated = props.stripes.connect(RenderPatronGroupLastUpdated);
-    this.connectedPatronGroupNumberOfUsers = props.stripes.connect(RenderPatronGroupNumberOfUsers);
 
     this.onCreateType = this.onCreateType.bind(this);
     this.onUpdateType = this.onUpdateType.bind(this);
@@ -196,6 +194,7 @@ class PatronGroupsSettings extends React.Component {
             nameKey="group"
             formatter={formatter}
             itemTemplate={{}}
+            addButtonId="clickable-add-patronGroup"
           />
         </Pane>
       </Paneset>

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -159,6 +159,20 @@ class PatronGroupsSettings extends React.Component {
       edit: () => false,
     };
 
+    const formatter = {
+      lastUpdated: (item) => { return (<RenderPatronGroupLastUpdated 
+          item={item} 
+          groups={this.props.resources ? this.props.resources.groups : null}
+          users={this.props.resources ? this.props.resources.users : null}
+          gloss="Last Updated"
+      />);},
+      numberOfUsers: (item) => <RenderPatronGroupNumberOfUsers 
+          item={item} 
+          usersPerGroup={this.props.resources ? this.props.resources.usersPerGroup : null}
+          gloss="# of Users"
+        />,
+    };
+
     return (
       <Paneset>
         <Pane defaultWidth="fill" fluidContentWidth paneTitle="Patron Groups">
@@ -169,26 +183,17 @@ class PatronGroupsSettings extends React.Component {
             // is pulled in. This still causes a JS warning, but not an error
             contentData={this.props.resources.groups.records || []}
             createButtonLabel="+ Add new"
-            visibleFields={['group', 'desc']}
-            itemTemplate={{ group: 'string', id: 'string', desc: 'string' }}
+            visibleFields={['group', 'desc', 'lastUpdated', 'numberOfUsers']}
+            columnMapping={{'desc': 'Description', 'lastUpdated': 'Last Updated', 'numberOfUsers': '# of Users'}}
+            readOnlyFields={[`lastUpdated`, `numberOfUsers`]}
             actionSuppression={suppressor}
             onCreate={this.onCreateType}
             onUpdate={this.onUpdateType}
             onDelete={this.onDeleteType}
             isEmptyMessage="There are no patron groups"
             nameKey="group"
-            additionalFields={{
-              lastUpdated: {
-                component: this.connectedPatronGroupLastUpdated,
-                gloss: 'Last Updated',
-                inheritedProps: this.props,
-              },
-              numberOfUsers: {
-                component: this.connectedPatronGroupNumberOfUsers,
-                gloss: '# of Users',
-                inheritedProps: this.props,
-              },
-            }}
+            formatter={formatter}
+            itemTemplate={{}}
           />
         </Pane>
       </Paneset>

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -160,17 +160,19 @@ class PatronGroupsSettings extends React.Component {
     };
 
     const formatter = {
-      lastUpdated: (item) => { return (<RenderPatronGroupLastUpdated 
-          item={item} 
-          groups={this.props.resources ? this.props.resources.groups : null}
-          users={this.props.resources ? this.props.resources.users : null}
-          gloss="Last Updated"
-      />);},
-      numberOfUsers: (item) => <RenderPatronGroupNumberOfUsers 
-          item={item} 
-          usersPerGroup={this.props.resources ? this.props.resources.usersPerGroup : null}
-          gloss="# of Users"
-        />,
+      lastUpdated: item => (<RenderPatronGroupLastUpdated
+        item={item}
+        groups={this.props.resources ? this.props.resources.groups : null}
+        users={this.props.resources ? this.props.resources.users : null}
+        gloss="Last Updated"
+      />
+      ),
+      numberOfUsers: item => (<RenderPatronGroupNumberOfUsers
+        item={item}
+        usersPerGroup={this.props.resources ? this.props.resources.usersPerGroup : null}
+        gloss="# of Users"
+      />
+      ),
     };
 
     return (
@@ -184,8 +186,8 @@ class PatronGroupsSettings extends React.Component {
             contentData={this.props.resources.groups.records || []}
             createButtonLabel="+ Add new"
             visibleFields={['group', 'desc', 'lastUpdated', 'numberOfUsers']}
-            columnMapping={{'desc': 'Description', 'lastUpdated': 'Last Updated', 'numberOfUsers': '# of Users'}}
-            readOnlyFields={[`lastUpdated`, `numberOfUsers`]}
+            columnMapping={{ desc: 'Description', lastUpdated: 'Last Updated', numberOfUsers: '# of Users' }}
+            readOnlyFields={['lastUpdated', 'numberOfUsers']}
             actionSuppression={suppressor}
             onCreate={this.onCreateType}
             onUpdate={this.onUpdateType}

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -197,7 +197,7 @@ class PatronGroupsSettings extends React.Component {
             nameKey="group"
             formatter={formatter}
             itemTemplate={{}}
-            addButtonId="clickable-add-patronGroup"
+            id="patrongroups"
           />
         </Pane>
       </Paneset>

--- a/test/ui-testing/patron_group.js
+++ b/test/ui-testing/patron_group.js
@@ -59,7 +59,7 @@ module.exports.test = function foo(uiTestCtx) {
         .wait(wait)
         .click('a[href="/settings/users/groups"]')
         .wait(wait)
-        .click('#clickable-add-patronGroup')
+        .click('#clickable-add-patrongroups')
         .wait(1000)
         .type('input[name="items[0].group"]', gid)
         .type('input[name="items[0].desc"]', gidlabel)


### PR DESCRIPTION
Updated Patron Group CRUD to use new features/API of <EditableList> once https://github.com/folio-org/stripes-components/pull/191 is merged in.

In short, it trades the `availableFields` API for the `formatters` API of `<MultiColumnList>`
It also includes configurable column header labels and the ability to set read-only fields.

Additionally, tests have been updated and the component has grown a few new, important `id` attributes.