### PR TITLE
Removed 'Loan Details' from row dropdown in Open Loans

### DIFF
--- a/lib/Loans/OpenLoans/OpenLoans.js
+++ b/lib/Loans/OpenLoans/OpenLoans.js
@@ -298,9 +298,6 @@ class OpenLoans extends React.Component {
           <MenuItem itemMeta={{ loan, action: 'itemDetails' }}>
             <Button buttonStyle="dropdownItem" href={`/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`}><FormattedMessage id="ui-users.itemDetails" /></Button>
           </MenuItem>
-          <MenuItem itemMeta={{ loan, action: 'details' }}>
-            <Button buttonStyle="dropdownItem" href={`/users/view/${loan.userId}?layer=loan&loan=${loan.id}`}><FormattedMessage id="ui-users.loanDetails" /></Button>
-          </MenuItem>
           <MenuItem itemMeta={{ loan, action: 'renew' }}>
             <Button buttonStyle="dropdownItem"><FormattedMessage id="ui-users.renew" /></Button>
           </MenuItem>


### PR DESCRIPTION
Requested by Cate in: https://issues.folio.org/browse/LIBAPP-233