### PR TITLE
Retrieve all patron-groups. Probably. Well, OK only if there are less than 50.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * Enter key should not submit the user edit form. Fixes UIU-394.
 * Upated loans views to match requirements of LIBAPP-233.
 * Externalized All The Strings. Refs UIU-416. 
+* Ugly hack: ask for more facet rows than we likely need. Refs MODUSERS-57.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -19,7 +19,7 @@ class PatronGroupsSettings extends React.Component {
     usersPerGroup: {
       type: 'okapi',
       records: 'users',
-      path: 'users?limit=0&facets=patronGroup',
+      path: 'users?limit=0&facets=patronGroup:50',
     },
   });
 

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -15,6 +15,12 @@ class PatronGroupsSettings extends React.Component {
     }).isRequired,
   };
 
+  // adding the desired-count parameter, :50, to this query is an egregious
+  // hack that willfully and knowingly abuses facets to contort them to 
+  // handle a reporting situation they were simply not designed for. 
+  // this may become inefficient with a large number of users; it will 
+  // certainly be non-functional with a large number (> 50) of groups.
+  // FIXME details at https://issues.folio.org/projects/MODUSERS/issues/MODUSERS-57
   static manifest = Object.freeze({
     usersPerGroup: {
       type: 'okapi',


### PR DESCRIPTION
We are using facets to do some reporting as though `facets=patronGroup` implements the equivalent of an SQL `group by patronGroup`, which it does not. Facets only retrieve the top five rows by default, but here we force it to retrieve the top 50 on the premise that there are not likely to be that many that many patron groups. 

This is a hack, plain and simple. 

Refs [MODUSERS-57](https://issues.folio.org/browse/MODUSERS-57)