### PR TITLE
SearchAndSort's show-single-row is now optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Add createdBy and updatedBy to metadata. Fixes UIU-325.
 * Consistent formatting for "No proxies/No sponsors" messages. Fixes UX-115.
 * Refactor settings to use ConfigManager. Fixes UIU-376.
+* Make SearchAndSort's show-single-row optional and on by default. Refs UIREQ-60, UICHKOUT-54, UIU-373, STSMACOM-52.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/Users.js
+++ b/Users.js
@@ -57,7 +57,12 @@ class Users extends React.Component {
     onComponentWillUnmount: PropTypes.func,
     visibleColumns: PropTypes.arrayOf(PropTypes.string),
     disableRecordCreation: PropTypes.bool,
+    showSingleResult: PropTypes.bool,
   };
+
+  static defaultProps = {
+    showSingleResult: true,
+  }
 
   static manifest = Object.freeze({
     query: {
@@ -234,6 +239,7 @@ class Users extends React.Component {
       disableRecordCreation={disableRecordCreation}
       parentResources={props.resources}
       parentMutator={props.mutator}
+      showSingleResult={props.showSingleResult}
     />);
   }
 }


### PR DESCRIPTION
The desired behavior of this app when used as a plugin as via
ui-plugin-find-users is different than when used as a standalone app. On
its own, a search that results in a single row should show that entry's
details pane. As part of a plugin, when being displayed in a modal, a
search that results in a single row should simply show that single row.

This change restores the previous functionality of the app when used as
a plugin while still allowing the app to take advantage of
SearchAndSort's show-single-row feature when used independently.

Refs [STSMACOM-52](https://issues.folio.org/browse/STSMACOM-52), [UIIN-58](https://issues.folio.org/browse/UIIN-58), [UIREQ-60](https://issues.folio.org/browse/UIREQ-60), [UICHKOUT-54](https://issues.folio.org/browse/UICHKOUT-54), [UIU-373](https://issues.folio.org/browse/UIU-373).