### PR TITLE
STCOR-267 Use react-intl formatDate with timeZone option

### DIFF
--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -542,7 +542,7 @@ class ViewUser extends React.Component {
         <Row end="xs"><Col xs><ExpandAllButton accordionStatus={this.state.sections} onToggle={this.handleExpandAll} /></Col></Row>
 
         <this.connectedUserInfo accordionId="userInformationSection" user={user} patronGroup={patronGroup} settings={settings} stripes={stripes} expanded={this.state.sections.userInformationSection} onToggle={this.handleSectionToggle} />
-        <ExtendedInfo accordionId="extendedInfoSection" stripes={stripes} user={user} expanded={this.state.sections.extendedInfoSection} onToggle={this.handleSectionToggle} />
+        <ExtendedInfo accordionId="extendedInfoSection" user={user} expanded={this.state.sections.extendedInfoSection} onToggle={this.handleSectionToggle} />
         <ContactInfo accordionId="contactInfoSection" stripes={stripes} user={user} addresses={addresses} addressTypes={this.addressTypes} expanded={this.state.sections.contactInfoSection} onToggle={this.handleSectionToggle} />
         <IfPermission perm="proxiesfor.collection.get">
           <ProxyPermissions

--- a/src/components/ViewSections/ExtendedInfo/ExtendedInfo.js
+++ b/src/components/ViewSections/ExtendedInfo/ExtendedInfo.js
@@ -1,45 +1,51 @@
-import _ from 'lodash';
+import get from 'lodash/get';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedDate, FormattedMessage } from 'react-intl';
 import {
-  Row,
-  Col,
   Accordion,
-  KeyValue
+  Col,
+  KeyValue,
+  Row
 } from '@folio/stripes/components';
 
-const ExtendedInfo = ({ expanded, onToggle, accordionId, user, stripes: { intl }, stripes }) => (
+const ExtendedInfo = ({ accordionId, expanded, onToggle, user }) => (
   <Accordion
-    open={expanded}
     id={accordionId}
+    label={<FormattedMessage id="ui-users.extended.extendedInformation" />}
     onToggle={onToggle}
-    label={intl.formatMessage({ id: 'ui-users.extended.extendedInformation' })}
+    open={expanded}
   >
     <Row>
-      <Col xs={3}>
-        <KeyValue label={intl.formatMessage({ id: 'ui-users.extended.dateEnrolled' })} value={stripes.formatDate(_.get(user, ['enrollmentDate'], ''))} />
+      <Col xs={12} md={3}>
+        <KeyValue label={<FormattedMessage id="ui-users.extended.dateEnrolled" />}>
+          {user.enrollmentDate ? <FormattedDate value={user.enrollmentDate} /> : '-'}
+        </KeyValue>
       </Col>
-      <Col xs={3}>
-        <KeyValue label={intl.formatMessage({ id: 'ui-users.extended.externalSystemId' })} value={_.get(user, ['externalSystemId'], '')} />
+      <Col xs={12} md={3}>
+        <KeyValue label={<FormattedMessage id="ui-users.extended.birthDate" />}>
+          {user.personal.dateOfBirth ? <FormattedDate value={user.personal.dateOfBirth} timeZone="UTC" /> : '-'}
+        </KeyValue>
       </Col>
-      <Col xs={3}>
-        <KeyValue label={intl.formatMessage({ id: 'ui-users.extended.birthDate' })} value={stripes.formatAbsoluteDate(_.get(user, ['personal', 'dateOfBirth'], ''))} />
+      <Col xs={12}>
+        <KeyValue label={<FormattedMessage id="ui-users.extended.folioNumber" />}>
+          {get(user, ['id'], '-')}
+        </KeyValue>
       </Col>
-      <Col xs={3}>
-        <KeyValue label={intl.formatMessage({ id: 'ui-users.extended.folioNumber' })} value={_.get(user, ['id'], '')} />
+      <Col xs={12}>
+        <KeyValue label={<FormattedMessage id="ui-users.extended.externalSystemId" />}>
+          {get(user, ['externalSystemId'], '-')}
+        </KeyValue>
       </Col>
     </Row>
-    <br />
   </Accordion>
 );
 
-
 ExtendedInfo.propTypes = {
+  accordionId: PropTypes.string.isRequired,
   expanded: PropTypes.bool,
   onToggle: PropTypes.func,
-  accordionId: PropTypes.string.isRequired,
-  user: PropTypes.object,
-  stripes: PropTypes.object.isRequired,
+  user: PropTypes.object
 };
 
 export default ExtendedInfo;


### PR DESCRIPTION
The date utility functions on the `stripes` god object are barreling toward a deprecation, since they simply duplicate functionality already provided by `react-intl`. This was the only instance of a `folio-org` repo consuming `stripes.formatAbsoluteDate()`. 

`<FormattedDate value={date} timeZone="UTC" />` provided by `react-intl` accomplishes the same thing.

While I was in `ExtendedInfo`, I adjusted the `react-flexbox-grid` usage, improved the `lodash` import, stopped passing in the `stripes` god object as a prop, and used `<FormattedMessage>` over `stripes.intl.formatMessage()`.