### PR TITLE
Clean defaultServicePointId when no service points are present. Part of STCOR-237

### DIFF
--- a/withServicePoints.js
+++ b/withServicePoints.js
@@ -139,7 +139,7 @@ const withServicePoints = WrappedComponent =>
       }
 
       record.servicePointsIds = servicePoints.map(sp => sp.id);
-      record.defaultServicePointId = preferredServicePoint === '-' ? null : preferredServicePoint;
+      record.defaultServicePointId = (!servicePoints.length || preferredServicePoint === '-') ? null : preferredServicePoint;
 
       mutator(record).then(() => {
         this.props.mutator.servicePointsUsers.reset();


### PR DESCRIPTION
https://issues.folio.org/browse/STCOR-237

@doytch while working on STCOR-237 I noticed that sometimes when all SPs are removed from the given user the `defaultServicePointId` was still hanging around. This PR is trying to address that.