### PR TITLE
UIU-618, UIU-620, UIU-621: Edit User Permissions bugs and additions

### DIFF
--- a/ViewUser.js
+++ b/ViewUser.js
@@ -407,10 +407,18 @@ class ViewUser extends React.Component {
 
     const { proxies, sponsors, permissions, servicePoints, preferredServicePoint } = user;
 
-    if (proxies) this.props.updateProxies(proxies);
-    if (sponsors) this.props.updateSponsors(sponsors);
-    if (permissions) this.updatePermissions(permissions);
-    if (servicePoints) this.props.updateServicePoints(servicePoints, preferredServicePoint);
+    if (this.props.stripes.hasPerm('proxiesfor.item.put,proxiesfor.item.post')) {
+      if (proxies) this.props.updateProxies(proxies);
+      if (sponsors) this.props.updateSponsors(sponsors);
+    }
+
+    if (permissions) {
+      this.updatePermissions(permissions);
+    }
+
+    if (servicePoints && this.props.stripes.hasPerm('inventory-storage.service-points-users.item.post,inventory-storage.service-points-users.item.put')) {
+      this.props.updateServicePoints(servicePoints, preferredServicePoint);
+    }
 
     const data = omit(user, ['creds', 'proxies', 'sponsors', 'permissions', 'servicePoints', 'preferredServicePoint']);
 

--- a/lib/EditSections/EditUserPerms/EditUserPerms.js
+++ b/lib/EditSections/EditUserPerms/EditUserPerms.js
@@ -23,6 +23,7 @@ class EditUserPerms extends React.Component {
       type: 'okapi',
       records: 'permissions',
       path: 'perms/permissions?length=1000',
+      permissionsRequired: 'perms.permissions.get'
     },
   });
 
@@ -31,7 +32,7 @@ class EditUserPerms extends React.Component {
     const availablePermissions = (resources.availablePermissions || {}).records || [];
 
     return (
-      <IfPermission perm="perms.users.get">
+      <IfPermission perm="perms.users.get,perms.permissions.get">
         <IfInterface name="permissions" version="5.0">
           <EditablePermissions
             {...this.props}

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
         "displayName": "Users: Can assign and unassign permissions to users",
         "description": "",
         "subPermissions": [
+          "ui-users.edit",
           "ui-users.viewperms",
           "perms.users.item.put",
           "perms.users.item.post",
@@ -116,6 +117,18 @@
           "ui-users.view",
           "inventory-storage.service-points.collection.get",
           "inventory-storage.service-points-users.collection.get"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-users.edituserservicepoints",
+        "displayName": "Users: Can assign and unassign service points to users",
+        "description": "",
+        "subPermissions": [
+          "ui-users.edit",
+          "ui-users.viewuserservicepoints",
+          "inventory-storage.service-points-users.item.post",
+          "inventory-storage.service-points-users.item.put"
         ],
         "visible": true
       },
@@ -203,6 +216,7 @@
         "displayName": "Users: Can create, edit and remove proxies",
         "description": "",
         "subPermissions": [
+          "ui-users.edit",
           "ui-users.viewproxies",
           "proxiesfor.item.get",
           "proxiesfor.item.post",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
         "description": "Also includes basic permissions to view users",
         "subPermissions": [
           "ui-users.view",
-          "perms.users.get"
+          "perms.users.get",
+          "perms.permissions.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
UIU-620 adds a permission set to edit a user's service points. This should _include_ the ability to edit a record in general. Per discussion on that issue with Cate, I extended the permission sets for editing proxies and permissions to also include the generic `ui-users.edit` permission for consistency.

UIU-618 is a bug where we're not checking if we have permissions to view the list of available permissions before fetching them. Made use of @mkuklis' work and threw a `permissionsRequired` prop on the manifest since the rendering permission-gating was already in place.

While doing that I noticed that the edit perms permission doesn't actually include the ability to read the permissions available. Fixed that.

UIU-621 is a bug where saving a user record without "edit proxy" or "edit service point" permissions would throw errors. Checked to make sure we have the required permissions to perform those actions before calling their `update*()` methods. 