### PR TITLE
UIU-585: Updated required interfaces

### DIFF
--- a/ViewUser.js
+++ b/ViewUser.js
@@ -543,15 +543,17 @@ class ViewUser extends React.Component {
 
         <IfPermission perm="circulation.loans.collection.get">
           <IfInterface name="circulation" version="3.0">
-            <this.connectedUserLoans
-              onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
-              onClickViewOpenLoans={this.onClickViewOpenLoans}
-              onClickViewClosedLoans={this.onClickViewClosedLoans}
-              expanded={this.state.sections.loansSection}
-              onToggle={this.handleSectionToggle}
-              accordionId="loansSection"
-              {...this.props}
-            />
+            <IfInterface name="loan-policy-storage" version="1.0">
+              <this.connectedUserLoans
+                onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
+                onClickViewOpenLoans={this.onClickViewOpenLoans}
+                onClickViewClosedLoans={this.onClickViewClosedLoans}
+                expanded={this.state.sections.loansSection}
+                onToggle={this.handleSectionToggle}
+                accordionId="loansSection"
+                {...this.props}
+              />
+            </IfInterface>
           </IfInterface>
         </IfPermission>
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     ],
     "okapiInterfaces": {
       "users": "15.0",
+      "configuration": "2.0",
       "circulation": "3.0",
       "permissions": "5.0",
+      "loan-policy-storage": "1.0",
       "loan-storage": "4.0",
       "login": "4.0",
       "feesfines": "14.0"


### PR DESCRIPTION
[UIU-585](https://issues.folio.org/browse/UIU-585): We're using `configuration` to get information about whether to show profile pictures.

While I was in the code I also noticed we weren't announcing our dependency on the interface for loan-policy-storage that we use to view a users loans and change their due date and renew them. So I included that in the `package.json` and wrapped the affected components in an `IfInterface` as well.