### PR TITLE
Deprecate transitionToParams in favor of this.props.mutator.query.update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Remove <Autocomplete> - Use new default `country` field control for address fields. Fixes UIU-298.
 * Change Default display to not return a list of all users. Fixes UIU-399.
 * Update new permission set detail record. Fixes UIU-410 and UIU-404.
+* Deprecate `transitionToParams` in favor of `this.props.mutator.query.update`. Fixes UIU-418.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -60,6 +60,7 @@ class ViewUser extends React.Component {
         POST: PropTypes.func.isRequired,
         DELETE: PropTypes.func.isRequired,
       }),
+      query: PropTypes.object.isRequired,
     }),
     match: PropTypes.shape({
       path: PropTypes.string.isRequired,
@@ -162,7 +163,6 @@ class ViewUser extends React.Component {
   onClickViewOpenLoans(e) {
     if (e) e.preventDefault();
     this.props.mutator.query.update({ layer: 'open-loans' });
-
     this.setState({
       viewOpenLoansMode: true,
     });

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -2,7 +2,6 @@ import { cloneDeep, get, omit, differenceBy } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
-import transitionToParams from '@folio/stripes-components/util/transitionToParams';
 import Pane from '@folio/stripes-components/lib/Pane';
 import PaneMenu from '@folio/stripes-components/lib/PaneMenu';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
@@ -12,7 +11,6 @@ import IfPermission from '@folio/stripes-components/lib/IfPermission';
 import IfInterface from '@folio/stripes-components/lib/IfInterface';
 import { ExpandAllButton } from '@folio/stripes-components/lib/Accordion';
 import IconButton from '@folio/stripes-components/lib/IconButton';
-import removeQueryParam from '@folio/stripes-components/util/removeQueryParam';
 
 import UserForm from './UserForm';
 import LoansHistory from './LoansHistory';
@@ -89,6 +87,7 @@ class ViewUser extends React.Component {
   };
 
   static manifest = Object.freeze({
+    query: {},
     selUser: {
       type: 'okapi',
       path: 'users/:{id}',
@@ -152,8 +151,6 @@ class ViewUser extends React.Component {
     this.onClickViewLoanActionsHistory = this.onClickViewLoanActionsHistory.bind(this);
     this.onClickCloseLoanActionsHistory = this.onClickCloseLoanActionsHistory.bind(this);
     this.onAddressesUpdate = this.onAddressesUpdate.bind(this);
-    this.transitionToParams = transitionToParams.bind(this);
-    this.removeQueryParam = removeQueryParam.bind(this);
     this.handleSectionToggle = this.handleSectionToggle.bind(this);
     this.handleExpandAll = this.handleExpandAll.bind(this);
   }
@@ -164,7 +161,7 @@ class ViewUser extends React.Component {
 
   onClickViewOpenLoans(e) {
     if (e) e.preventDefault();
-    this.transitionToParams({ layer: 'open-loans' });
+    this.props.mutator.query.update({ layer: 'open-loans' });
 
     this.setState({
       viewOpenLoansMode: true,
@@ -173,7 +170,7 @@ class ViewUser extends React.Component {
 
   onClickViewClosedLoans(e) {
     if (e) e.preventDefault();
-    this.transitionToParams({ layer: 'closed-loans' });
+    this.props.mutator.query.update({ layer: 'closed-loans' });
     this.setState({
       viewOpenLoansMode: false,
     });
@@ -181,13 +178,12 @@ class ViewUser extends React.Component {
 
   onClickCloseLoansHistory(e) {
     if (e) e.preventDefault();
-    this.removeQueryParam('layer');
+    this.props.mutator.query.update({ layer: null });
   }
 
   onClickViewLoanActionsHistory(e, selectedLoan) {
     if (e) e.preventDefault();
-    this.transitionToParams({ layer: 'loan', loan: selectedLoan.id });
-
+    this.props.mutator.query.update({ layer: 'loan', loan: selectedLoan.id });
     this.setState({
       selectedLoan,
     });
@@ -196,7 +192,7 @@ class ViewUser extends React.Component {
   onClickCloseLoanActionsHistory(e) {
     if (e) e.preventDefault();
     const layer = this.state.viewOpenLoansMode ? 'open-loans' : 'closed-loans';
-    this.transitionToParams({ layer, loan: null });
+    this.props.mutator.query.update({ layer, loan: null });
     this.setState({
       selectedLoan: {},
     });


### PR DESCRIPTION
Fixes [UIU-418](https://issues.folio.org/browse/UIU-418).

`stripes-components/util/transitionToParams.js` reaches directly to `props.location.query` for the query to update rather than using the anointed resource. (See https://github.com/folio-org/stripes-core/blob/e0d938d97f257f88bbb34481f64ee62408383442/doc/dev-guide.md#url-navigation for details on using an anointed resource to manage the query string, rather than manipulating it directly.)