### PR TITLE
UIU-431: Show but disable the Delete button for in-use patron groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "@folio/eslint-config-stripes": "^1.1.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.0.5",
+    "@folio/stripes-components": "^2.0.7",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-smart-components": "^1.4.5",
     "classnames": "^2.2.5",

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -194,15 +194,15 @@ class PatronGroupsSettings extends React.Component {
           const groupCounts = _.get(usersPerGroup, ['resultInfo', 'facets', 0, 'facetValues'], []);
           disableDelete = _.map(groupCounts, 'value');
         }
-        if (!!(_.includes(disableDelete, item.id))) {
+        if (_.includes(disableDelete, item.id)) {
           return {
-            disabled: !!(_.includes(disableDelete, item.id)),
-            title: 'Patron group cannot be deleted when used by one or more users'
+            disabled: _.includes(disableDelete, item.id),
+            title: 'Patron group cannot be deleted when used by one or more users',
           };
         }
 
         return {};
-      }
+      },
     };
 
     const formatter = {

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -186,18 +186,23 @@ class PatronGroupsSettings extends React.Component {
   render() {
     if (!this.props.resources.groups) return <div />;
 
-    // If a suppressor returns true, the control for that action will not appear
-    const suppressor = {
+    const actionProps = {
       delete: (item) => {
         const usersPerGroup = (this.props.resources.usersPerGroup || {}).other || {};
-        let suppressDelete = [];
+        let disableDelete = [];
         if (_.has(usersPerGroup, ['resultInfo', 'facets'])) {
           const groupCounts = _.get(usersPerGroup, ['resultInfo', 'facets', 0, 'facetValues'], []);
-          suppressDelete = _.map(groupCounts, 'value');
+          disableDelete = _.map(groupCounts, 'value');
         }
-        return !!(_.includes(suppressDelete, item.id));
-      },
-      edit: () => false,
+        if (!!(_.includes(disableDelete, item.id))) {
+          return {
+            disabled: !!(_.includes(disableDelete, item.id)),
+            title: 'Patron group cannot be deleted when used by one or more users'
+          };
+        }
+
+        return {};
+      }
     };
 
     const formatter = {
@@ -233,7 +238,7 @@ class PatronGroupsSettings extends React.Component {
             visibleFields={['group', 'desc', 'lastUpdated', 'numberOfUsers']}
             columnMapping={{ desc: 'Description', lastUpdated: 'Last Updated', numberOfUsers: '# of Users' }}
             readOnlyFields={['lastUpdated', 'numberOfUsers']}
-            actionSuppression={suppressor}
+            actionProps={actionProps}
             onCreate={this.onCreateType}
             onUpdate={this.onUpdateType}
             onDelete={this.showConfirm}


### PR DESCRIPTION
PatronGroupSettings should show the Delete button for all patron groups but disable the button for groups that currently have members. 

Currently, the button is simply hidden by using the actionSuppression. [This uses the new actionProps prop added here](https://github.com/folio-org/stripes-components/pull/274).