### PR TITLE
Release v2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change history for ui-users
-## 2.17.0
-* Depend on `@folio/stripes`.
-* Update imports for components moved from `stripes-components` to `stripes-smart-components`.
+## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.16.0) (2018-10-5)
+[Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)
+
+* Depend on `@folio/stripes`. (Part of FOLIO-1547)
+* Update imports for components moved from `stripes-components` to `stripes-smart-components`. (Part of FOLIO-1547)
 
 ## [2.16.0](https://github.com/folio-org/ui-users/tree/v2.16.0) (2018-09-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.11.0...v2.16.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change history for ui-users
-## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.16.0) (2018-10-5)
+## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)
 
 * Depend on `@folio/stripes`. (Part of FOLIO-1547)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/users",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "User management",
   "repository": "folio-org/ui-users",
   "publishConfig": {


### PR DESCRIPTION
* Depend on `@folio/stripes`. (Part of FOLIO-1547)
* Update imports for components moved from `stripes-components` to `stripes-smart-components`. (Part of FOLIO-1547)