### PR TITLE
UIU-497: Added ability to change loan due dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * Restore patron-group sort. Fixes UIU-481.
 * "Use new proxyFor schema instead of meta. Fixes UIU-495.
 * Validate proxy relationship status. Fixes UIU-200 and UIU-201.
+* Added ability to change due date of loans in loan listings and individual views. Fixes UIU-497.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/LoanActionsHistory.js
+++ b/LoanActionsHistory.js
@@ -219,6 +219,7 @@ class LoanActionsHistory extends React.Component {
         loans={[this.props.loan]}
         onClose={this.hideChangeDueDateDialog}
         open={this.state.changeDueDateDialogOpen}
+        user={this.props.user}
       />
     );
   }

--- a/LoanActionsHistory.js
+++ b/LoanActionsHistory.js
@@ -18,7 +18,7 @@ import { getFullName } from './util';
 import loanActionMap from './data/loanActionMap';
 import LoanActionsHistoryProxy from './LoanActionsHistoryProxy';
 import withRenew from './withRenew';
-/* eslint-disable react/no-deprecated */
+
 /**
  * Detail view of a user's loan.
  */

--- a/LoanActionsHistory.js
+++ b/LoanActionsHistory.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import Link from 'react-router-dom/Link';
 import PropTypes from 'prop-types';
+import ChangeDueDateDialog from '@folio/stripes-smart-components/lib/ChangeDueDateDialog';
 import Popover from '@folio/stripes-components/lib/Popover';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import Modal from '@folio/stripes-components/lib/Modal';
@@ -17,7 +18,7 @@ import { getFullName } from './util';
 import loanActionMap from './data/loanActionMap';
 import LoanActionsHistoryProxy from './LoanActionsHistoryProxy';
 import withRenew from './withRenew';
-
+/* eslint-disable react/no-deprecated */
 /**
  * Detail view of a user's loan.
  */
@@ -80,10 +81,14 @@ class LoanActionsHistory extends React.Component {
     this.formatDateTime = this.props.stripes.formatDateTime;
     this.hideNonRenewedLoansModal = this.hideNonRenewedLoansModal.bind(this);
     this.showTitle = this.showTitle.bind(this);
+    this.showChangeDueDateDialog = this.showChangeDueDateDialog.bind(this);
+    this.hideChangeDueDateDialog = this.hideChangeDueDateDialog.bind(this);
+
     this.state = {
       loanActionCount: 0,
       nonRenewedLoanItems: [],
-      nonRenewedLoansModalOpen: false
+      nonRenewedLoansModalOpen: false,
+      changeDueDateDialogOpen: false,
     };
   }
 
@@ -144,6 +149,18 @@ class LoanActionsHistory extends React.Component {
     return promise;
   }
 
