### PR TITLE
remove prepublishOnly npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -408,7 +408,6 @@
     "lint": "eslint .",
     "test": "echo 'No unit tests implemented'",
     "test-int": "stripes test nightmare",
-    "prepublishOnly": "node ../stripes-core/util/package2md.js package.json > ModuleDescriptor.json"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -407,7 +407,7 @@
     "build": "stripes build",
     "lint": "eslint .",
     "test": "echo 'No unit tests implemented'",
-    "test-int": "stripes test nightmare",
+    "test-int": "stripes test nightmare"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^2.0.3",


### PR DESCRIPTION
The npm script, prepublishOnly, fails.   It assumes there is a stripes-core checkout one directory-level higher than this module's root directory.   Really bad assumption. 