### PR TITLE
Test New Perms: Added waitUntilNetworkIdle before deletion check

### DIFF
--- a/test/ui-testing/new_permission_set.js
+++ b/test/ui-testing/new_permission_set.js
@@ -87,7 +87,7 @@ module.exports.test = function foo(uiTestCtx) {
           .click('a[href^="/settings/users/groups"]')
           .wait('a[href="/settings/users/perms"]')
           .click('a[href="/settings/users/perms"]')
-          .wait(222)
+          .waitUntilNetworkIdle(1000)
           .evaluate((euuid) => {
             const element = document.querySelector(`a[href*="${euuid}"]`);
             if (element) {


### PR DESCRIPTION
The deletion of the permission set is not instantaneous but is only reflected in the UI once the `DELETE` call returns successfully. Frequently, the subsequent `evaluate()` call would fire before the `DELETE` call returned, erroneously indicating a failed deletion.