### PR TITLE
[WIP] Replace ignoreLocalOffset prop

### DIFF
--- a/lib/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/lib/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -59,7 +59,7 @@ class EditExtendedInfo extends React.Component {
                   dateFormat="YYYY-MM-DD"
                   name="personal.dateOfBirth"
                   id="adduser_dateofbirth"
-                  ignoreLocalOffset
+                  timeZone="UTC"
                   backendDateStandard="YYYY-MM-DD"
                 />
               </Col>


### PR DESCRIPTION
## Purpose
See https://github.com/folio-org/stripes-components/pull/349 and https://github.com/folio-org/stripes-core/pull/284 for work with new React Context API and testing `Datepicker`.

## Approach
Instead of expanding the `Datepicker` API, override the `timeZone` delivered by context with the `timeZone` prop.

## TODO
- [ ] Merge https://github.com/folio-org/stripes-components/pull/349
- [ ] Merge https://github.com/folio-org/stripes-core/pull/284
