### PR TITLE
STCOM-352 Display large headline on detail record

### DIFF
--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -11,6 +11,7 @@ import {
   ExpandAllButton,
   Row,
   Col,
+  Headline
 } from '@folio/stripes/components';
 import stripesForm from '@folio/stripes/form';
 
@@ -197,6 +198,7 @@ class UserForm extends React.Component {
         <Paneset isRoot>
           <Pane defaultWidth="100%" firstMenu={firstMenu} lastMenu={lastMenu} paneTitle={paneTitle} appIcon={{ app: 'users' }}>
             <div className={css.UserFormContent}>
+              <Headline size="xx-large" tag="h2">{getFullName(initialValues)}</Headline>
               <Row end="xs">
                 <Col xs>
                   <ExpandAllButton accordionStatus={sections} onToggle={this.handleExpandAll} />

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -14,6 +14,7 @@ import {
   IfPermission,
   IfInterface,
   Layer,
+  Headline
 } from '@folio/stripes/components';
 import { withTags } from '@folio/stripes/smart-components';
 
@@ -539,6 +540,9 @@ class ViewUser extends React.Component {
     return (
       <Pane id="pane-userdetails" defaultWidth={this.props.paneWidth} paneTitle={getFullName(user)} lastMenu={detailMenu} dismissible onClose={this.props.onClose} appIcon={{ app: 'users' }}>
         <TitleManager record={getFullName(user)} />
+
+        <Headline size="xx-large" tag="h2">{getFullName(user)}</Headline>
+
         <Row end="xs"><Col xs><ExpandAllButton accordionStatus={this.state.sections} onToggle={this.handleExpandAll} /></Col></Row>
 
         <this.connectedUserInfo accordionId="userInformationSection" user={user} patronGroup={patronGroup} settings={settings} stripes={stripes} expanded={this.state.sections.userInformationSection} onToggle={this.handleSectionToggle} />


### PR DESCRIPTION
Adds `xx-large` `<h2>` to user detail pane and form.

https://issues.folio.org/browse/STCOM-352

![localhost_3000_users_view_6eff0514-6f14-4683-b3dc-c17812cf6554_layer edit query s sort name ipad pro](https://user-images.githubusercontent.com/230597/46619588-0fbbf600-cae8-11e8-8861-3b752443a1b1.png)
