### PR TITLE
Preventing display of empty parentheses

### DIFF
--- a/lib/EditSections/EditUserInfo/EditUserInfo.js
+++ b/lib/EditSections/EditUserInfo/EditUserInfo.js
@@ -9,7 +9,7 @@ import { Accordion } from '@folio/stripes-components/lib/Accordion';
 
 const EditUserInfo = ({ parentResources, initialValues, expanded, onToggle, accordionId }) => {
   const patronGroups = (parentResources.patronGroups || {}).records || [];
-  const patronGroupOptions = (patronGroups || []).map(g => ({ label: `${g.group} (${g.desc})`, value: g.id, selected: initialValues.patronGroup === g.id }));
+  const patronGroupOptions = (patronGroups || []).map(g => ({ label: `${g.group}`.concat(g.desc ? ` (${g.desc})` : ``), value: g.id, selected: initialValues.patronGroup === g.id }));
   const statusOptions = [
     { label: 'Active', value: true },
     { label: 'Inactive', value: false },

--- a/lib/EditSections/EditUserInfo/EditUserInfo.js
+++ b/lib/EditSections/EditUserInfo/EditUserInfo.js
@@ -9,7 +9,7 @@ import { Accordion } from '@folio/stripes-components/lib/Accordion';
 
 const EditUserInfo = ({ parentResources, initialValues, expanded, onToggle, accordionId }) => {
   const patronGroups = (parentResources.patronGroups || {}).records || [];
-  const patronGroupOptions = (patronGroups || []).map(g => ({ label: `${g.group}`.concat(g.desc ? ` (${g.desc})` : ``), value: g.id, selected: initialValues.patronGroup === g.id }));
+  const patronGroupOptions = (patronGroups || []).map(g => ({ label: g.group.concat(g.desc ? ` (${g.desc})` : ''), value: g.id, selected: initialValues.patronGroup === g.id }));
   const statusOptions = [
     { label: 'Active', value: true },
     { label: 'Inactive', value: false },


### PR DESCRIPTION
Resolves [UIU-391](https://issues.folio.org/browse/UIU-391)

Checks to see if the patron group has a description and only appends the
parenthetical if the description exits.