### PR TITLE
UIU-424: Updated tests to handle empty users list onload

### DIFF
--- a/test/ui-testing/new_proxy.js
+++ b/test/ui-testing/new_proxy.js
@@ -26,6 +26,8 @@ module.exports.test = function foo(uiTestCtx) {
       it('should get active user barcodes', (done) => {
         nightmare
           .click('#clickable-users-module')
+          .wait(1000)
+          .click('#clickable-filter-active-Active')
           .wait('#list-users div[role="listitem"]:nth-child(9)')
           .evaluate(() => {
             const ubc = [];

--- a/test/ui-testing/patron_group.js
+++ b/test/ui-testing/patron_group.js
@@ -70,9 +70,11 @@ module.exports.test = function foo(uiTestCtx) {
           .then(() => { done(); })
           .catch(done);
       });
-      it('should find a user to edit', (done) => {
+      it('should find an active user to edit', (done) => {
         nightmare
           .click('#clickable-users-module')
+          .wait(1000)
+          .click('#clickable-filter-active-Active')
           .wait('#list-users div[role="listitem"]:nth-of-type(11) > a > div:nth-of-type(5)')
           .evaluate(() => document.querySelector('#list-users div[role="listitem"]:nth-of-type(11) > a > div:nth-of-type(5)').title)
           .then((result) => {


### PR DESCRIPTION
The Users module was changed to not show any users on initial load. This PR changes the tests to check the 'Active' filter to ensure that a list of users is fetched and displayed.