### PR TITLE
Add timezone, call number, material type, contributors list to loans …

### DIFF
--- a/lib/ClosedLoans/ClosedLoans.js
+++ b/lib/ClosedLoans/ClosedLoans.js
@@ -3,11 +3,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import MultiColumnList from '@folio/stripes-components/lib/MultiColumnList';
-import { formatDate, formatDateTime } from '../../util';
 import Label from '../Label';
 
 const ClosedLoans = (props) => {
-  const { loans } = props;
+  const { loans, stripes } = props;
+  const { formatDate, formatDateTime } = stripes;
 
   const loansFormatter = {
     title: loan => _.get(loan, ['item', 'title'], ''),
@@ -52,6 +52,10 @@ const ClosedLoans = (props) => {
 ClosedLoans.propTypes = {
   onClickViewLoanActionsHistory: PropTypes.func.isRequired,
   loans: PropTypes.arrayOf(PropTypes.object).isRequired,
+  stripes: PropTypes.shape({
+    formatDate: PropTypes.func.isRequired,
+    formatDateTime: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 export default ClosedLoans;

--- a/lib/OpenLoans/OpenLoans.js
+++ b/lib/OpenLoans/OpenLoans.js
@@ -10,7 +10,6 @@ import { UncontrolledDropdown } from '@folio/stripes-components/lib/Dropdown';
 import MenuItem from '@folio/stripes-components/lib/MenuItem';
 import DropdownMenu from '@folio/stripes-components/lib/DropdownMenu';
 import Label from '../Label';
-import { formatDate, formatDateTime } from '../../util';
 import css from './OpenLoans.css';
 
 import withRenew from '../../withRenew';
@@ -35,6 +34,10 @@ class OpenLoans extends React.Component {
     resources: PropTypes.shape({
       query: PropTypes.object,
     }),
+    stripes: PropTypes.shape({
+      formatDate: PropTypes.func.isRequired,
+      formatDateTime: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
   static manifest = {
@@ -49,6 +52,8 @@ class OpenLoans extends React.Component {
     this.toggleAll = this.toggleAll.bind(this);
     this.renewSelected = this.renewSelected.bind(this);
     this.onSort = this.onSort.bind(this);
+    this.formatDate = this.props.stripes.formatDate;
+    this.formatDateTime = this.props.stripes.formatDateTime;
     this.hideLoansModal = this.hideLoansModal.bind(this);
     this.callout = null;
 
@@ -98,8 +103,8 @@ class OpenLoans extends React.Component {
       title: loan => _.get(loan, ['item', 'title'], ''),
       barcode: loan => _.get(loan, ['item', 'barcode'], ''),
       itemStatus: loan => `${_.get(loan, ['item', 'status', 'name'], '')}`,
-      loanDate: loan => formatDate(loan.loanDate),
-      dueDate: loan => formatDateTime(loan.dueDate),
+      loanDate: loan => this.formatDate(loan.loanDate),
+      dueDate: loan => this.formatDateTime(loan.dueDate),
       renewals: loan => loan.renewalCount || 0,
       ' ': loan => this.renderActions(loan),
     };

--- a/lib/ProxyGroup/ProxyEditItem/ProxyEditItem.js
+++ b/lib/ProxyGroup/ProxyEditItem/ProxyEditItem.js
@@ -7,14 +7,14 @@ import Select from '@folio/stripes-components/lib/Select';
 import Datepicker from '@folio/stripes-components/lib/Datepicker';
 import { Field } from 'redux-form';
 
-import { getFullName, formatDateTime } from '../../../util';
+import { getFullName } from '../../../util';
 import css from './ProxyEditItem.css';
 
 const relationStatusValues = ['Active', 'Inactive'];
 const proxySponsorValues = ['Sponsor', 'Proxy'];
 const yesNoValues = ['Yes', 'No'];
 
-const ProxyEditItem = ({ name, record, onDelete }) => {
+const ProxyEditItem = ({ name, record, onDelete, stripes }) => {
   const relationStatusOptions = relationStatusValues.map(val => ({ label: val, value: val, selected: record.meta && record.meta.status === val }));
   const requestForSponsorOptions = yesNoValues.map(val => ({ label: val, value: val, selected: record.meta && record.meta.requestForSponsor === val }));
   const notificationsToOptions = proxySponsorValues.map(val => ({ label: val, value: val, selected: record.meta && record.meta.notificationsTo === val }));
@@ -23,7 +23,7 @@ const ProxyEditItem = ({ name, record, onDelete }) => {
   const proxyLink = (
     <div>
       <Link to={`/users/view/${record.user.id}`}>{getFullName(record.user)}</Link>
-      {record.meta.createdDate && <span className={css.creationLabel}>(Relationship created: {formatDateTime(record.meta.createdDate)})</span>}
+      {record.meta.createdDate && <span className={css.creationLabel}>(Relationship created: {stripes.formatDateTime(record.meta.createdDate)})</span>}
     </div>
   );
 
@@ -85,6 +85,7 @@ ProxyEditItem.propTypes = {
   record: PropTypes.object,
   name: PropTypes.string,
   onDelete: PropTypes.func,
+  stripes: PropTypes.object,
 };
 
 export default ProxyEditItem;

--- a/lib/ProxyGroup/ProxyItem/ProxyItem.js
+++ b/lib/ProxyGroup/ProxyItem/ProxyItem.js
@@ -6,14 +6,14 @@ import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import KeyValue from '@folio/stripes-components/lib/KeyValue';
 import LayoutHeader from '@folio/stripes-components/lib/LayoutHeader';
 
-import { getFullName, formatDateTime } from '../../../util';
+import { getFullName } from '../../../util';
 import css from './ProxyItem.css';
 
-const ProxyItem = ({ record }) => {
+const ProxyItem = ({ record, stripes }) => {
   const link = (
     <div>
       <Link to={`/users/view/${record.user.id}`}>{getFullName(record.user)}</Link>
-      {record.meta.createdDate && <span className={css.creationLabel}>(Relationship created: {formatDateTime(record.meta.createdDate)})</span>}
+      {record.meta.createdDate && <span className={css.creationLabel}>(Relationship created: {stripes.formatDateTime(record.meta.createdDate)})</span>}
     </div>
   );
 
@@ -67,6 +67,7 @@ const ProxyItem = ({ record }) => {
 
 ProxyItem.propTypes = {
   record: PropTypes.object,
+  stripes: PropTypes.object,
 };
 
 export default ProxyItem;

--- a/lib/ViewSections/ExtendedInfo/ExtendedInfo.js
+++ b/lib/ViewSections/ExtendedInfo/ExtendedInfo.js
@@ -5,9 +5,7 @@ import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import KeyValue from '@folio/stripes-components/lib/KeyValue';
 import { Accordion } from '@folio/stripes-components/lib/Accordion';
 
-import { formatDate } from '../../../util';
-
-const ExtendedInfo = ({ expanded, onToggle, accordionId, user }) => (
+const ExtendedInfo = ({ expanded, onToggle, accordionId, user, stripes }) => (
   <Accordion
     open={expanded}
     id={accordionId}
@@ -16,13 +14,13 @@ const ExtendedInfo = ({ expanded, onToggle, accordionId, user }) => (
   >
     <Row>
       <Col xs={3}>
-        <KeyValue label="Date enrolled" value={formatDate(_.get(user, ['enrollmentDate'], ''))} />
+        <KeyValue label="Date enrolled" value={stripes.formatDate(_.get(user, ['enrollmentDate'], ''))} />
       </Col>
       <Col xs={3}>
         <KeyValue label="External system ID" value={_.get(user, ['externalSystemId'], '')} />
       </Col>
       <Col xs={3}>
-        <KeyValue label="Birth date" value={formatDate(_.get(user, ['personal', 'dateOfBirth'], ''))} />
+        <KeyValue label="Birth date" value={stripes.formatDate(_.get(user, ['personal', 'dateOfBirth'], ''))} />
       </Col>
       <Col xs={3}>
         <KeyValue label="FOLIO number" value={_.get(user, ['id'], '')} />
@@ -38,6 +36,8 @@ ExtendedInfo.propTypes = {
   onToggle: PropTypes.func,
   accordionId: PropTypes.string.isRequired,
   user: PropTypes.object,
+  stripes: PropTypes.object,
+
 };
 
 export default ExtendedInfo;

--- a/lib/ViewSections/UserInfo/UserInfo.js
+++ b/lib/ViewSections/UserInfo/UserInfo.js
@@ -6,7 +6,7 @@ import KeyValue from '@folio/stripes-components/lib/KeyValue';
 import MetaSection from '@folio/stripes-components/lib/MetaSection';
 import { Accordion } from '@folio/stripes-components/lib/Accordion';
 
-import { formatDate, getFullName } from '../../../util';
+import { getFullName } from '../../../util';
 
 class UserInfo extends React.Component {
   static manifest = Object.freeze({
@@ -29,6 +29,7 @@ class UserInfo extends React.Component {
     user: PropTypes.object.isRequired,
     patronGroup: PropTypes.object.isRequired,
     settings: PropTypes.arrayOf(PropTypes.object).isRequired,
+    stripes: PropTypes.object.isRequired,
     resources: PropTypes.shape({
       createdBy: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
@@ -37,7 +38,7 @@ class UserInfo extends React.Component {
   };
 
   render() {
-    const { user, patronGroup, settings, resources, expanded, accordionId, onToggle } = this.props;
+    const { user, patronGroup, settings, resources, expanded, accordionId, onToggle, stripes } = this.props;
     const userStatus = (get(user, ['active'], '') ? 'active' : 'inactive');
     const hasProfilePicture = (settings.length && settings[0].value === 'true');
     const createdBy = (resources.createdBy || {}).records || [];
@@ -87,7 +88,7 @@ class UserInfo extends React.Component {
                 <KeyValue label="Status" value={userStatus} />
               </Col>
               <Col xs={3}>
-                <KeyValue label="Expiration date" value={formatDate(get(user, ['expirationDate'], ''))} />
+                <KeyValue label="Expiration date" value={stripes.formatDate(get(user, ['expirationDate'], ''))} />
               </Col>
               <Col xs={3}>
                 <KeyValue label="Username" value={get(user, ['username'], '')} />


### PR DESCRIPTION
…refs UIORG-55 UIU-396

- Reorder the format in which we display the loan details
- Make the title and barcode as links
- Add contributors list, make it a popover if too long
- Handle dates considering timezones in openLoans, closedLoans, proxyItem, extendedInfo, and UserInfo panels/pages