### PR TITLE
UIU-266 Patron Group Limits

### DIFF
--- a/Users.js
+++ b/Users.js
@@ -116,7 +116,7 @@ class Users extends React.Component {
     },
     patronGroups: {
       type: 'okapi',
-      path: 'groups?query=cql.allRecords=1 sortby group',
+      path: 'groups?limit=50&query=cql.allRecords=1 sortby group',
       records: 'usergroups',
     },
     addressTypes: {

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -105,7 +105,7 @@ class ViewUser extends React.Component {
     },
     patronGroups: {
       type: 'okapi',
-      path: 'groups',
+      path: 'groups?query=cql.allRecords=1 sortby group',
       records: 'usergroups',
     },
     // NOTE: 'indexField', used as a parameter in the userPermissions paths,

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -105,7 +105,7 @@ class ViewUser extends React.Component {
     },
     patronGroups: {
       type: 'okapi',
-      path: 'groups?query=cql.allRecords=1 sortby group',
+      path: 'groups?limit=50&query=cql.allRecords=1 sortby group',
       records: 'usergroups',
     },
     // NOTE: 'indexField', used as a parameter in the userPermissions paths,

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -48,7 +48,7 @@ class PatronGroupsSettings extends React.Component {
         // We have to unset the dataKey to prevent the props.resources in
         // <ControlledVocab> from being overwritten by the props.resources here.
         dataKey={undefined}
-        baseUrl="groups"
+        baseUrl="groups?limit=50"
         records="usergroups"
         label={this.props.stripes.intl.formatMessage({ id: 'ui-users.information.patronGroups' })}
         labelSingular={this.props.stripes.intl.formatMessage({ id: 'ui-users.information.patronGroup' })}


### PR DESCRIPTION
Resolves [UIU-266](https://issues.folio.org/browse/UIU-266), depends on #345.

There was still some strange behavior when more than 10 Patron Groups were present. The requested limit is increased to an arbitrarily large number to ensure all Patron Groups are returned.

The limit of 50 was chosen as recommended in [MODUSERS-57](https://issues.folio.org/browse/MODUSERS-57).

This PR is a fast-forward of #345 to prevent merge conflicts.