### PR TITLE
Updated tests to expect a present-but-disabled Delete PG button

### DIFF
--- a/test/ui-testing/patron_group.js
+++ b/test/ui-testing/patron_group.js
@@ -119,7 +119,7 @@ module.exports.test = function foo(uiTestCtx) {
           .then(() => { done(); })
           .catch(done);
       });
-      it(`should not find a "Delete" button for "${gid}" group`, (done) => {
+      it(`should not find an enabled "Delete" button for "${gid}" group`, (done) => {
         nightmare
           .wait(1200)
           .click('#clickable-settings')
@@ -137,8 +137,8 @@ module.exports.test = function foo(uiTestCtx) {
           .wait(222)
           .evaluate((dp) => {
             const cnode = document.querySelector(dp);
-            if (cnode !== null) {
-              throw new Error('Delete button found when patron group is in use!');
+            if (cnode.disabled !== true) {
+              throw new Error('Delete button found and not disabled when patron group is in use!');
             }
           }, deletePath)
           .wait(parseInt(process.env.FOLIO_UI_DEBUG, 10) ? parseInt(config.debug_sleep, 10) : 555) // debugging


### PR DESCRIPTION
PatronGroupSettings were changed to always show the Delete button but leave it disabled. This updates the behaviour expected by the tests. 