### PR TITLE
pass table-header keys, not values to plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * Upated loans views to match requirements of LIBAPP-233.
 * Externalized All The Strings. Refs UIU-416. 
 * Ugly hack: ask for more facet rows than we likely need. Refs MODUSERS-57.
+* Bug fix: translate table-headers fixes proxy lookup. Fixes UIU-452.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/lib/ProxyGroup/ProxyEditList/ProxyEditList.js
+++ b/lib/ProxyGroup/ProxyEditList/ProxyEditList.js
@@ -70,6 +70,13 @@ export default class ProxyEditList extends React.Component {
       />
     ));
 
+    const columnMapping = {
+      name: intl.formatMessage({ id: 'ui-users.information.name' }),
+      patronGroup: intl.formatMessage({ id: 'ui-users.information.patronGroup' }),
+      username: intl.formatMessage({ id: 'ui-users.information.username' }),
+      barcode: intl.formatMessage({ id: 'ui-users.information.barcode' }),
+    };
+
     return (
       <div>
         <Row>
@@ -86,7 +93,8 @@ export default class ProxyEditList extends React.Component {
                 searchLabel="+ New"
                 searchButtonStyle="default"
                 selectUser={user => this.onAdd(user)}
-                visibleColumns={['Name', 'Patron Group', 'Username', 'Barcode']}
+                visibleColumns={['name', 'patronGroup', 'username', 'barcode']}
+                columnMapping={columnMapping}
                 disableRecordCreation={disableRecordCreation}
               >
                 <span>[no user-selection plugin]</span>

--- a/lib/ProxyGroup/ProxyEditList/ProxyEditList.js
+++ b/lib/ProxyGroup/ProxyEditList/ProxyEditList.js
@@ -70,6 +70,7 @@ export default class ProxyEditList extends React.Component {
       />
     ));
 
+    // map column-IDs to table-header-values
     const columnMapping = {
       name: intl.formatMessage({ id: 'ui-users.information.name' }),
       patronGroup: intl.formatMessage({ id: 'ui-users.information.patronGroup' }),


### PR DESCRIPTION
In order to handle internationalized strings in a table-header, we need
to always pass in a map of field-names to header-values rather than
relying on the field-name to match the header-value. The field name,
e.g. username, patronGroup, etc. is never displayed whereas the
header-value, e.g. Username, Patron Group, is.

The header-name may be translated and therefore cannot be used as a key.

Fixes [UIU-452](https://issues.folio.org/browse/UIU-452)