### PR TITLE
Test Settings Perms: Added a wait() to let network settle as a hack

### DIFF
--- a/test/ui-testing/new_permission_set.js
+++ b/test/ui-testing/new_permission_set.js
@@ -36,6 +36,7 @@ module.exports.test = function foo(uiTestCtx) {
           .wait('button[title^="Add "]')
           .click('button[title^="Add "]')
           .wait('#input-permission-title')
+          .wait(5000) // FIXME: waiting for all the /perms endpoints to return
           .insert('#input-permission-title', displayName)
           .insert('#input-permission-description', description)
           .click('#clickable-add-permission')


### PR DESCRIPTION
Trying to get tests passing again. We need a better way of:

- letting the network settle, or
- figuring out why all our components are getting clobbered and rebuilt.