### PR TITLE
avoid validation NPE

### DIFF
--- a/settings/FeeFinesTable/FeeFines.js
+++ b/settings/FeeFinesTable/FeeFines.js
@@ -32,7 +32,8 @@ function validate(type, props) {
 
     const exist = includes(allfeefines.filter(f => f.id !== item.id), item.feeFineType, 'feeFineType', 'ownerId') || '';
     const owner = includes(owners, exist, 'id', 'owner');
-    const shared = owners.find(o => o.owner === 'Shared').id || '';
+    const sharedOwner = owners.find(o => o.owner === 'Shared');
+    const shared = sharedOwner ? sharedOwner.id : '';
     if (exist === ownerId) {
       errors.items[i].feeFineType = props.stripes.intl.formatMessage({ id: 'ui-users.feefines.errors.exist' });
     } else if (owner !== undefined && (ownerId === shared || owner === 'Shared')) {


### PR DESCRIPTION
Validate was expecting to retrieve an item from a list and then retrieve
a property from that item but not considering the possibility that the
list was empty. This change avoids the null pointer exception in order to
keep the UI from becoming corrupted but does address the underlying
cause. Consequently, validation when the list contains no items always
fails, but at least it doesn't explode when it fails.