### PR TITLE
UIU-386: do not change loanDate on renewal

### DIFF
--- a/lib/OpenLoans/OpenLoans.js
+++ b/lib/OpenLoans/OpenLoans.js
@@ -137,7 +137,7 @@ class OpenLoans extends React.Component {
   renew(loan) {
     Object.assign(loan, {
       renewalCount: (loan.renewalCount || 0) + 1,
-      loanDate: moment().format(),
+      loanDate: moment(loan.loanDate).format(),
       dueDate: moment(loan.dueDate).add(30, 'days').format(),
       action: 'renewed',
     });


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-386

The bug is that renewing a loan sets the loan's loan date to the current time.

With this PR, renewing a loan does not change the loan date.