### PR TITLE
STCOM-198 Use semantic tags, update headings.

### DIFF
--- a/lib/ProxyGroup/ProxyViewList/ProxyViewList.js
+++ b/lib/ProxyGroup/ProxyViewList/ProxyViewList.js
@@ -11,7 +11,7 @@ const ProxyViewList = ({ records, name, label, itemComponent }) => {
 
   return (
     <div className={css.list}>
-      <Headline tag="h2" size="medium">{label}</Headline>
+      <Headline tag="h4" size="medium">{label}</Headline>
       {items.length ? items : <p className={css.isEmptyMessage}>No {name} found</p>}
     </div>
   );

--- a/lib/ViewSections/UserInfo/UserInfo.js
+++ b/lib/ViewSections/UserInfo/UserInfo.js
@@ -41,7 +41,7 @@ class UserInfo extends React.Component {
     const updatedBy = (resources.updatedBy || {}).records || [];
 
     return (
-      <div>
+      <section>
         <Headline tag="h3" margin="medium" faded>
           User information
         </Headline>
@@ -100,7 +100,7 @@ class UserInfo extends React.Component {
             </Col>
           }
         </Row>
-      </div>
+      </section>
     );
   }
 }


### PR DESCRIPTION
The goal of STCOM-198 is clean up the "outlining" of folio modules at the component level and, in some cases, within the modules themselves.
This PR corresponds with PR's in both `stripes-components` and `stripes-core` (will add shortly)
Using the "Headings List" of the NVDA screen-reader the before-and-after states can be seen:
Before:
![image](https://user-images.githubusercontent.com/20704067/36741374-883984c8-1baa-11e8-9ff9-385e3fc56845.png)
After: Notice the hierarchy of content is captured with the Main Navigation and 3 Panes at level 2, having sub-pane content also arranged within.
![image](https://user-images.githubusercontent.com/20704067/36741817-af561bb0-1bab-11e8-9699-de071f1009b8.png)

