### PR TITLE
pass id prop to ConfirmationModal

### DIFF
--- a/settings/permissions/PermissionSetForm.js
+++ b/settings/permissions/PermissionSetForm.js
@@ -190,6 +190,7 @@ class PermissionSetForm extends React.Component {
               </Row>
             </Accordion>
             <ConfirmationModal
+              id="deletepermissionset-confirmation"
               open={confirmDelete}
               heading={intl.formatMessage({ id: 'ui-users.permissions.deletePermissionSet' })}
               message={confirmationMessage}


### PR DESCRIPTION
Generation of HTML element-IDs in `<ConfirmationModal>` changed in
https://github.com/folio-org/stripes-components/commit/ce3ba8c996463a389ae3c3aeb36069d9a785ed69
and that broke a bunch of tests that relied on the old style of element
IDs. Happily, we can restore this behavior by passing in an ID prop that
matches the old format.

This necessitated some slight rewriting of the proxy-deletion test which
previously relied on the value of a translated field to generate the
HTML element ID for the confirmation button. In order to avoid that, the
value passed into the ConfirmationModal changed from "deletesponsor" to
"deletesponsors" and from "deleteproxy" to "deleteproxies".

Refs [STCOM-317](https://issues.folio.org/browse/STCOM-317)