### PR TITLE
UIU-266 Patron Group Limits

### DIFF
--- a/Users.js
+++ b/Users.js
@@ -116,7 +116,7 @@ class Users extends React.Component {
     },
     patronGroups: {
       type: 'okapi',
-      path: 'groups?query=cql.allRecords=1 sortby group',
+      path: 'groups?limit=50&query=cql.allRecords=1 sortby group',
       records: 'usergroups',
     },
     addressTypes: {

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -105,7 +105,7 @@ class ViewUser extends React.Component {
     },
     patronGroups: {
       type: 'okapi',
-      path: 'groups',
+      path: 'groups?limit=50&query=cql.allRecords=1 sortby group',
       records: 'usergroups',
     },
     // NOTE: 'indexField', used as a parameter in the userPermissions paths,


### PR DESCRIPTION
Resolves [UIU-266](https://issues.folio.org/browse/UIU-266), depends on #345.

There was still some strange behavior when more than 10 Patron Groups were present. The requested limit is increased to an arbitrarily large number to ensure all Patron Groups are returned.

The limit of 50 was chosen as recommended in [MODUSERS-57](https://issues.folio.org/browse/MODUSERS-57).

This PR is a fast-forward of #345 to prevent merge conflicts.