### PR TITLE
Upgrade react-bootstrap-typeahead dependency to v2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
     "react-bootstrap": "^0.31.1",
-    "react-bootstrap-typeahead": "^1.4.0",
+    "react-bootstrap-typeahead": "^2.4.0",
     "react-flexbox-grid": "^2.0.0",
     "react-intl": "^2.3.0",
     "react-router": "^4.2.0",


### PR DESCRIPTION
This pulls in v0.8.x of react-overlays, rather then v0.7.x as before,
and so avoids a clash with the v0.8.x used by stripes-core.

Resolves the last part of STCOR-167.