+  showChangeDueDateDialog() {
+    this.setState({
+      changeDueDateDialogOpen: true,
+    });
+  }
+
+  hideChangeDueDateDialog() {
+    this.setState({
+      changeDueDateDialogOpen: false,
+    });
+  }
+
   getContributorslist(loan) {
     this.loan = loan;
     const contributors = _.get(this.loan, ['item', 'contributors']);
@@ -195,6 +212,17 @@ class LoanActionsHistory extends React.Component {
     this.callout.sendCallout({ message });
   }
 
+  renderChangeDueDateDialog() {
+    return (
+      <ChangeDueDateDialog
+        stripes={this.props.stripes}
+        loans={[this.props.loan]}
+        onClose={this.hideChangeDueDateDialog}
+        open={this.state.changeDueDateDialogOpen}
+      />
+    );
+  }
+
   render() {
     const { onCancel, loan, patronGroup, user, resources: { loanActionsWithUser }, stripes: { intl } } = this.props;
     const { nonRenewedLoanItems } = this.state;
@@ -231,6 +259,9 @@ class LoanActionsHistory extends React.Component {
           <Row>
             <Col>
               <Button buttonStyle="primary" onClick={this.renew}>{this.props.stripes.intl.formatMessage({ id: 'ui-users.renew' })}</Button>
+            </Col>
+            <Col>
+              <Button buttonStyle="primary" onClick={this.showChangeDueDateDialog}>{this.props.stripes.intl.formatMessage({ id: 'stripes-smart-components.cddd.changeDueDate' })}</Button>
             </Col>
           </Row>
           <Row>
@@ -317,6 +348,7 @@ class LoanActionsHistory extends React.Component {
                   </li>))
             }
           </Modal>
+          { this.renderChangeDueDateDialog() }
           <Callout ref={(ref) => { this.callout = ref; }} />
         </Pane>
       </Paneset>

--- a/LoanActionsHistory.js
+++ b/LoanActionsHistory.js
@@ -75,6 +75,7 @@ class LoanActionsHistory extends React.Component {
   constructor(props) {
     super(props);
     this.connectedProxy = props.stripes.connect(LoanActionsHistoryProxy);
+    this.connectedChangeDueDateDialog = props.stripes.connect(ChangeDueDateDialog);
     this.renew = this.renew.bind(this);
     this.getContributorslist = this.getContributorslist.bind(this);
     this.showContributors = this.showContributors.bind(this);
@@ -214,9 +215,9 @@ class LoanActionsHistory extends React.Component {
 
   renderChangeDueDateDialog() {
     return (
-      <ChangeDueDateDialog
+      <this.connectedChangeDueDateDialog
         stripes={this.props.stripes}
-        loans={[this.props.loan]}
+        loanIds={[{ id: this.props.loan.id }]}
         onClose={this.hideChangeDueDateDialog}
         open={this.state.changeDueDateDialogOpen}
         user={this.props.user}

--- a/data/loanActionMap.js
+++ b/data/loanActionMap.js
@@ -5,4 +5,5 @@ export default {
   Operator: 'ui-users.data.loanActionMap.source',
   holdrequested: 'ui-users.data.loanActionMap.holdRequested',
   recallrequested: 'ui-users.data.loanActionMap.recallRequested',
+  dueDateChanged: 'ui-users.data.loanActionMap.dueDateChanged',
 };

--- a/lib/Loans/OpenLoans/OpenLoans.js
+++ b/lib/Loans/OpenLoans/OpenLoans.js
@@ -43,6 +43,9 @@ class OpenLoans extends React.Component {
       query: PropTypes.object,
       itemIds: PropTypes.object,
     }),
+    user: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }).isRequired,
   };
 
   static manifest = Object.freeze({
@@ -626,6 +629,7 @@ class OpenLoans extends React.Component {
         loanPolicies={this.state.loanPolicies}
         onClose={this.hideChangeDueDateDialog}
         open={this.state.changeDueDateDialogOpen}
+        user={this.props.user}
       />
     );
   }

--- a/lib/Loans/OpenLoans/OpenLoans.js
+++ b/lib/Loans/OpenLoans/OpenLoans.js
@@ -11,6 +11,7 @@ import IconButton from '@folio/stripes-components/lib/IconButton';
 import { UncontrolledDropdown } from '@folio/stripes-components/lib/Dropdown';
 import MenuItem from '@folio/stripes-components/lib/MenuItem';
 import DropdownMenu from '@folio/stripes-components/lib/DropdownMenu';
+import ChangeDueDateDialog from '@folio/stripes-smart-components/lib/ChangeDueDateDialog';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import Label from '../../Label';
 import css from './OpenLoans.css';
@@ -91,6 +92,8 @@ class OpenLoans extends React.Component {
     this.formatDateTime = this.props.stripes.formatDateTime;
     this.hideRenewedLoansModal = this.hideRenewedLoansModal.bind(this);
     this.hideNonRenewedLoansModal = this.hideNonRenewedLoansModal.bind(this);
+    this.showChangeDueDateDialog = this.showChangeDueDateDialog.bind(this);
+    this.hideChangeDueDateDialog = this.hideChangeDueDateDialog.bind(this);
     this.getContributorslist = this.getContributorslist.bind(this);
     this.fetchLoanPolicyNames = this.fetchLoanPolicyNames.bind(this);
     this.callout = null;
@@ -137,7 +140,8 @@ class OpenLoans extends React.Component {
       renewedLoansModalOpen: false,
       renewedLoanItems: [],
       nonRenewedLoanItems: [],
-      nonRenewedLoansModalOpen: false
+      nonRenewedLoansModalOpen: false,
+      changeDueDateDialogOpen: false,
     };
   }
 
@@ -427,6 +431,25 @@ class OpenLoans extends React.Component {
     }
   }
 
+  showChangeDueDateDialog() {
+    this.setState({
+      changeDueDateDialogOpen: true,
+    });
+  }
+
+  hideChangeDueDateDialog() {
+    this.setState({
+      changeDueDateDialogOpen: false,
+    });
+  }
+
+  changeDueDate(loan) {
+    this.setState({
+      activeLoan: loan.id,
+      changeDueDateDialogOpen: true,
+    });
+  }
+
   /**
    * change handler for the options-menu prevents the event from bubbling
    * up to the event handler attached to the row.
@@ -477,6 +500,9 @@ class OpenLoans extends React.Component {
           <MenuItem itemMeta={{ loan, action: 'renew' }}>
             <Button buttonStyle="dropdownItem"><FormattedMessage id="ui-users.renew" /></Button>
           </MenuItem>
+          <MenuItem itemMeta={{ loan, action: 'changeDueDate' }}>
+            <Button buttonStyle="dropdownItem"><FormattedMessage id="stripes-smart-components.cddd.changeDueDate" /></Button>
+          </MenuItem>
           <MenuItem itemMeta={{ loan, action: 'showLoanPolicy' }}>
             <Button buttonStyle="dropdownItem" href={`/settings/circulation/loan-policies/${loan.loanPolicyId}`}><FormattedMessage id="ui-users.loans.details.loanPolicy" /></Button>
           </MenuItem>
@@ -493,25 +519,119 @@ class OpenLoans extends React.Component {
   }
 
   renderSubHeader() {
-    const checkedLoans = this.state.checkedLoans;
+    const { formatMessage } = this.props.stripes.intl;
+    const noSelectedLoans = _.size(this.state.checkedLoans) === 0;
 
-    let stringToolTip = this.props.stripes.intl.formatMessage({ id: 'ui-users.renew' });
-    const isDisabled = _.size(checkedLoans) === 0;
-
-    if (isDisabled) {
-      stringToolTip = this.props.stripes.intl.formatMessage({ id: 'ui-users.renew.toolTip' });
-    }
+    const bulkActionsTooltip = formatMessage({ id: 'ui-users.bulkActions.tooltip' });
+    const renewString = formatMessage({ id: 'ui-users.renew' });
+    const changeDueDateString = formatMessage({ id: 'stripes-smart-components.cddd.changeDueDate' });
 
     return (
       <ActionsBar
-        contentStart={<Label>{this.props.stripes.intl.formatMessage({ id: 'ui-users.resultCount' }, { count: this.props.loans.length })}</Label>}
-        contentEnd={<Button marginBottom0 id="renew-all" disabled={isDisabled} title={stringToolTip} onClick={this.renewSelected}><FormattedMessage id="ui-users.renew" /></Button>}
+        contentStart={<Label>{formatMessage({ id: 'ui-users.resultCount' }, { count: this.props.loans.length })}</Label>}
+        contentEnd={
+          <span>
+            <Button
+              marginBottom0
+              id="change-due-date-all"
+              disabled={noSelectedLoans}
+              title={noSelectedLoans ? bulkActionsTooltip : changeDueDateString}
+              onClick={this.showChangeDueDateDialog}
+            >{changeDueDateString}
+            </Button>
+            <Button
+              marginBottom0
+              id="renew-all"
+              disabled={noSelectedLoans}
+              title={noSelectedLoans ? bulkActionsTooltip : renewString}
+              onClick={this.renewSelected}
+            >{renewString}
+            </Button>
+          </span>
+        }
+      />
+    );
+  }
+
+  renderRenewedLoansModal() {
+    const { renewedLoanItems } = this.state;
+
+    return (
+      <Modal
+        dismissible
+        closeOnBackgroundClick
+        onClose={this.hideRenewedLoansModal}
+        open={this.state.renewedLoansModalOpen}
+        label={this.props.stripes.intl.formatMessage({ id: 'ui-users.loans.items.renewed.label' })}
+      >
+        <p>
+          <FormattedMessage
+            id="ui-users.loans.items.renewed.subHeading"
+            values={{
+              strongCount: <strong>{renewedLoanItems.length}</strong>,
+              count: renewedLoanItems.length,
+              verb: <strong>{this.props.stripes.intl.formatMessage({ id: 'ui-users.loans.item.renewed.callout.verb' })}</strong>,
+            }}
+          />
+        </p>
+        {
+            renewedLoanItems.map((loanItem, index) => (
+              <li key={index}>
+                <span>{loanItem.item.title}</span>
+              </li>))
+        }
+      </Modal>
+    );
+  }
+
+  renderNonRenewedLoansModal() {
+    const { nonRenewedLoanItems } = this.state;
+
+    return (
+      <Modal
+        dismissible
+        closeOnBackgroundClick
+        onClose={this.hideNonRenewedLoansModal}
+        open={this.state.nonRenewedLoansModalOpen}
+        label={this.props.stripes.intl.formatMessage({ id: 'ui-users.loans.items.nonRenewed.label' })}
+      >
+        <p>
+          <FormattedMessage
+            id="ui-users.loans.items.nonRenewed.subHeading"
+            values={{
+              strongCount: <strong>{nonRenewedLoanItems.length}</strong>,
+              count: nonRenewedLoanItems.length,
+              verb: <strong>{this.props.stripes.intl.formatMessage({ id: 'ui-users.loans.item.nonRenewed.callout.verb' })}</strong>,
+            }}
+          />
+        </p>
+        {
+          nonRenewedLoanItems.map((loanItem, index) => (
+            <li key={index}>
+              <span>{loanItem.item.title}</span>
+            </li>))
+        }
+      </Modal>
+    );
+  }
+
+  renderChangeDueDateDialog() {
+    const { loans } = this.props;
+    const { activeLoan, checkedLoans } = this.state;
+
+    return (
+      <ChangeDueDateDialog
+        stripes={this.props.stripes}
+        loans={loans.filter(loan => checkedLoans[loan.id] || activeLoan === loan.id)}
+        loanPolicies={this.state.loanPolicies}
+        onClose={this.hideChangeDueDateDialog}
+        open={this.state.changeDueDateDialogOpen}
       />
     );
   }
 
   render() {
-    const { sortOrder, sortDirection, allChecked, renewedLoanItems, nonRenewedLoanItems, loanPolicies } = this.state;
+    const { sortOrder, sortDirection, allChecked, loanPolicies } = this.state;
 
     if (_.isEmpty(loanPolicies)) {
       return <div />;
@@ -534,34 +654,6 @@ class OpenLoans extends React.Component {
 
     const loans = _.orderBy(this.props.loans,
       [this.sortMap[sortOrder[0]], this.sortMap[sortOrder[1]]], sortDirection);
-    const subHeading = (
-      <p>
-        <FormattedMessage
-          id="ui-users.loans.items.renewed.subHeading"
-          values={{
-            strongCount: <strong>{renewedLoanItems.length}</strong>,
-            count: renewedLoanItems.length,
-            verb: <strong>{this.props.stripes.intl.formatMessage({ id: 'ui-users.loans.item.renewed.callout.verb' })}</strong>,
-          }}
-        />
-      </p>
-    );
-
-    const failedRenewalsSubHeading = (
-      <p>
-        <FormattedMessage
-          id="ui-users.loans.items.nonRenewed.subHeading"
-          values={{
-            strongCount: <strong>{nonRenewedLoanItems.length}</strong>,
-            count: nonRenewedLoanItems.length,
-            verb: <strong>{this.props.stripes.intl.formatMessage({ id: 'ui-users.loans.item.nonRenewed.callout.verb' })}</strong>,
-          }}
-        />
-      </p>
-    );
-
-    const label = this.props.stripes.intl.formatMessage({ id: 'ui-users.loans.items.renewed.label' });
-    const nonRenewedLabel = this.props.stripes.intl.formatMessage({ id: 'ui-users.loans.items.nonRenewed.label' });
 
     return (
       <div className={css.root}>
@@ -580,24 +672,9 @@ class OpenLoans extends React.Component {
           sortDirection={`${sortDirection[0]}ending`}
           contentData={loans}
         />
-        <Modal dismissible closeOnBackgroundClick onClose={this.hideRenewedLoansModal} open={this.state.renewedLoansModalOpen} label={label}>
-          {subHeading}
-          {
-              renewedLoanItems.map((loanItem, index) => (
-                <li key={index}>
-                  <span>{loanItem.item.title}</span>
-                </li>))
-          }
-        </Modal>
-        <Modal dismissible closeOnBackgroundClick onClose={this.hideNonRenewedLoansModal} open={this.state.nonRenewedLoansModalOpen} label={nonRenewedLabel}>
-          {failedRenewalsSubHeading}
-          {
-              nonRenewedLoanItems.map((loanItem, index) => (
-                <li key={index}>
-                  <span>{loanItem.item.title}</span>
-                </li>))
-          }
-        </Modal>
+        { this.renderRenewedLoansModal() }
+        { this.renderNonRenewedLoansModal() }
+        { this.renderChangeDueDateDialog() }
         <Callout ref={(ref) => { this.callout = ref; }} />
       </div>
     );

--- a/lib/Loans/OpenLoans/OpenLoans.js
+++ b/lib/Loans/OpenLoans/OpenLoans.js
@@ -103,6 +103,8 @@ class OpenLoans extends React.Component {
 
     const { stripes } = props;
 
+    this.connectedChangeDueDateDialog = stripes.connect(ChangeDueDateDialog);
+
     this.sortMap = {
       [stripes.intl.formatMessage({ id: 'ui-users.loans.columns.title' })]: loan => _.get(loan, ['item', 'title']),
       [stripes.intl.formatMessage({ id: 'ui-users.loans.columns.barcode' })]: loan => _.get(loan, ['item', 'barcode']),
@@ -139,6 +141,7 @@ class OpenLoans extends React.Component {
         stripes.intl.formatMessage({ id: 'ui-users.loans.columns.loanDate' }),
       ],
       sortDirection: ['asc', 'asc'],
+      activeLoan: undefined,
       loans: [],
       renewedLoansModalOpen: false,
       renewedLoanItems: [],
@@ -443,6 +446,7 @@ class OpenLoans extends React.Component {
   hideChangeDueDateDialog() {
     this.setState({
       changeDueDateDialogOpen: false,
+      activeLoan: undefined,
     });
   }
 
@@ -622,11 +626,17 @@ class OpenLoans extends React.Component {
     const { loans } = this.props;
     const { activeLoan, checkedLoans } = this.state;
 
+    let loanIds;
+    if (activeLoan) { // Only changing one due date.
+      loanIds = loans.filter(loan => activeLoan === loan.id);
+    } else { // Bulk-changing due dates.
+      loanIds = loans.filter(loan => checkedLoans[loan.id]);
+    }
+
     return (
-      <ChangeDueDateDialog
+      <this.connectedChangeDueDateDialog
         stripes={this.props.stripes}
-        loans={loans.filter(loan => checkedLoans[loan.id] || activeLoan === loan.id)}
-        loanPolicies={this.state.loanPolicies}
+        loanIds={loanIds}
         onClose={this.hideChangeDueDateDialog}
         open={this.state.changeDueDateDialogOpen}
         user={this.props.user}

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "@folio/react-intl-safe-html": "^1.0.10005",
     "@folio/stripes-components": "^2.0.8",
     "@folio/stripes-form": "^0.8.2",
-    "@folio/stripes-smart-components": "^1.4.11",
+    "@folio/stripes-smart-components": "^1.4.15",
     "classnames": "^2.2.5",
     "hashcode": "^1.0.3",
     "lodash": "^4.17.4",

--- a/translations/en.json
+++ b/translations/en.json
@@ -261,6 +261,7 @@
   "data.loanActionMap.source": "Source",
   "data.loanActionMap.holdRequested": "Hold requested",
   "data.loanActionMap.recallRequested": "Recall requested",
+  "data.loanActionMap.dueDateChanged": "Due date changed",
 
   "loans.title": "Loans",
   "loans.open": "Open",
@@ -411,6 +412,6 @@
 
   "itemDetails": "Item Details",
   "renew": "Renew",
-  "renew.toolTip": "Multiple loans can be processed at the same time. Please select loans first.",
+  "bulkActions.tooltip": "Multiple loans can be processed at the same time. Please select loans first.",
   "loanNotRenewed": "Loan not renewed"
 }


### PR DESCRIPTION
[Per UIU-497](https://issues.folio.org/browse/UIU-497), this adds the ability for users to change the due date of an existing loan without executing a renewal. This uses the new `ChangeDueDateDialog` smart component [introduced here](https://github.com/folio-org/stripes-smart-components/pull/179).

This functionality is available via a user's open loans page, or via the loan details page.

While mucking around in the OpenLoans component, I cleaned up the modal rendering a tad as well.

A subsequent PR that adds this functionality to the Check Out page is coming.