### PR TITLE
Support circulation interface 3.0 and 4.0 UIU-627

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Remove Tax/Vat column for Manual Fees/Fines Table. Fixes UIU-577.
 * Ensure the availability of data to Charge manual Fee/Fine. Fixes UIU-219.
 * Add functions for link to fee/fine history and fee/fine details. Fixes UIU-238 and UIU-239.
-* Bump circulation interface to v.4.0. Part of UIU-627.
+* Support `circulation` interface 3.0 or 4.0. Part of UIU-627.
 
 ## [2.13.0](https://github.com/folio-org/ui-users/tree/v2.13.0) (2018-09-04)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.12.0...v2.13.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Ensure the availability of data to Charge manual Fee/Fine. Fixes UIU-219.
 * Add functions for link to fee/fine history and fee/fine details. Fixes UIU-238 and UIU-239.
 * Support `circulation` interface 3.0 or 4.0. Part of UIU-627.
+* Support `loan-storage` interface 4.0 and 5.0. Part of UIU-627.
 
 ## [2.13.0](https://github.com/folio-org/ui-users/tree/v2.13.0) (2018-09-04)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.12.0...v2.13.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 * Remove Tax/Vat column for Manual Fees/Fines Table. Fixes UIU-577.
 * Ensure the availability of data to Charge manual Fee/Fine. Fixes UIU-219.
 * Add functions for link to fee/fine history and fee/fine details. Fixes UIU-238 and UIU-239.
-* Support `circulation` interface 3.0 or 4.0. Part of UIU-627.
-* Support `loan-storage` interface 4.0 and 5.0. Part of UIU-627.
+* Support either `circulation` interface version 3.0 or 4.0. Part of UIU-627.
+* Support either `loan-storage` interface version 4.0 or 5.0. Part of UIU-627.
 
 ## [2.13.0](https://github.com/folio-org/ui-users/tree/v2.13.0) (2018-09-04)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.12.0...v2.13.0)

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -563,19 +563,10 @@ class ViewUser extends React.Component {
 
         <IfPermission perm="circulation.loans.collection.get">
           <IfInterface name="loan-policy-storage" version="1.0">
-            { /* Separate checks for each version of interface, consolidate if possible */ }
-            <IfInterface name="circulation" version="3.0">
-              <this.connectedUserLoans
-                onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
-                onClickViewOpenLoans={this.onClickViewOpenLoans}
-                onClickViewClosedLoans={this.onClickViewClosedLoans}
-                expanded={this.state.sections.loansSection}
-                onToggle={this.handleSectionToggle}
-                accordionId="loansSection"
-                {...this.props}
-              />
-            </IfInterface>
-            <IfInterface name="circulation" version="4.0">
+            { /* Check without version, so can support either of multiple versions.
+            Replace with specific check when facility for providing
+            multiple versions is available */ }
+            <IfInterface name="circulation">
               <this.connectedUserLoans
                 onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
                 onClickViewOpenLoans={this.onClickViewOpenLoans}

--- a/ViewUser.js
+++ b/ViewUser.js
@@ -562,8 +562,20 @@ class ViewUser extends React.Component {
         </IfPermission>
 
         <IfPermission perm="circulation.loans.collection.get">
-          <IfInterface name="circulation" version="4.0">
-            <IfInterface name="loan-policy-storage" version="1.0">
+          <IfInterface name="loan-policy-storage" version="1.0">
+            { /* Separate checks for each version of interface, consolidate if possible */ }
+            <IfInterface name="circulation" version="3.0">
+              <this.connectedUserLoans
+                onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
+                onClickViewOpenLoans={this.onClickViewOpenLoans}
+                onClickViewClosedLoans={this.onClickViewClosedLoans}
+                expanded={this.state.sections.loansSection}
+                onToggle={this.handleSectionToggle}
+                accordionId="loansSection"
+                {...this.props}
+              />
+            </IfInterface>
+            <IfInterface name="circulation" version="4.0">
               <this.connectedUserLoans
                 onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
                 onClickViewOpenLoans={this.onClickViewOpenLoans}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "circulation": "3.0 4.0",
       "permissions": "5.0",
       "loan-policy-storage": "1.0",
-      "loan-storage": "4.0",
+      "loan-storage": "4.0 5.0",
       "login": "4.0",
       "feesfines": "14.0"
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "okapiInterfaces": {
       "users": "15.0",
       "configuration": "2.0",
-      "circulation": "4.0",
+      "circulation": "3.0 4.0",
       "permissions": "5.0",
       "loan-policy-storage": "1.0",
       "loan-storage": "4.0",


### PR DESCRIPTION
*Purpose*

https://issues.folio.org/browse/UIU-627

Support both major versions in order to ease the transition between major versions of the `circulation` and `loan-storage` interfaces  (in order to introduce support loan anonymization)

*Approach*

* Changed the package to support both 3.0 and 4.0 versions of the `circulation` interface
* Changed the package to support both 4.0 and 5.0 versions of the `loan-storage` interface (as the only module which provides `circulation` 4.0 requires `loan-storage` 5.0 as this is a cascading change. They need to be in unison to form a coherent backend)
* ~~Extended the interface check in the view to first look for `circulation` version 3.0 and then 4.0~~
* Changed the interface check in the view to for any version of `circulation` interface (to be replaced by explicit versions, when the facility to check for either is available, see https://issues.folio.org/browse/STCOR-249 )

*Questions*
~~The interface check in the view includes some duplication to check for both versions explicitly. 
According to https://github.com/folio-org/stripes-components/tree/master/lib/IfInterface this could replaced with a check without a version.~~

~~I don't know what the policy is around this. All of the examples that I found from a search included a version number. Which is the more idiomatic stripes approach?~~

*Limitations*
I do not have a full local UI setup, so have only performed very limited testing.

I have run `yarn lint`, which produces the same two errors as master for me (both referring to CSV export).

I have `yarn test-int --url http://folio-testing.aws.indexdata.com/` (both master and the branch produce 28 passing for me).

I receive the following error for both my branch and master locally:
```Some tests failed or something went wrong while attempting to run the tests.
TypeError: Cannot set property 'testsSuccessful' of undefined
    at nightmareService.runNightmareTests.then (/Users/marc/Development/folio/ui-users/node_modules/@folio/stripes-cli/lib/commands/test/nightmare.js:58:32)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
(node:19092) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot set property 'testsSuccessful' of undefined
(node:19092) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.```
