### PR TITLE
pass id prop to ConfirmationModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * Removed "Accrue-fees-to" functionality for proxy/sponsors
 * Adjust renew error messages. Fixes UIU-552.
 * Lower-case search terms AND permission names when searching. Refs UIORG-76.
+* Provide an id prop to `<ConfirmationModal>` to avoid it autogenerating one for us. Refs STCOM-317.
 
 ## [2.12.0](https://github.com/folio-org/ui-users/tree/v2.12.0) (2017-11-28)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.12.0)

--- a/lib/ProxyGroup/ProxyEditList/ProxyEditList.js
+++ b/lib/ProxyGroup/ProxyEditList/ProxyEditList.js
@@ -65,6 +65,7 @@ export default class ProxyEditList extends React.Component {
 
     return (
       <ConfirmationModal
+        id={`delete${name}-confirmation`}
         open={confirmDelete}
         heading={heading}
         message={message}

--- a/package.json
+++ b/package.json
@@ -419,7 +419,7 @@
     "@folio/react-intl-safe-html": "^1.0.10005",
     "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-form": "^0.8.2",
-    "@folio/stripes-smart-components": "^1.4.19",
+    "@folio/stripes-smart-components": "^1.4.23",
     "classnames": "^2.2.5",
     "hashcode": "^1.0.3",
     "lodash": "^4.17.4",

--- a/test/ui-testing/new_proxy.js
+++ b/test/ui-testing/new_proxy.js
@@ -74,26 +74,30 @@ module.exports.test = function foo(uiTestCtx) {
 
       it('should delete a sponsor of user 2', (done) => {
         nightmare
-          /* .wait(4444)
-          .evaluate(() => {
-            document.querySelector('#input-user-search').value = '';
-          }) */
-          .wait('#users-module-display > div > section:nth-child(2) > div > button')
-          .click('#users-module-display > div > section:nth-child(2) > div > button')
           .wait(2222)
+          // put some junk in the search field to get the reset button
+          // so we can click it and be sure the field is clear before
+          // entering new data.
+          .type('#input-user-search', 'asdf')
+          .wait('#clickable-reset-all')
+          .click('#clickable-reset-all')
+          .wait(222)
           .type('#input-user-search', userIds[1].barcode)
           .wait(`#list-users div[role="listitem"] > a > div[title="${userIds[1].barcode}"]`)
+          .wait(222)
           .click(`#list-users div[role="listitem"] > a > div[title="${userIds[1].barcode}"]`)
           .wait(222)
+          .wait('#accordion-toggle-button-proxySection')
+          .wait('#clickable-edituser')
           .click('#clickable-edituser')
           .wait('#accordion-toggle-button-proxy')
           .click('#accordion-toggle-button-proxy')
           .wait(`#proxy a[href*="${userIds[0].uuid}"]`)
           .xclick(`id("proxy")//a[contains(@href, "${userIds[0].uuid}")]/../../../..//button`)
           .wait(2111)
-          .wait('#clickable-deleteproxy-confirmation-confirm')
+          .wait('#clickable-deleteproxies-confirmation-confirm')
           .wait(2111)
-          .click('#clickable-deleteproxy-confirmation-confirm')
+          .click('#clickable-deleteproxies-confirmation-confirm')
           .wait('#clickable-updateuser')
           .click('#clickable-updateuser')
           .wait(1111)


### PR DESCRIPTION
Generation of HTML element-IDs in `<ConfirmationModal>` changed in
https://github.com/folio-org/stripes-components/commit/ce3ba8c996463a389ae3c3aeb36069d9a785ed69
and that broke a bunch of tests that relied on the old style of element
IDs. Happily, we can restore this behavior by passing in an ID prop that
matches the old format.

This necessitated some slight rewriting of the proxy-deletion test which
previously relied on the value of a translated field to generate the
HTML element ID for the confirmation button. In order to avoid that, the
value passed into the ConfirmationModal changed from "deletesponsor" to
"deletesponsors" and from "deleteproxy" to "deleteproxies".

Refs [STCOM-317](https://issues.folio.org/browse/STCOM-317)