### PR TITLE
Adding marginbottom0 to buttons + more

### DIFF
--- a/UserForm.js
+++ b/UserForm.js
@@ -5,7 +5,7 @@ import Paneset from '@folio/stripes-components/lib/Paneset';
 import Pane from '@folio/stripes-components/lib/Pane';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import Button from '@folio/stripes-components/lib/Button';
-import Icon from '@folio/stripes-components/lib/Icon';
+import IconButton from '@folio/stripes-components/lib/IconButton';
 import stripesForm from '@folio/stripes-form';
 import { ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
@@ -109,9 +109,13 @@ class UserForm extends React.Component {
 
     return (
       <PaneMenu>
-        <button id="clickable-closenewuserdialog" onClick={onCancel} title="close" aria-label="Close New User Dialog">
-          <span style={{ fontSize: '30px', color: '#999', lineHeight: '18px' }} >&times;</span>
-        </button>
+        <IconButton
+          id="clickable-closenewuserdialog"
+          onClick={onCancel}
+          title="close"
+          ariaLabel="Close New User Dialog"
+          icon="closeX"
+        />
       </PaneMenu>
     );
   }
@@ -127,6 +131,8 @@ class UserForm extends React.Component {
           title={label}
           disabled={pristine || submitting}
           onClick={handleSubmit}
+          buttonStyle="primary paneHeaderNewButton"
+          marginBottom0
         >
           {label}
         </Button>
@@ -150,7 +156,7 @@ class UserForm extends React.Component {
     const { initialValues } = this.props;
     const { sections } = this.state;
     const firstMenu = this.getAddFirstMenu();
-    const paneTitle = initialValues.id ? <span><Icon icon="edit" iconRootClass={css.UserFormEditIcon} />Edit: <Icon icon="profile" iconRootClass={css.UserFormEditIcon} />{getFullName(initialValues)}</span> : 'Create user';
+    const paneTitle = initialValues.id ? `Edit: ${getFullName(initialValues)}` : 'Create user';
     const lastMenu = initialValues.id ?
       this.getLastMenu('clickable-updateuser', 'Update user') :
       this.getLastMenu('clickable-createnewuser', 'Create user');

--- a/UserForm.js
+++ b/UserForm.js
@@ -89,6 +89,7 @@ class UserForm extends React.Component {
 
     this.state = {
       sections: {
+        editUserInfo: true,
         extendedInfo: true,
         contactInfo: true,
         proxy: false,
@@ -170,7 +171,7 @@ class UserForm extends React.Component {
                 <ExpandAllButton accordionStatus={sections} onToggle={this.handleExpandAll} />
               </Col>
             </Row>
-            <EditUserInfo {...this.props} />
+            <EditUserInfo accordionId="editUserInfo" expanded={sections.editUserInfo} onToggle={this.handleSectionToggle} {...this.props} />
             <EditExtendedInfo accordionId="extendedInfo" expanded={sections.extendedInfo} onToggle={this.handleSectionToggle} {...this.props} />
             <EditContactInfo accordionId="contactInfo" expanded={sections.contactInfo} onToggle={this.handleSectionToggle} {...this.props} />
             {initialValues.id &&

--- a/lib/EditSections/EditContactInfo/EditContactInfo.js
+++ b/lib/EditSections/EditContactInfo/EditContactInfo.js
@@ -27,9 +27,7 @@ const EditContactInfo = ({ expanded, onToggle, accordionId, parentResources, ini
       open={expanded}
       id={accordionId}
       onToggle={onToggle}
-      label={
-        <h2>Contact information</h2>
-      }
+      label="Contact information"
     >
       <Row>
         <Col xs={8}>

--- a/lib/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/lib/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -30,9 +30,7 @@ class EditExtendedInfo extends React.Component {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={
-          <h2>Extended information</h2>
-        }
+        label="Extended information"
       >
         <Row>
           <Col xs={8}>

--- a/lib/EditSections/EditProxy/EditProxy.js
+++ b/lib/EditSections/EditProxy/EditProxy.js
@@ -17,9 +17,7 @@ const EditProxy = (props) => {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={
-          <h2>Proxy</h2>
-        }
+        label="Proxy"
         displayWhenClosed={
           <Badge>{sponsors.length + proxies.length}</Badge>
         }

--- a/lib/EditSections/EditUserInfo/EditUserInfo.js
+++ b/lib/EditSections/EditUserInfo/EditUserInfo.js
@@ -5,10 +5,9 @@ import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import Select from '@folio/stripes-components/lib/Select';
 import Datepicker from '@folio/stripes-components/lib/Datepicker';
 import TextField from '@folio/stripes-components/lib/TextField';
+import { Accordion } from '@folio/stripes-components/lib/Accordion';
 
-import css from './EditUserInfo.css';
-
-const EditUserInfo = ({ parentResources, initialValues }) => {
+const EditUserInfo = ({ parentResources, initialValues, expanded, onToggle, accordionId }) => {
   const patronGroups = (parentResources.patronGroups || {}).records || [];
   const patronGroupOptions = (patronGroups || []).map(g => ({
     label: `${g.group} (${g.desc})`, value: g.id, selected: initialValues.patronGroup === g.id }));
@@ -18,73 +17,75 @@ const EditUserInfo = ({ parentResources, initialValues }) => {
   ].map(s => ({ ...s, selected: (initialValues.active === s.value || s.value === true) }));
 
   return (
-    <div>
-      <section className={css.root}>
-        <div className={css.label}>
-          <h2>User information</h2>
-        </div>
-        <Row>
-          <Col xs={8}>
-            <Row>
-              <Col xs={3}>
-                <Field label="Last name *" name="personal.lastName" id="adduser_lastname" component={TextField} required fullWidth />
-              </Col>
-              <Col xs={3}>
-                <Field label="First name" name="personal.firstName" id="adduser_firstname" component={TextField} fullWidth />
-              </Col>
-              <Col xs={3}>
-                <Field label="Middle name" name="personal.middleName" id="adduser_middlename" component={TextField} fullWidth />
-              </Col>
-              <Col xs={3}>
-                <Field label="Barcode" name="barcode" id="adduser_barcode" component={TextField} fullWidth />
-              </Col>
-            </Row>
+    <Accordion
+      label="User information"
+      open={expanded}
+      id={accordionId}
+      onToggle={onToggle}
+    >
+      <Row>
+        <Col xs={8}>
+          <Row>
+            <Col xs={3}>
+              <Field label="Last name *" name="personal.lastName" id="adduser_lastname" component={TextField} required fullWidth />
+            </Col>
+            <Col xs={3}>
+              <Field label="First name" name="personal.firstName" id="adduser_firstname" component={TextField} fullWidth />
+            </Col>
+            <Col xs={3}>
+              <Field label="Middle name" name="personal.middleName" id="adduser_middlename" component={TextField} fullWidth />
+            </Col>
+            <Col xs={3}>
+              <Field label="Barcode" name="barcode" id="adduser_barcode" component={TextField} fullWidth />
+            </Col>
+          </Row>
 
-            <Row>
-              <Col xs={3}>
-                <Field
-                  label="Patron group *"
-                  name="patronGroup"
-                  id="adduser_group"
-                  component={Select}
-                  fullWidth
-                  dataOptions={[{ label: 'Select patron group', value: '' }, ...patronGroupOptions]}
-                />
-              </Col>
-              <Col xs={3}>
-                <Field
-                  label="Status *"
-                  name="active"
-                  id="useractive"
-                  component={Select}
-                  fullWidth
-                  dataOptions={statusOptions}
-                />
-              </Col>
-              <Col xs={3}>
-                <Field
-                  component={Datepicker}
-                  label="Expiration date"
-                  dateFormat="YYYY-MM-DD"
-                  name="expirationDate"
-                  id="adduser_expirationdate"
-                />
-              </Col>
-              <Col xs={3}>
-                <Field label="Username *" name="username" id="adduser_username" component={TextField} required fullWidth />
-              </Col>
-            </Row>
-          </Col>
-        </Row>
-      </section>
-      <br />
-    </div>
+          <Row>
+            <Col xs={3}>
+              <Field
+                label="Patron group *"
+                name="patronGroup"
+                id="adduser_group"
+                component={Select}
+                fullWidth
+                dataOptions={[{ label: 'Select patron group', value: '' }, ...patronGroupOptions]}
+              />
+            </Col>
+            <Col xs={3}>
+              <Field
+                label="Status *"
+                name="active"
+                id="useractive"
+                component={Select}
+                fullWidth
+                dataOptions={statusOptions}
+              />
+            </Col>
+            <Col xs={3}>
+              <Field
+                component={Datepicker}
+                label="Expiration date"
+                dateFormat="YYYY-MM-DD"
+                name="expirationDate"
+                id="adduser_expirationdate"
+              />
+            </Col>
+            <Col xs={3}>
+              <Field label="Username *" name="username" id="adduser_username" component={TextField} required fullWidth />
+            </Col>
+          </Row>
+        </Col>
+      </Row>
+    </Accordion>
   );
 };
 
 EditUserInfo.propTypes = {
   parentResources: PropTypes.object,
   initialValues: PropTypes.object,
+  expanded: PropTypes.bool,
+  onToggle: PropTypes.func,
+  accordionId: PropTypes.string.isRequired,
 };
 
 export default EditUserInfo;

--- a/lib/EditablePermissions/EditablePermissions.js
+++ b/lib/EditablePermissions/EditablePermissions.js
@@ -172,9 +172,7 @@ class EditablePermissions extends React.Component {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={
-          <h2 className="marginTop0">{this.props.heading}</h2>
-        }
+        label={this.props.heading}
         displayWhenClosed={
           <Badge>{permissions.length}</Badge>
         }

--- a/settings/ProfilePictureForm.js
+++ b/settings/ProfilePictureForm.js
@@ -15,7 +15,7 @@ const LocaleForm = (props) => {
     label,
   } = props;
 
-  const lastMenu = (<Button type="submit" disabled={(pristine || submitting)}>Save</Button>);
+  const lastMenu = (<Button type="submit" buttonStyle="primary paneHeaderNewButton" disabled={(pristine || submitting)} marginBottom0>Save</Button>);
 
   return (
     <form id="locale-form" onSubmit={handleSubmit}>


### PR DESCRIPTION
Adding marginBottom0 prop to buttons that doesn't need margin bottom. The reason is that we are re-adding the default margin on buttons.

While I was adding the props in a few places I came across some minor things on edit user that I decided to fix:

- Fixed headers on accordions
- Added accordion to edit user info
- Fixed PaneHeader (added IconButton for close icon and removed icons from PaneTitle)