### PR TITLE
Improve button style consistency

### DIFF
--- a/lib/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/lib/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -74,7 +74,7 @@ class EditExtendedInfo extends React.Component {
                 </Col>
                 <Col xs={1}>
                   <div className={css.togglePw}>
-                    <Button buttonStyle="secondary hollow" id="toggle_pw_btn" onClick={() => this.togglePassword()}>
+                    <Button id="toggle_pw_btn" onClick={() => this.togglePassword()}>
                       {this.state.showPassword ? 'Hide' : 'Show'}
                     </Button>
                   </div>

--- a/lib/ProxyGroup/ProxyEditList/ProxyEditList.js
+++ b/lib/ProxyGroup/ProxyEditList/ProxyEditList.js
@@ -80,7 +80,7 @@ export default class ProxyEditList extends React.Component {
                 {...this.props}
                 dataKey={name}
                 searchLabel="+ New"
-                searchButtonStyle="primary"
+                searchButtonStyle="default"
                 selectUser={user => this.onAdd(user)}
                 visibleColumns={['Name', 'Patron Group', 'Username', 'Barcode']}
                 disableRecordCreation={disableRecordCreation}


### PR DESCRIPTION
Follow-up to https://github.com/folio-org/stripes-components/pull/209.

1. `secondary` and `hollow` are no longer available button styles
2. The user edit view had inconsistent styles for "New" buttons:
<img width="596" alt="image001" src="https://user-images.githubusercontent.com/230597/35816208-bc67ca04-0a5f-11e8-8018-77c10889c15c.png">
They're now all `default` button style, not a mix of `default` and `primary`.