### PR TITLE
use code/name mapping in country-list

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "@folio/eslint-config-stripes": "^1.1.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.0.7",
+    "@folio/stripes-components": "^2.0.8",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-smart-components": "^1.4.7",
     "classnames": "^2.2.5",


### PR DESCRIPTION
Update the stripes-components dependency in order to get a list of
countries that maps code to name, rather than name to name, for use in
the country component of the address.

Refs [UIU-416](https://issues.folio.org/browse/UIU-416)