### PR TITLE
create renew-by-id permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Change history for ui-users
+
+## 2.18.0 (IN PROGRESS)
+
+* Create permission for renewing loans. Fixes UIU-625.
+
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)
 

--- a/package.json
+++ b/package.json
@@ -425,6 +425,18 @@
         "subPermissions": [
           "ui-users.settings.transfertypes"
         ]
+      },
+      {
+        "permissionName": "ui-users.loans.renew",
+        "displayName": "Loans: Renew loans",
+        "description": "Also includes basic permissions to view users",
+        "subPermissions": [
+          "ui-users.view",
+          "circulation.loans.collection.get",
+          "circulation.loans.item.get",
+          "circulation.renew-by-id.post"
+        ],
+        "visible": true
       }
     ]
   },


### PR DESCRIPTION
Create a grantable permission that allows users to renew loans by
user-id and loan-id, and that also includes basic permissions to view
users.

Fixes [UIU-625](https://issues.folio.org/browse/UIU-625)