### PR TITLE
don't use deprecated props for Typeahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Pass packageInfo to SearchAndSort; it's simpler. Refs STSMACOM-64. Available after v2.12.1.
 * Upgrade stripes-components dependency to v2.0.3. Fixes UIU-423.
 * Modal users-in-users app can now search again, thanks to the STCOM-226 fix. Fixes UIU-426.
+* Avoid deprecated props for `<Typeahead>`. Refs UIU-427.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/lib/Autocomplete/Autocomplete.js
+++ b/lib/Autocomplete/Autocomplete.js
@@ -8,7 +8,7 @@ function defaultFilterBy(option, text) {
   return option.label.toLowerCase().startsWith(text.toLowerCase());
 }
 
-const Autocomplete = ({ dataOptions, tether, filterBy, label, input: { value, onChange } }) => {
+const Autocomplete = ({ dataOptions, tether, filterBy, label, input: { value, onChange }, inputProps }) => {
   const selected = (value) ? [value] : [];
   const filter = filterBy || defaultFilterBy;
   const mergedTetherProps = Object.assign({}, Autocomplete.defaultProps.tether, tether);
@@ -19,7 +19,7 @@ const Autocomplete = ({ dataOptions, tether, filterBy, label, input: { value, on
       <div className={css.root}>
         <Typeahead
           clearButton
-          name={label}
+          inputProps={inputProps}
           bsSize="small"
           filterBy={filter}
           onInputChange={val => onChange(val)}

--- a/lib/Autocomplete/Autocomplete.js
+++ b/lib/Autocomplete/Autocomplete.js
@@ -53,6 +53,9 @@ Autocomplete.propTypes = {
   dataOptions: PropTypes.arrayOf(PropTypes.object),
   filterBy: PropTypes.func,
   tether: PropTypes.object,
+  inputProps: PropTypes.shape({
+    name: PropTypes.string,
+  }),
 };
 
 export default Autocomplete;

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "@folio/eslint-config-stripes": "^1.1.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.0.4",
+    "@folio/stripes-components": "^2.0.5",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-smart-components": "^1.4.3",
     "classnames": "^2.2.5",


### PR DESCRIPTION
The prop `name` was deprecated for `<Typeahead>` in favor of `inputProps`, generating a console warning. This update resolves the console warning, and also sets the field's `name` attribute based on `inputProps.name` rather than `label`, which must have been an unnoticed bug.

Refs [UIU-427](https://issues.folio.org/browse/UIU-427).

See also https://github.com/folio-org/stripes-components/pull/267