### PR TITLE
UIU-468: Stopped filtering backend loans data based on translated values

### DIFF
--- a/LoansHistory.js
+++ b/LoansHistory.js
@@ -64,7 +64,7 @@ class LoansHistory extends React.Component {
 
   render() {
     const { user, patronGroup, openLoans, loansHistory, stripes: { intl } } = this.props;
-    const loanStatus = openLoans ? intl.formatMessage({ id: 'ui-users.loans.open' }) : intl.formatMessage({ id: 'ui-users.loans.closed' });
+    const loanStatus = openLoans ? 'Open' : 'Closed';
     const loans = _.filter(loansHistory, loan => loanStatus === _.get(loan, ['status', 'name']));
     if (!loans) return <div />;
 


### PR DESCRIPTION
The backend data is not being translated currently so it doesn't make sense to check if a loan is "offen" or "abgeschlossen" if the locale is German since the loan object's status will always either be "open" or "closed".

Backend responses will be translated later but it makes sense to have the system be functional for now, esp given the small footprint of this change and the potential for confusion as evidenced by the fact that UIU-468 was opened.