### PR TITLE
Test New Perm Set: Let deletion settle and log uuid

### DIFF
--- a/test/ui-testing/new_permission_set.js
+++ b/test/ui-testing/new_permission_set.js
@@ -72,12 +72,13 @@ module.exports.test = function foo(uiTestCtx) {
           .click('#clickable-delete-set')
           .wait('#clickable-deletepermissionset-confirmation-confirm')
           .click('#clickable-deletepermissionset-confirmation-confirm')
+          .waitUntilNetworkIdle(500)
           .url()
           .then((result) => {
             done();
             uuid = result;
             uuid = uuid.replace(/^.+\/([^?]+).*/, '$1');
-            // console.log(`          ID of deleted permission set: ${uuid}`);
+            console.log(`          ID of deleted permission set: ${uuid}`);
           })
           .catch(done);
       });


### PR DESCRIPTION
- Wait for the deletion request to settle before ending the test.
- Added back the logging of the UUID of the permission set for further debugging in case we need it.