### PR TITLE
Display the patron details on the request Info detail pane, refs UIRE…

### DIFF
--- a/lib/ProxyGroup/ProxyItem/ProxyItem.js
+++ b/lib/ProxyGroup/ProxyItem/ProxyItem.js
@@ -18,7 +18,9 @@ const ProxyItem = ({ record, stripes }) => {
       <Link to={`/users/view/${record.user.id}`}>{getFullName(record.user)}</Link>
       {record.proxy && record.proxy.metadata && record.proxy.metadata.createdDate && (
       <span className={css.creationLabel}>
-        {`(Relationship created: ${stripes.formatDateTime(record.proxy.metadata.createdDate)})`}
+        (Relationship created:
+        {' '}
+        {stripes.formatDateTime(record.proxy.metadata.createdDate)}
         )
       </span>
       )}


### PR DESCRIPTION
…Q-120

- Make lint (jsx-one-expression-per-line) happy by braking the logic into multiple lines