### PR TITLE
IfInterface test should match package.json version. Refs UIU-471

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * Make username and password optional, though mutually dependent. Fixes UIU-389.
 * Handle metadata field case insensitively. Fixes UIU-471.
 * Bah. One case to rule them all. Handles UIU-471 in concert with CIRCSTORE-43.
+* `<IfInterface>` test should match dependency version in `package.json`. Refs UIU-471.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -402,7 +402,7 @@ class ViewUser extends React.Component {
         </IfPermission>
 
         <IfPermission perm="circulation.loans.collection.get">
-          <IfInterface name="circulation" version="2.1">
+          <IfInterface name="circulation" version="3.0">
             <this.connectedUserLoans
               onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
               onClickViewOpenLoans={this.onClickViewOpenLoans}


### PR DESCRIPTION
We made a major-version update to an Okapi dependency in `package.json` but didn't update the `<IfInterface>` test in the codebase. The discrepancy caused loan information to be unavailable in the user profile. 

Refs [UIU-471](https://issues.folio.org/browse/UIU-471)