### PR TITLE
Clean up user edit form layout

### DIFF
--- a/src/UserForm.css
+++ b/src/UserForm.css
@@ -2,6 +2,12 @@
   height: 100%;
   overflow: auto;
 }
+
 .UserFormEditIcon {
   display: inline-block;
+}
+
+.UserFormContent {
+  margin: 0 auto;
+  max-width: 50em;
 }

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -193,21 +193,53 @@ class UserForm extends React.Component {
       <form className={css.UserFormRoot} id="form-user" onSubmit={handleSubmit} onKeyDown={this.handleKeyDown}>
         <Paneset isRoot>
           <Pane defaultWidth="100%" firstMenu={firstMenu} lastMenu={lastMenu} paneTitle={paneTitle} appIcon={{ app: 'users' }}>
-            <Row end="xs">
-              <Col xs>
-                <ExpandAllButton accordionStatus={sections} onToggle={this.handleExpandAll} />
-              </Col>
-            </Row>
-            <EditUserInfo accordionId="editUserInfo" expanded={sections.editUserInfo} onToggle={this.handleSectionToggle} {...this.props} />
-            <EditExtendedInfo accordionId="extendedInfo" expanded={sections.extendedInfo} onToggle={this.handleSectionToggle} {...this.props} />
-            <EditContactInfo accordionId="contactInfo" expanded={sections.contactInfo} onToggle={this.handleSectionToggle} {...this.props} />
-            {initialValues.id &&
-              <div>
-                <EditProxy accordionId="proxy" expanded={sections.proxy} onToggle={this.handleSectionToggle} {...this.props} />
-                <this.connectedEditUserPerms accordionId="permissions" expanded={sections.permissions} onToggle={this.handleSectionToggle} {...this.props} />
-                <EditServicePoints accordionId="servicePoints" expanded={sections.servicePoints} onToggle={this.handleSectionToggle} {...this.props} />
-              </div>
-            }
+            <div className={css.UserFormContent}>
+              <Row end="xs">
+                <Col xs>
+                  <ExpandAllButton accordionStatus={sections} onToggle={this.handleExpandAll} />
+                </Col>
+              </Row>
+              <EditUserInfo
+                accordionId="editUserInfo"
+                expanded={sections.editUserInfo}
+                onToggle={this.handleSectionToggle}
+                {...this.props}
+              />
+              <EditExtendedInfo
+                accordionId="extendedInfo"
+                expanded={sections.extendedInfo}
+                onToggle={this.handleSectionToggle}
+                {...this.props}
+              />
+              <EditContactInfo
+                accordionId="contactInfo"
+                expanded={sections.contactInfo}
+                onToggle={this.handleSectionToggle}
+                {...this.props}
+              />
+              {initialValues.id &&
+                <div>
+                  <EditProxy
+                    accordionId="proxy"
+                    expanded={sections.proxy}
+                    onToggle={this.handleSectionToggle}
+                    {...this.props}
+                  />
+                  <this.connectedEditUserPerms
+                    accordionId="permissions"
+                    expanded={sections.permissions}
+                    onToggle={this.handleSectionToggle}
+                    {...this.props}
+                  />
+                  <EditServicePoints
+                    accordionId="servicePoints"
+                    expanded={sections.servicePoints}
+                    onToggle={this.handleSectionToggle}
+                    {...this.props}
+                  />
+                </div>
+              }
+            </div>
           </Pane>
         </Paneset>
       </form>

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.js
@@ -33,36 +33,28 @@ const EditContactInfo = ({ expanded, onToggle, accordionId, parentResources, ini
       label={intl.formatMessage({ id: 'ui-users.contact.contactInformation' })}
     >
       <Row>
-        <Col xs={8}>
-          <Row>
-            <Col xs={3}>
-              <Field label={intl.formatMessage({ id: 'ui-users.contact.email' })} name="personal.email" id="adduser_email" component={TextField} required fullWidth />
-            </Col>
-            <Col xs={3}>
-              <Field label={intl.formatMessage({ id: 'ui-users.contact.phone' })} name="personal.phone" id="adduser_phone" component={TextField} fullWidth />
-            </Col>
-            <Col xs={3}>
-              <Field label={intl.formatMessage({ id: 'ui-users.contact.mobilePhone' })} name="personal.mobilePhone" id="adduser_mobilePhone" component={TextField} fullWidth />
-            </Col>
-            <Col xs={3}>
-              <Field
-                label={`${intl.formatMessage({ id: 'ui-users.contact.preferredContact' })} *`}
-                name="personal.preferredContactTypeId"
-                id="adduser_preferredcontact"
-                component={Select}
-                dataOptions={[{ label: intl.formatMessage({ id: 'ui-users.contact.selectContactType' }), value: '' }, ...contactTypeOptions]}
-                fullWidth
-              />
-            </Col>
-          </Row>
-          <br />
-          <Row>
-            <Col xs={12}>
-              <AddressEditList name="personal.addresses" fieldComponents={addressFields} canDelete />
-            </Col>
-          </Row>
+        <Col xs={12} md={3}>
+          <Field label={intl.formatMessage({ id: 'ui-users.contact.email' })} name="personal.email" id="adduser_email" component={TextField} required fullWidth />
+        </Col>
+        <Col xs={12} md={3}>
+          <Field label={intl.formatMessage({ id: 'ui-users.contact.phone' })} name="personal.phone" id="adduser_phone" component={TextField} fullWidth />
+        </Col>
+        <Col xs={12} md={3}>
+          <Field label={intl.formatMessage({ id: 'ui-users.contact.mobilePhone' })} name="personal.mobilePhone" id="adduser_mobilePhone" component={TextField} fullWidth />
+        </Col>
+        <Col xs={12} md={3}>
+          <Field
+            label={`${intl.formatMessage({ id: 'ui-users.contact.preferredContact' })} *`}
+            name="personal.preferredContactTypeId"
+            id="adduser_preferredcontact"
+            component={Select}
+            dataOptions={[{ label: intl.formatMessage({ id: 'ui-users.contact.selectContactType' }), value: '' }, ...contactTypeOptions]}
+            fullWidth
+          />
         </Col>
       </Row>
+      <br />
+      <AddressEditList name="personal.addresses" fieldComponents={addressFields} canDelete />
     </Accordion>
   );
 };

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import Datepicker from '@folio/stripes-components/lib/Datepicker';
 import Button from '@folio/stripes-components/lib/Button';
 import { Accordion } from '@folio/stripes-components/lib/Accordion';
 import TextField from '@folio/stripes-components/lib/TextField';
+import KeyValue from '@folio/stripes-components/lib/KeyValue';
 import { Field } from 'redux-form';
 
 import css from './EditExtendedInfo.css';
@@ -32,66 +32,63 @@ class EditExtendedInfo extends React.Component {
         label={this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.extendedInformation' })}
       >
         <Row>
-          <Col xs={8}>
-            <Row>
-              <Col xs={3}>
-                <Field
-                  component={Datepicker}
-                  label={this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.dateEnrolled' })}
-                  dateFormat="YYYY-MM-DD"
-                  name="enrollmentDate"
-                  id="adduser_enrollmentdate"
-                />
-              </Col>
-              <Col xs={3}>
-                <Field
-                  label={this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.externalSystemId' })}
-                  name="externalSystemId"
-                  id="adduser_externalsystemid"
-                  component={TextField}
-                  fullWidth
-                />
-              </Col>
-              <Col xs={3}>
-                <Field
-                  component={Datepicker}
-                  label={this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.birthDate' })}
-                  dateFormat="YYYY-MM-DD"
-                  name="personal.dateOfBirth"
-                  id="adduser_dateofbirth"
-                  timeZone="UTC"
-                  backendDateStandard="YYYY-MM-DD"
-                />
-              </Col>
-              <Col xs={3}>
-                <p className={css.label}><FormattedMessage id="ui-users.extended.folioNumber" /></p>
-                <p>{initialValues.id || '-'}</p>
-              </Col>
-            </Row>
-            {!initialValues.id &&
-              <Row>
-                <Col xs={4}>
-                  <Field
-                    component={TextField}
-                    label={`${this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.folioPassword' })} `}
-                    name="creds.password"
-                    id="pw"
-                    autoComplete="new-password"
-                    type={this.state.showPassword ? 'text' : 'password'}
-                    fullWidth
-                  />
-                </Col>
-                <Col xs={1}>
-                  <div className={css.togglePw}>
-                    <Button id="toggle_pw_btn" onClick={() => this.togglePassword()}>
-                      {this.state.showPassword ? this.props.stripes.intl.formatMessage({ id: 'ui-users.hide' }) : this.props.stripes.intl.formatMessage({ id: 'ui-users.show' })}
-                    </Button>
-                  </div>
-                </Col>
-              </Row>
-            }
+          <Col xs={12} md={3}>
+            <Field
+              component={Datepicker}
+              label={this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.dateEnrolled' })}
+              dateFormat="YYYY-MM-DD"
+              name="enrollmentDate"
+              id="adduser_enrollmentdate"
+            />
+          </Col>
+          <Col xs={12} md={3}>
+            <Field
+              label={this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.externalSystemId' })}
+              name="externalSystemId"
+              id="adduser_externalsystemid"
+              component={TextField}
+              fullWidth
+            />
+          </Col>
+          <Col xs={12} md={3}>
+            <Field
+              component={Datepicker}
+              label={this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.birthDate' })}
+              dateFormat="YYYY-MM-DD"
+              name="personal.dateOfBirth"
+              id="adduser_dateofbirth"
+              timeZone="UTC"
+              backendDateStandard="YYYY-MM-DD"
+            />
+          </Col>
+          <Col xs={12} md={3}>
+            <KeyValue label={this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.folioNumber' })}>
+              {initialValues.id || '-'}
+            </KeyValue>
           </Col>
         </Row>
+        {!initialValues.id &&
+          <Row>
+            <Col xs={4}>
+              <Field
+                component={TextField}
+                label={`${this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.folioPassword' })} `}
+                name="creds.password"
+                id="pw"
+                autoComplete="new-password"
+                type={this.state.showPassword ? 'text' : 'password'}
+                fullWidth
+              />
+            </Col>
+            <Col xs={1}>
+              <div className={css.togglePw}>
+                <Button id="toggle_pw_btn" onClick={() => this.togglePassword()}>
+                  {this.state.showPassword ? this.props.stripes.intl.formatMessage({ id: 'ui-users.hide' }) : this.props.stripes.intl.formatMessage({ id: 'ui-users.show' })}
+                </Button>
+              </div>
+            </Col>
+          </Row>
+        }
         <br />
       </Accordion>
     );

--- a/src/components/EditSections/EditProxy/EditProxy.js
+++ b/src/components/EditSections/EditProxy/EditProxy.js
@@ -29,14 +29,10 @@ const EditProxy = (props) => {
           <Badge>{sponsors.length + proxies.length}</Badge>
         }
       >
-        <Row>
-          <Col xs={8}>
-            <ProxyEditList itemComponent={ProxyEditItem} label={isProxyFor} name="sponsors" {...props} />
-            <br />
-            <ProxyEditList itemComponent={ProxyEditItem} label={isSponsorOf} name="proxies" {...props} />
-            <br />
-          </Col>
-        </Row>
+        <ProxyEditList itemComponent={ProxyEditItem} label={isProxyFor} name="sponsors" {...props} />
+        <br />
+        <ProxyEditList itemComponent={ProxyEditItem} label={isSponsorOf} name="proxies" {...props} />
+        <br />
       </Accordion>
     </IfPermission>
   );

--- a/src/components/EditSections/EditServicePoints/EditServicePoints.js
+++ b/src/components/EditSections/EditServicePoints/EditServicePoints.js
@@ -174,14 +174,10 @@ class EditServicePoints extends React.Component {
             onToggle={this.props.onToggle}
             displayWhenClosed={<Badge>{(this.userServicePoints && this.userServicePoints.length) || 0}</Badge>}
           >
-            <Row>
-              <Col xs={8}>
-                { this.renderAddServicePointButton() }
-                { this.renderPreferredServicePointSelect() }
-                { this.renderServicePoints() }
-                { this.renderAddServicePointModal() }
-              </Col>
-            </Row>
+            <div>{ this.renderAddServicePointButton() }</div>
+            { this.renderPreferredServicePointSelect() }
+            { this.renderServicePoints() }
+            { this.renderAddServicePointModal() }
           </Accordion>
         </IfInterface>
       </IfPermission>

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -55,68 +55,62 @@ class EditUserInfo extends React.Component {
         id={accordionId}
         onToggle={onToggle}
       >
+
+        <this.cViewMetaData metadata={initialValues.metadata} />
+
         <Row>
-          <Col xs={12}>
-            <this.cViewMetaData metadata={initialValues.metadata} />
+          <Col xs={12} md={3}>
+            <Field label={`${intl.formatMessage({ id: 'ui-users.information.lastName' })} *`} name="personal.lastName" id="adduser_lastname" component={TextField} required fullWidth />
+          </Col>
+          <Col xs={12} md={3}>
+            <Field label={intl.formatMessage({ id: 'ui-users.information.firstName' })} name="personal.firstName" id="adduser_firstname" component={TextField} fullWidth />
+          </Col>
+          <Col xs={12} md={3}>
+            <Field label={intl.formatMessage({ id: 'ui-users.information.middleName' })} name="personal.middleName" id="adduser_middlename" component={TextField} fullWidth />
+          </Col>
+          <Col xs={12} md={3}>
+            <Field label={intl.formatMessage({ id: 'ui-users.information.barcode' })} name="barcode" id="adduser_barcode" component={TextField} fullWidth />
           </Col>
         </Row>
-        <Row>
-          <Col xs={8}>
-            <Row>
-              <Col xs={3}>
-                <Field label={`${intl.formatMessage({ id: 'ui-users.information.lastName' })} *`} name="personal.lastName" id="adduser_lastname" component={TextField} required fullWidth />
-              </Col>
-              <Col xs={3}>
-                <Field label={intl.formatMessage({ id: 'ui-users.information.firstName' })} name="personal.firstName" id="adduser_firstname" component={TextField} fullWidth />
-              </Col>
-              <Col xs={3}>
-                <Field label={intl.formatMessage({ id: 'ui-users.information.middleName' })} name="personal.middleName" id="adduser_middlename" component={TextField} fullWidth />
-              </Col>
-              <Col xs={3}>
-                <Field label={intl.formatMessage({ id: 'ui-users.information.barcode' })} name="barcode" id="adduser_barcode" component={TextField} fullWidth />
-              </Col>
-            </Row>
 
-            <Row>
-              <Col xs={3}>
-                <Field
-                  label={`${intl.formatMessage({ id: 'ui-users.information.patronGroup' })} *`}
-                  name="patronGroup"
-                  id="adduser_group"
-                  component={Select}
-                  fullWidth
-                  dataOptions={[{ label: intl.formatMessage({ id: 'ui-users.information.selectPatronGroup' }), value: '' }, ...patronGroupOptions]}
-                />
-              </Col>
-              <Col xs={3}>
-                <Field
-                  label={`${intl.formatMessage({ id: 'ui-users.information.status' })} *`}
-                  name="active"
-                  id="useractive"
-                  component={Select}
-                  fullWidth
-                  dataOptions={statusOptions}
-                  disabled={isStatusFieldDisabled()}
-                />
-                {isUserExpired() && (
-                  <span style={{ 'color': '#900', 'position': 'relative', 'top': '-10px', 'fontSize': '0.9em' }}>
-                    {`${intl.formatMessage({ id: 'ui-users.errors.userExpired' })}`}
-                  </span>
-                )}
-              </Col>
-              <Col xs={3}>
-                <Field
-                  component={Datepicker}
-                  label={intl.formatMessage({ id: 'ui-users.expirationDate' })}
-                  dateFormat="YYYY-MM-DD"
-                  name="expirationDate"
-                  id="adduser_expirationdate"
-                />
-              </Col>
-              <Col xs={3}>
-                <Field label={`${intl.formatMessage({ id: 'ui-users.information.username' })}`} name="username" id="adduser_username" component={TextField} fullWidth validStylesEnabled />
-              </Col>
-            </Row>
+        <Row>
+          <Col xs={12} md={3}>
+            <Field
+              label={`${intl.formatMessage({ id: 'ui-users.information.patronGroup' })} *`}
+              name="patronGroup"
+              id="adduser_group"
+              component={Select}
+              fullWidth
+              dataOptions={[{ label: intl.formatMessage({ id: 'ui-users.information.selectPatronGroup' }), value: '' }, ...patronGroupOptions]}
+            />
+          </Col>
+          <Col xs={12} md={3}>
+            <Field
+              label={`${intl.formatMessage({ id: 'ui-users.information.status' })} *`}
+              name="active"
+              id="useractive"
+              component={Select}
+              fullWidth
+              dataOptions={statusOptions}
+              disabled={isStatusFieldDisabled()}
+            />
+            {isUserExpired() && (
+              <span style={{ 'color': '#900', 'position': 'relative', 'top': '-10px', 'fontSize': '0.9em' }}>
+                {`${intl.formatMessage({ id: 'ui-users.errors.userExpired' })}`}
+              </span>
+            )}
+          </Col>
+          <Col xs={12} md={3}>
+            <Field
+              component={Datepicker}
+              label={intl.formatMessage({ id: 'ui-users.expirationDate' })}
+              dateFormat="YYYY-MM-DD"
+              name="expirationDate"
+              id="adduser_expirationdate"
+            />
+          </Col>
+          <Col xs={12} md={3}>
+            <Field label={`${intl.formatMessage({ id: 'ui-users.information.username' })}`} name="username" id="adduser_username" component={TextField} fullWidth validStylesEnabled />
           </Col>
         </Row>
       </Accordion>

--- a/src/components/EditablePermissions/EditablePermissions.js
+++ b/src/components/EditablePermissions/EditablePermissions.js
@@ -160,7 +160,8 @@ class EditablePermissions extends React.Component {
           onToggle={this.onToggleAddPermDD}
         >
           <Button align="end" bottomMargin0 data-role="toggle" aria-haspopup="true" id="clickable-add-permission">
-&#43;
+            &#43;
+            {' '}
             <FormattedMessage id="ui-users.permissions.addPermission" />
           </Button>
           <DropdownMenu
@@ -185,21 +186,8 @@ class EditablePermissions extends React.Component {
           <Badge>{size}</Badge>
         }
       >
-        <Row>
-          <Col xs={8}>
-            <Row>
-              <Col xs={12}>
-                {permsDropdownButton}
-              </Col>
-            </Row>
-            <br />
-            <Row>
-              <Col xs={12}>
-                <FieldArray name={this.props.name} component={this.renderList} />
-              </Col>
-            </Row>
-          </Col>
-        </Row>
+        <div>{permsDropdownButton}</div>
+        <FieldArray name={this.props.name} component={this.renderList} />
       </Accordion>
     );
   }


### PR DESCRIPTION
## Purpose 
The user edit form doesn't do the flexing it needs to for different screen widths.

## Approach
Set a max-width of `50em` for the entire form. Adjust `react-flexbox-grid` usage as necessary.

## Tips
1. Don't use `react-flexbox-grid` to set a faux max-width. Set the max-width on the container, so the `<Row>` fills the container.
2. Don't use `react-flexbox-grid` when you don't need to.
```
<Row>
  <Col xs={12}>
    Content
  </Col>
</Row>
```
does exactly the same thing as 
```
<div>
  Content
</div>
```

## Next Steps
- `react-flexbox-grid` is effective when you can guarantee the parent container is 100% of the width of the browser. Some day we might want this form to be renderable in the third pane of a `SearchAndSort`-esque layout. Then we'll want to write a little more custom CSS in this repo instead of using `react-flexbox-grid`.
- Four inputs per row is a lot. UX researchers are pretty consistent in advocating for single-column forms: https://baymard.com/blog/avoid-multi-column-forms

## Screenshots
### Before
![folio-q3 aws indexdata com_users_view_05afe1c7-efcb-4312-b0d5-7076cf695875_layer edit query e ipad](https://user-images.githubusercontent.com/230597/45833290-fa626180-bcc9-11e8-8731-58234b874c72.png)

![folio-q3 aws indexdata com_users_view_05afe1c7-efcb-4312-b0d5-7076cf695875_layer edit query e ipad 1](https://user-images.githubusercontent.com/230597/45833292-fa626180-bcc9-11e8-9bb1-495501916e16.png)


### After
![localhost_3000_users_view_05afe1c7-efcb-4312-b0d5-7076cf695875_layer edit query e ipad 1](https://user-images.githubusercontent.com/230597/45833296-fe8e7f00-bcc9-11e8-80ae-ce454fd7ed74.png)

![localhost_3000_users_view_05afe1c7-efcb-4312-b0d5-7076cf695875_layer edit query e ipad](https://user-images.githubusercontent.com/230597/45833297-fe8e7f00-bcc9-11e8-8a06-8c674412f809.png)