### PR TITLE
STCOM-305: Use generic ViewMetaData component

### DIFF
--- a/lib/ViewSections/UserInfo/UserInfo.js
+++ b/lib/ViewSections/UserInfo/UserInfo.js
@@ -3,25 +3,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import KeyValue from '@folio/stripes-components/lib/KeyValue';
-import MetaSection from '@folio/stripes-components/lib/MetaSection';
 import { Accordion } from '@folio/stripes-components/lib/Accordion';
-
-import { getFullName } from '../../../util';
+import ViewMetaData from '@folio/stripes-smart-components/lib/ViewMetaData';
 
 class UserInfo extends React.Component {
-  static manifest = Object.freeze({
-    createdBy: {
-      type: 'okapi',
-      records: 'users',
-      path: 'users?query=(id==!{user.metadata.createdByUserId})',
-    },
-    updatedBy: {
-      type: 'okapi',
-      records: 'users',
-      path: 'users?query=(id==!{user.metadata.updatedByUserId})',
-    },
-  });
-
   static propTypes = {
     expanded: PropTypes.bool,
     stripes: PropTypes.object.isRequired,
@@ -30,19 +15,18 @@ class UserInfo extends React.Component {
     user: PropTypes.object.isRequired,
     patronGroup: PropTypes.object.isRequired,
     settings: PropTypes.arrayOf(PropTypes.object).isRequired,
-    resources: PropTypes.shape({
-      createdBy: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object),
-      }),
-    }),
   };
 
+  constructor(props) {
+    super(props);
+
+    this.cViewMetaData = props.stripes.connect(ViewMetaData);
+  }
+
   render() {
-    const { user, patronGroup, settings, resources, expanded, accordionId, onToggle, stripes: { intl }, stripes } = this.props;
+    const { user, patronGroup, settings, expanded, accordionId, onToggle, stripes: { intl }, stripes } = this.props;
     const userStatus = (get(user, ['active'], '') ? 'active' : 'inactive');
     const hasProfilePicture = (settings.length && settings[0].value === 'true');
-    const createdBy = (resources.createdBy || {}).records || [];
-    const updatedBy = (resources.updatedBy || {}).records || [];
 
     return (
       <Accordion
@@ -53,14 +37,7 @@ class UserInfo extends React.Component {
       >
         <Row>
           <Col xs={12}>
-            <MetaSection
-              id="userInfoRecordMeta"
-              contentId="userInfoRecordMetaContent"
-              lastUpdatedDate={(user.metadata && user.metadata.updatedDate) || ''}
-              createdDate={(user.metadata && user.metadata.createdDate) || ''}
-              lastUpdatedBy={getFullName(updatedBy[0])}
-              createdBy={getFullName(createdBy[0])}
-            />
+            <this.cViewMetaData metadata={user.metadata} />
           </Col>
         </Row>
         <Row>

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "@folio/react-intl-safe-html": "^1.0.10005",
     "@folio/stripes-components": "^2.1.5",
     "@folio/stripes-form": "^0.8.2",
-    "@folio/stripes-smart-components": "^1.4.15",
+    "@folio/stripes-smart-components": "^1.4.19",
     "classnames": "^2.2.5",
     "hashcode": "^1.0.3",
     "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
   },
   "dependencies": {
     "@folio/react-intl-safe-html": "^1.0.10005",
-    "@folio/stripes-components": "^2.0.8",
+    "@folio/stripes-components": "^2.1.5",
     "@folio/stripes-form": "^0.8.2",
     "@folio/stripes-smart-components": "^1.4.15",
     "classnames": "^2.2.5",


### PR DESCRIPTION
There's no need to maintain a separate component to show metadata, so we're switching to the generic one as it gains more functionality as of folio-org/stripes-smart-components#207.