### PR TITLE
Disabeling the status select when user is expired

### DIFF
--- a/lib/EditSections/EditUserInfo/EditUserInfo.js
+++ b/lib/EditSections/EditUserInfo/EditUserInfo.js
@@ -15,6 +15,19 @@ const EditUserInfo = ({ parentResources, initialValues, expanded, onToggle, acco
     { label: intl.formatMessage({ id: 'ui-users.inactive' }), value: false },
   ].map(s => ({ ...s, selected: (initialValues.active === s.value || s.value === true) }));
 
+
+  const isUserExpired = function () {
+    const expirationDate = new Date(initialValues.expirationDate);
+    const now = Date.now();
+    return expirationDate <= now;
+  };
+
+  const isStatusFieldDisabled = function () {
+    let statusFieldDisabled = false;
+    statusFieldDisabled = isUserExpired();
+    return statusFieldDisabled;
+  };
+
   return (
     <Accordion
       label={intl.formatMessage({ id: 'ui-users.information.userInformation' })}
@@ -58,7 +71,13 @@ const EditUserInfo = ({ parentResources, initialValues, expanded, onToggle, acco
                 component={Select}
                 fullWidth
                 dataOptions={statusOptions}
+                disabled={isStatusFieldDisabled()}
               />
+              {isUserExpired() && (
+                <span style={{ 'color': '#900', 'position': 'relative', 'top': '-10px', 'font-size': '0.9em' }}>
+                  {`${intl.formatMessage({ id: 'ui-users.errors.userExpired' })}`}
+                </span>
+              )}
             </Col>
             <Col xs={3}>
               <Field

--- a/translations/en.json
+++ b/translations/en.json
@@ -371,6 +371,7 @@
   "errors.noMatch.oops": "Uh-oh!",
   "errors.noMatch.how": "How did you get to {location}?",
 
+  "errors.userExpired": "User has expired",
   "errors.usernameUnavailable": "This username does not exist",
 
   "hide": "Hide",


### PR DESCRIPTION
Resolves [UIU-235](https://issues.folio.org/browse/UIU-235).

This puts the UI work in place to disable the status select when the user has expired. It also places a error-style message beneath the field to explain the disabled state. This was not done as validation for two reason:

1) The message needs to show up immediately upon form load, and not only at form submit.
2) The presence of the message should not prohibit form submission.
 