### PR TITLE
make sure stripes is available where necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
   "dependencies": {
     "@folio/stripes-components": "^2.0.7",
     "@folio/stripes-form": "^0.8.2",
-    "@folio/stripes-smart-components": "^1.4.7",
+    "@folio/stripes-smart-components": "^1.4.8",
     "classnames": "^2.2.5",
     "hashcode": "^1.0.3",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Update the dependency on stripes-smart-components. Earlier versions
contain a bug wherein the `stripes` object is not always passed on to the
new-record handler.

Refs [STSMACOM-75](https://issues.folio.org/browse/STSMACOM-75).