### PR TITLE
Adjust headline sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.18.0 (IN PROGRESS)
 
 * Create permission for renewing loans. Fixes UIU-625.
+* Adjust accordion headline sizes for correct a11y and visual hierarchy
 
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.js
@@ -7,6 +7,7 @@ import {
   Row,
   Col,
   Accordion,
+  Headline
 } from '@folio/stripes/components';
 import { AddressEditList } from '@folio/stripes/smart-components';
 
@@ -32,7 +33,7 @@ const EditContactInfo = ({ expanded, onToggle, accordionId, parentResources, ini
       open={expanded}
       id={accordionId}
       onToggle={onToggle}
-      label={intl.formatMessage({ id: 'ui-users.contact.contactInformation' })}
+      label={<Headline size="large" tag="h3">{intl.formatMessage({ id: 'ui-users.contact.contactInformation' })}</Headline>}
     >
       <Row>
         <Col xs={12} md={3}>

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -8,6 +8,7 @@ import {
   Accordion,
   KeyValue,
   Datepicker,
+  Headline
 } from '@folio/stripes/components';
 import { Field } from 'redux-form';
 
@@ -32,7 +33,7 @@ class EditExtendedInfo extends React.Component {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.extendedInformation' })}
+        label={<Headline size="large" tag="h3">{this.props.stripes.intl.formatMessage({ id: 'ui-users.extended.extendedInformation' })}</Headline>}
       >
         <Row>
           <Col xs={12} md={3}>

--- a/src/components/EditSections/EditProxy/EditProxy.js
+++ b/src/components/EditSections/EditProxy/EditProxy.js
@@ -4,6 +4,7 @@ import {
   Accordion,
   Badge,
   IfPermission,
+  Headline
 } from '@folio/stripes/components';
 
 import ProxyEditList from '../../ProxyGroup/ProxyEditList';
@@ -25,7 +26,7 @@ const EditProxy = (props) => {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={proxySponsor}
+        label={<Headline size="large" tag="h3">{proxySponsor}</Headline>}
         displayWhenClosed={
           <Badge>{sponsors.length + proxies.length}</Badge>
         }

--- a/src/components/EditSections/EditServicePoints/EditServicePoints.js
+++ b/src/components/EditSections/EditServicePoints/EditServicePoints.js
@@ -13,6 +13,7 @@ import {
   List,
   IfPermission,
   IfInterface,
+  Headline
 } from '@folio/stripes/components';
 
 import AddServicePointModal from '../../AddServicePointModal';
@@ -170,7 +171,7 @@ class EditServicePoints extends React.Component {
       <IfPermission perm="inventory-storage.service-points-users.item.post,inventory-storage.service-points-users.item.put">
         <IfInterface name="service-points-users" version="1.0">
           <Accordion
-            label={this.props.stripes.intl.formatMessage({ id: 'ui-users.sp.servicePoints' })}
+            label={<Headline size="large" tag="h3">{this.props.stripes.intl.formatMessage({ id: 'ui-users.sp.servicePoints' })}</Headline>}
             open={this.props.expanded}
             id={this.props.accordionId}
             onToggle={this.props.onToggle}

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -8,6 +8,7 @@ import {
   Col,
   Accordion,
   Datepicker,
+  Headline
 } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 
@@ -53,7 +54,7 @@ class EditUserInfo extends React.Component {
 
     return (
       <Accordion
-        label={intl.formatMessage({ id: 'ui-users.information.userInformation' })}
+        label={<Headline size="large" tag="h3">{intl.formatMessage({ id: 'ui-users.information.userInformation' })}</Headline>}
         open={expanded}
         id={accordionId}
         onToggle={onToggle}

--- a/src/components/EditablePermissions/EditablePermissions.js
+++ b/src/components/EditablePermissions/EditablePermissions.js
@@ -12,6 +12,7 @@ import {
   Badge,
   List,
   IfPermission,
+  Headline
 } from '@folio/stripes/components';
 
 import PermissionList from '../PermissionList';
@@ -181,7 +182,7 @@ class EditablePermissions extends React.Component {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={this.props.heading}
+        label={<Headline size="large" tag="h3">{this.props.heading}</Headline>}
         displayWhenClosed={
           <Badge>{size}</Badge>
         }

--- a/src/components/RenderPermissions/RenderPermissions.js
+++ b/src/components/RenderPermissions/RenderPermissions.js
@@ -5,6 +5,7 @@ import {
   List,
   Accordion,
   Badge,
+  Headline
 } from '@folio/stripes/components';
 
 class RenderPermissions extends React.Component {
@@ -61,7 +62,7 @@ class RenderPermissions extends React.Component {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={this.props.heading}
+        label={<Headline size="large" tag="h3">{this.props.heading}</Headline>}
         displayWhenClosed={
           <Badge>{listedPermissions.length}</Badge>
         }

--- a/src/components/ViewSections/ContactInfo/ContactInfo.js
+++ b/src/components/ViewSections/ContactInfo/ContactInfo.js
@@ -5,7 +5,8 @@ import {
   Row,
   Col,
   Accordion,
-  KeyValue
+  KeyValue,
+  Headline
 } from '@folio/stripes/components';
 
 import UserAddresses from '../../UserAddresses';
@@ -19,7 +20,7 @@ const ContactInfo = ({ expanded, onToggle, accordionId, user, addressTypes, addr
       open={expanded}
       id={accordionId}
       onToggle={onToggle}
-      label={intl.formatMessage({ id: 'ui-users.contact.contactInformation' })}
+      label={<Headline size="large" tag="h3">{intl.formatMessage({ id: 'ui-users.contact.contactInformation' })}</Headline>}
     >
       <Row>
         <Col xs={3}>

--- a/src/components/ViewSections/ExtendedInfo/ExtendedInfo.js
+++ b/src/components/ViewSections/ExtendedInfo/ExtendedInfo.js
@@ -5,6 +5,7 @@ import { FormattedDate, FormattedMessage } from 'react-intl';
 import {
   Accordion,
   Col,
+  Headline,
   KeyValue,
   Row
 } from '@folio/stripes/components';
@@ -12,7 +13,7 @@ import {
 const ExtendedInfo = ({ accordionId, expanded, onToggle, user }) => (
   <Accordion
     id={accordionId}
-    label={<FormattedMessage id="ui-users.extended.extendedInformation" />}
+    label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.extended.extendedInformation" /></Headline>}
     onToggle={onToggle}
     open={expanded}
   >

--- a/src/components/ViewSections/ProxyPermissions/ProxyPermissions.js
+++ b/src/components/ViewSections/ProxyPermissions/ProxyPermissions.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   Badge,
   Accordion,
+  Headline
 } from '@folio/stripes/components';
 
 import ProxyViewList from '../../ProxyGroup/ProxyViewList';
@@ -25,7 +26,7 @@ const ProxyPermissions = (props) => {
       displayWhenClosed={
         <Badge>{proxies.length + sponsors.length}</Badge>
       }
-      label={proxySponsor}
+      label={<Headline size="large" tag="h3">{proxySponsor}</Headline>}
     >
       <ProxyViewList records={sponsors} stripes={stripes} label={isProxyFor} name="sponsors" itemComponent={ProxyItem} />
       <ProxyViewList records={proxies} stripes={stripes} label={isSponsorOf} name="proxies" itemComponent={ProxyItem} />

--- a/src/components/ViewSections/UserAccounts/UserAccounts.js
+++ b/src/components/ViewSections/UserAccounts/UserAccounts.js
@@ -10,6 +10,7 @@ import {
   Accordion,
   Icon,
   List,
+  Headline
 } from '@folio/stripes/components';
 
 /**
@@ -121,7 +122,7 @@ class UserAccounts extends React.Component {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={<FormattedMessage id="ui-users.accounts.title" />}
+        label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.accounts.title" /></Headline>}
         displayWhenClosed={displayWhenClosed}
         displayWhenOpen={displayWhenOpen}
       >

--- a/src/components/ViewSections/UserInfo/UserInfo.js
+++ b/src/components/ViewSections/UserInfo/UserInfo.js
@@ -6,6 +6,7 @@ import {
   Col,
   KeyValue,
   Accordion,
+  Headline
 } from '@folio/stripes/components';
 
 import { ViewMetaData } from '@folio/stripes/smart-components';
@@ -37,7 +38,7 @@ class UserInfo extends React.Component {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={intl.formatMessage({ id: 'ui-users.information.userInformation' })}
+        label={<Headline size="large" tag="h3">{intl.formatMessage({ id: 'ui-users.information.userInformation' })}</Headline>}
       >
         <Row>
           <Col xs={12}>

--- a/src/components/ViewSections/UserLoans/UserLoans.js
+++ b/src/components/ViewSections/UserLoans/UserLoans.js
@@ -9,6 +9,7 @@ import {
   Accordion,
   List,
   Icon,
+  Headline
 } from '@folio/stripes/components';
 
 /**
@@ -82,7 +83,7 @@ class UserLoans extends React.Component {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={<FormattedMessage id="ui-users.loans.title" />}
+        label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.loans.title" /></Headline>}
         displayWhenClosed={displayWhenClosed}
       >
         {loansLoaded ?

--- a/src/components/ViewSections/UserServicePoints/UserServicePoints.js
+++ b/src/components/ViewSections/UserServicePoints/UserServicePoints.js
@@ -4,7 +4,8 @@ import {
   Accordion,
   Badge,
   KeyValue,
-  List
+  List,
+  Headline
 } from '@folio/stripes/components';
 
 class UserServicePoints extends React.Component {
@@ -65,7 +66,7 @@ class UserServicePoints extends React.Component {
       <Accordion
         displayWhenClosed={<Badge>{this.props.servicePoints.length}</Badge>}
         id={this.props.accordionId}
-        label={this.props.stripes.intl.formatMessage({ id: 'ui-users.sp.servicePoints' })}
+        label={<Headline size="large" tag="h3">{this.props.stripes.intl.formatMessage({ id: 'ui-users.sp.servicePoints' })}</Headline>}
         onToggle={this.props.onToggle}
         open={this.props.expanded}
       >

--- a/src/settings/permissions/PermissionSetDetails.js
+++ b/src/settings/permissions/PermissionSetDetails.js
@@ -7,6 +7,7 @@ import {
   Col,
   Accordion,
   ExpandAllButton,
+  Headline
 } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 
@@ -66,7 +67,7 @@ class PermissionSetDetails extends React.Component {
           open={sections.generalInformation}
           id="generalInformation"
           onToggle={this.handleSectionToggle}
-          label={this.props.stripes.intl.formatMessage({ id: 'ui-users.permissions.generalInformation' })}
+          label={<Headline size="large" tag="h3">{this.props.stripes.intl.formatMessage({ id: 'ui-users.permissions.generalInformation' })}</Headline>}
         >
           {selectedSet.metadata && selectedSet.metadata.createdDate &&
             <Row>

--- a/src/settings/permissions/PermissionSetForm.js
+++ b/src/settings/permissions/PermissionSetForm.js
@@ -17,6 +17,7 @@ import {
   Col,
   IfPermission,
   ConfirmationModal,
+  Headline
 } from '@folio/stripes/components';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 
@@ -188,7 +189,7 @@ class PermissionSetForm extends React.Component {
               open={sections.generalSection}
               id="generalSection"
               onToggle={this.handleSectionToggle}
-              label={intl.formatMessage({ id: 'ui-users.permissions.generalInformation' })}
+              label={<Headline size="large" tag="h3">{intl.formatMessage({ id: 'ui-users.permissions.generalInformation' })}</Headline>}
             >
               {selectedSet.metadata && selectedSet.metadata.createdDate &&
                 <Row>


### PR DESCRIPTION
Adjusts accordion headline sizes for correct a11y and visual hierarchy.

### Before

![folio-testing aws indexdata com_users_view_bf953133-5221-4983-a6f1-19c2ef64b31d_query e sort name pixel 2](https://user-images.githubusercontent.com/230597/46698443-bd103600-cbdc-11e8-8032-893daaa88cf8.png)


### After
_includes change from https://github.com/folio-org/ui-users/pull/529_

![localhost_3000_users_view_bf953133-5221-4983-a6f1-19c2ef64b31d_query e sort name pixel 2](https://user-images.githubusercontent.com/230597/46698438-baaddc00-cbdc-11e8-9389-26bc8a087fb0.png)

