### PR TITLE
Added app icon in PaneHeader's

### DIFF
--- a/UserForm.js
+++ b/UserForm.js
@@ -177,7 +177,7 @@ class UserForm extends React.Component {
     return (
       <form className={css.UserFormRoot} id="form-user">
         <Paneset isRoot>
-          <Pane defaultWidth="100%" firstMenu={firstMenu} lastMenu={lastMenu} paneTitle={paneTitle} appIcon="users">
+          <Pane defaultWidth="100%" firstMenu={firstMenu} lastMenu={lastMenu} paneTitle={paneTitle} appIcon={{ app: 'users' }}>
             <Row end="xs">
               <Col xs>
                 <ExpandAllButton accordionStatus={sections} onToggle={this.handleExpandAll} />

--- a/UserForm.js
+++ b/UserForm.js
@@ -169,7 +169,7 @@ class UserForm extends React.Component {
     const { initialValues } = this.props;
     const { sections } = this.state;
     const firstMenu = this.getAddFirstMenu();
-    const paneTitle = initialValues.id ? `Edit: ${getFullName(initialValues)}` : 'Create user';
+    const paneTitle = initialValues.id ? getFullName(initialValues) : 'Create user';
     const lastMenu = initialValues.id ?
       this.getLastMenu('clickable-updateuser', 'Update user') :
       this.getLastMenu('clickable-createnewuser', 'Create user');
@@ -177,7 +177,7 @@ class UserForm extends React.Component {
     return (
       <form className={css.UserFormRoot} id="form-user">
         <Paneset isRoot>
-          <Pane defaultWidth="100%" firstMenu={firstMenu} lastMenu={lastMenu} paneTitle={paneTitle}>
+          <Pane defaultWidth="100%" firstMenu={firstMenu} lastMenu={lastMenu} paneTitle={paneTitle} appIcon="users">
             <Row end="xs">
               <Col xs>
                 <ExpandAllButton accordionStatus={sections} onToggle={this.handleExpandAll} />

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -341,7 +341,7 @@ class ViewUser extends React.Component {
     const userFormData = this.getUserFormData(user, addresses, sponsors, proxies, permissions);
 
     return (
-      <Pane id="pane-userdetails" defaultWidth={this.props.paneWidth} paneTitle={getFullName(user)} lastMenu={detailMenu} dismissible onClose={this.props.onClose} appIcon="users">
+      <Pane id="pane-userdetails" defaultWidth={this.props.paneWidth} paneTitle={getFullName(user)} lastMenu={detailMenu} dismissible onClose={this.props.onClose} appIcon={{ app: 'users' }}>
         <Row end="xs"><Col xs><ExpandAllButton accordionStatus={this.state.sections} onToggle={this.handleExpandAll} /></Col></Row>
 
         <this.connectedUserInfo user={user} patronGroup={patronGroup} settings={settings} stripes={stripes} />

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -341,7 +341,7 @@ class ViewUser extends React.Component {
     const userFormData = this.getUserFormData(user, addresses, sponsors, proxies, permissions);
 
     return (
-      <Pane id="pane-userdetails" defaultWidth={this.props.paneWidth} paneTitle={getFullName(user)} lastMenu={detailMenu} dismissible onClose={this.props.onClose}>
+      <Pane id="pane-userdetails" defaultWidth={this.props.paneWidth} paneTitle={getFullName(user)} lastMenu={detailMenu} dismissible onClose={this.props.onClose} appIcon="users">
         <Row end="xs"><Col xs><ExpandAllButton accordionStatus={this.state.sections} onToggle={this.handleExpandAll} /></Col></Row>
 
         <this.connectedUserInfo user={user} patronGroup={patronGroup} settings={settings} stripes={stripes} />


### PR DESCRIPTION
We added the functionality of adding AppIcon in a PaneHeader so this is a minor update to activate that feature in ui-users.

This can be passed down from Pane as well like so: ` <Pane appIcon={{ app: 'users' }} />`. For more info check out the storybook -> Pane -> readme.