### PR TITLE
Release v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Change history for ui-users
 
-## 2.16.0 (IN PROGRESS)
+## [2.16.0](https://github.com/folio-org/ui-users/tree/v2.16.0) (2018-09-27)
+[Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.16.0)
 
 * Update `stripes-form` dependency to v1.0.0
 * Fix charge Manual Fee/Fine,Display fees/fines history,Display Fee/Fine Details,Pay Fee/Fine. Fix UIU-635, UIU-645.
 * Update tags counter when tags are being added or removed. Fixes UIU-660.
 * Update closed loans counter after anonymization. Fixes UIU-647.
+* Move files into src directory
 
 ## [2.15.1](https://github.com/folio-org/ui-users/tree/v2.15.1) (2018-09-13)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.15.0...v2.15.1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/users",
-  "version": "2.15.2",
+  "version": "2.16.0",
   "description": "User management",
   "repository": "folio-org/ui-users",
   "publishConfig": {


### PR DESCRIPTION
https://github.com/folio-org/ui-users/pull/527 changed the directory structure of `ui-users`, which `ui-plugin-find-user` was relying on:
```
ERROR in ./node_modules/@folio/plugin-find-user/UserSearch/UserSearchModal.js
Module not found: Error: Can't resolve '@folio/users/Users' in '/home/jenkins/folio-testing-platform/node_modules/@folio/plugin-find-user/UserSearch'
 @ ./node_modules/@folio/plugin-find-user/UserSearch/UserSearchModal.js 15:0-39 29:47-52
 @ ./node_modules/@folio/plugin-find-user/UserSearch/UserSearch.js
 @ ./node_modules/@folio/plugin-find-user/UserSearch/index.js
 @ ./node_modules/@folio/plugin-find-user/index.js
 @ ./node_modules/stripes-config.js
 @ ./node_modules/@folio/stripes-core/src/App.js
 @ ./node_modules/@folio/stripes-core/src/HotApp.js
 @ ./node_modules/@folio/stripes-core/src/index.js
 @ multi typeface-source-sans-pro @folio/stripes-components/lib/global.css ./node_modules/@folio/stripes-core/src/index
```

Long term, we should explore how that relationship gets defined. Exports? Have the plugin live within this repo?

For now, cut this release so `ui-plugin-find-user` can update its dependency and point to the new file path.
