### PR TITLE
UIU-558: Split out loan history fetch to avoid permission errors

### DIFF
--- a/LoansHistory.js
+++ b/LoansHistory.js
@@ -17,6 +17,14 @@ import css from './LoansHistory.css';
  * the loan's item-record.
  */
 class LoansHistory extends React.Component {
+  static manifest = {
+    loansHistory: {
+      type: 'okapi',
+      records: 'loans',
+      path: 'circulation/loans?query=(userId=:{id}) sortby id&limit=100',
+    },
+  };
+
   static propTypes = {
     stripes: PropTypes.shape({
       locale: PropTypes.string.isRequired,
@@ -29,7 +37,11 @@ class LoansHistory extends React.Component {
     onClickViewClosedLoans: PropTypes.func.isRequired,
     user: PropTypes.object.isRequired,
     patronGroup: PropTypes.object.isRequired,
-    loansHistory: PropTypes.arrayOf(PropTypes.object).isRequired,
+    resources: PropTypes.shape({
+      loansHistory: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
+    })
   };
 
   constructor(props) {
@@ -63,9 +75,12 @@ class LoansHistory extends React.Component {
   }
 
   render() {
-    const { user, patronGroup, openLoans, loansHistory, stripes: { intl } } = this.props;
+    const { user, patronGroup, openLoans, resources, stripes: { intl } } = this.props;
     const loanStatus = openLoans ? 'Open' : 'Closed';
-    const loans = _.filter(loansHistory, loan => loanStatus === _.get(loan, ['status', 'name']));
+    const loans = _.filter(
+      _.get(resources, ['loansHistory', 'records'], []),
+      loan => loanStatus === _.get(loan, ['status', 'name'])
+    );
     if (!loans) return <div />;
 
     return (

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -41,11 +41,6 @@ class ViewUser extends React.Component {
       path: 'users/:{id}',
       clear: false,
     },
-    loansHistory: {
-      type: 'okapi',
-      records: 'loans',
-      path: 'circulation/loans?query=(userId=:{id}) sortby id&limit=100',
-    },
     patronGroups: {
       type: 'okapi',
       path: 'groups',
@@ -98,9 +93,6 @@ class ViewUser extends React.Component {
         records: PropTypes.arrayOf(PropTypes.object),
       }),
       settings: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object),
-      }),
-      loansHistory: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
       }),
     }),
@@ -367,7 +359,6 @@ class ViewUser extends React.Component {
     const patronGroups = (resources.patronGroups || {}).records || [];
     const permissions = (resources.permissions || {}).records || [];
     const settings = (resources.settings || {}).records || [];
-    const loans = (resources.loansHistory || {}).records || [];
     const sponsors = this.props.getSponsors();
     const proxies = this.props.getProxies();
     const formatMsg = stripes.intl.formatMessage;
@@ -410,7 +401,6 @@ class ViewUser extends React.Component {
 
     const loansHistory = (<this.connectedLoansHistory
       user={user}
-      loansHistory={loans}
       patronGroup={patronGroup}
       stripes={stripes}
       history={this.props.history}
@@ -513,9 +503,11 @@ class ViewUser extends React.Component {
           />
         </Layer>
 
-        <Layer isOpen={query.layer ? query.layer === 'open-loans' || query.layer === 'closed-loans' : false} contentLabel={formatMsg({ id: 'ui-users.loans.title' })}>
-          {loansHistory}
-        </Layer>
+        <IfPermission perm="circulation.loans.collection.get">
+          <Layer isOpen={query.layer ? query.layer === 'open-loans' || query.layer === 'closed-loans' : false} contentLabel={formatMsg({ id: 'ui-users.loans.title' })}>
+            {loansHistory}
+          </Layer>
+        </IfPermission>
         <Layer isOpen={query.layer ? query.layer === 'loan' : false} contentLabel={formatMsg({ id: 'ui-users.loanActionsHistory' })}>
           {loanDetails}
         </Layer>

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
           "users.collection.get",
           "users.item.get",
           "usergroups.collection.get",
-          "login.item.get"
+          "login.item.get",
+          "configuration.entries.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
`LoansHistory` was already being `connect()`ed so rather than taking the `loansHistory` records from it's parent (ViewUser), it now fetches `/circulation/loans` itself so that the fetch can be avoided via `IfPermission` if the logged-in user doesn't have permission to look at loan history.

Also, the decision of whether or not to render the profile photo relies on a check of `/configurations/entries` so I added the permission required to fetch that endpoint to the `ui-users.view` permission set.