### PR TITLE
UIU-401: Fixed bug where sorting by user status didn't work

### DIFF
--- a/Users.js
+++ b/Users.js
@@ -34,6 +34,10 @@ const filterConfig = [
   },
 ];
 
+const columnMapping = {
+  Status: 'active',
+};
+
 class Users extends React.Component {
   static propTypes = {
     resources: PropTypes.shape({
@@ -206,6 +210,7 @@ class Users extends React.Component {
       parentResources={props.resources}
       parentMutator={props.mutator}
       showSingleResult={showSingleResult}
+      columnMapping={columnMapping}
     />);
   }
 }


### PR DESCRIPTION
JIRA: [Sorting on the "Status" field didn't work.](https://issues.folio.org/browse/UIU-401)

Made use of the `columnMapping` prop to provide the correct key to sort on to mod-users.