### PR TITLE
Change loansHistory params query. Fixes UIU-602

### DIFF
--- a/LoansHistory.js
+++ b/LoansHistory.js
@@ -17,13 +17,17 @@ import css from './LoansHistory.css';
  * the loan's item-record.
  */
 class LoansHistory extends React.Component {
-  static manifest = {
+  static manifest = Object.freeze({
     loansHistory: {
       type: 'okapi',
+      path: 'circulation/loans',
       records: 'loans',
-      path: 'circulation/loans?query=(userId=:{id}) sortby id&limit=100',
+      params: {
+        query: '(userId=!{user.id}) sortby id',
+        limit: '100',
+      },
     },
-  };
+  });
 
   static propTypes = {
     stripes: PropTypes.shape({


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-602

This PR fixes the issue related to refreshing the `loanHistory` resource after mutation (renew).

It looks like what was happening here is that the string template `:{id}` (extracting data defined by react-router) was never executed. I assume this was due to a fact that `LoansHistory` has no association with the router.

Since we are already passing `user` as a prop the `!{user.id}` template works just fine.

The interesting fact here is that the `loansHistory` resource was actually present (the data was loaded) when the `LoansHistory` component got connected and mounted. The resource data was coming from:

https://github.com/folio-org/ui-users/blob/master/lib/ViewSections/UserLoans/UserLoans.js#L25

Since the resource names match.