### PR TITLE
UIU-393 Filters switching place

### DIFF
--- a/ViewUser.js
+++ b/ViewUser.js
@@ -105,7 +105,7 @@ class ViewUser extends React.Component {
     },
     patronGroups: {
       type: 'okapi',
-      path: 'groups',
+      path: 'groups?query=cql.allRecords=1 sortby group',
       records: 'usergroups',
     },
     // NOTE: 'indexField', used as a parameter in the userPermissions paths,


### PR DESCRIPTION
Resolves UIU-393

[ViewUser.js](https://github.com/folio-org/ui-users/blob/master/ViewUser.js#L108) was not getting a sorted list of Patron Groups, but [Users.js](https://github.com/folio-org/ui-users/blob/master/Users.js#L119) was. This caused the list of filters to switch places depending on whichever was called most recently. 

Resolved by addling identical sorting to ViewUser.js so both requests for Patron Groups would give identical results.