### PR TITLE
UIU-458: Fixed issue with rendering correct material type for open loans

### DIFF
--- a/lib/Loans/OpenLoans/OpenLoans.js
+++ b/lib/Loans/OpenLoans/OpenLoans.js
@@ -17,7 +17,6 @@ import ActionsBar from '../components/ActionsBar';
 
 import withRenew from '../../../withRenew';
 
-
 class OpenLoans extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
@@ -43,12 +42,14 @@ class OpenLoans extends React.Component {
   constructor(props) {
     super(props);
 
-    this.handleOptionsChange = this.handleOptionsChange.bind(this);
     this.onRowClick = this.onRowClick.bind(this);
-    this.toggleAll = this.toggleAll.bind(this);
-    this.renewSelected = this.renewSelected.bind(this);
-    this.getContributorslist = this.getContributorslist.bind(this);
     this.onSort = this.onSort.bind(this);
+    this.getContributorslist = this.getContributorslist.bind(this);
+    this.getLoansFormatter = this.getLoansFormatter.bind(this);
+    this.toggleItem = this.toggleItem.bind(this);
+    this.toggleAll = this.toggleAll.bind(this);
+    this.handleOptionsChange = this.handleOptionsChange.bind(this);
+    this.renewSelected = this.renewSelected.bind(this);
     this.formatDate = this.props.stripes.formatDate;
     this.formatDateTime = this.props.stripes.formatDateTime;
     this.hideLoansModal = this.hideLoansModal.bind(this);
@@ -100,8 +101,7 @@ class OpenLoans extends React.Component {
   }
 
   getContributorslist(loan) {
-    this.loan = loan;
-    const contributors = _.get(this.loan, ['item', 'contributors']);
+    const contributors = _.get(loan, ['item', 'contributors']);
     const contributorsList = [];
     if (typeof contributors !== 'undefined') {
       Object.keys(contributors).forEach(contributor => contributorsList.push(`${contributors[contributor].name}, `));
@@ -125,7 +125,7 @@ class OpenLoans extends React.Component {
         const title = _.get(loan, ['item', 'title'], '');
         if (title) {
           const titleTodisplay = (title.length >= 77) ? `${title.substring(0, 77)}...` : title;
-          return `${titleTodisplay}(${_.get(this.loan, ['item', 'materialType', 'name'])})`;
+          return `${titleTodisplay}(${_.get(loan, ['item', 'materialType', 'name'])})`;
         }
         return '-';
       },


### PR DESCRIPTION
[Fixed UIU-458](https://issues.folio.org/browse/UIU-458)

Incorrect usage of `this.loan` in the file as opposed to just using the `loan` passed into the callback was the cause.