### PR TITLE
avoid limit=0 in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.15.3 (IN PROGRESS)
+
+* Avoid limit=0 in queries due to a RAML regression in 1.0 vs 0.8. Refs FOLIO-1517.
+
 ## [2.15.2](https://github.com/folio-org/ui-users/tree/v2.15.2) (2018-09-14)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.15.1...v2.15.2)
 

--- a/settings/FeeFinesTable/FeeFines.js
+++ b/settings/FeeFinesTable/FeeFines.js
@@ -60,12 +60,12 @@ class FeeFines extends React.Component {
     feefinesPerOwner: {
       type: 'okapi',
       records: 'feefines',
-      path: 'feefines?limit=0&facets=ownerId',
+      path: 'feefines?limit=1&facets=ownerId',
     },
     accountsPerFeeFine: {
       type: 'okapi',
       records: 'accounts',
-      path: 'accounts?limit=0&facets=feeFineId',
+      path: 'accounts?limit=1&facets=feeFineId',
     },
 
     feefines: {

--- a/settings/PatronGroupsSettings.js
+++ b/settings/PatronGroupsSettings.js
@@ -15,7 +15,7 @@ class PatronGroupsSettings extends React.Component {
     usersPerGroup: {
       type: 'okapi',
       records: 'users',
-      path: 'users?limit=0&facets=patronGroup:50',
+      path: 'users?limit=1&facets=patronGroup:50',
     },
   });
 


### PR DESCRIPTION
Due to a regression in RAML from 0.8 to 1.0, limit=0 in queries results
in an error. While it should be syntactically valid, the simplest thing
for the release is to use limit=1 instead of re-releasing a bajillion
server-side modules.

Refs [FOLIO-1517](https://issues.folio.org/browse/FOLIO-1517)