### PR TITLE
Use `cql.allIndexes=1` when no query is supplied, instead of a wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * Validate proxy relationship status. Fixes UIU-200 and UIU-201.
 * Added ability to change due date of loans in loan listings and individual views. Fixes UIU-497.
 * Update paths for relocated components. Refs STCOM-277.
+* Use `cql.allIndexes=1` when no query is supplied, instead of a wildcard. Fixes UIU-541.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/Users.js
+++ b/Users.js
@@ -87,7 +87,7 @@ class Users extends React.Component {
       GET: {
         params: {
           query: makeQueryFunction(
-            'username=*',
+            'cql.allRecords=1',
             '(username="%{query.query}*" or personal.firstName="%{query.query}*" or personal.lastName="%{query.query}*" or personal.email="%{query.query}*" or barcode="%{query.query}*" or id="%{query.query}*" or externalSystemId="%{query.query}*")',
             {
               'Active': 'active',


### PR DESCRIPTION
Fixes UIU-541.