### PR TITLE
specify sort for patron groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Adjust accordion headline sizes for correct a11y and visual hierarchy
 * Load proxies/sponsors on initial load. Fixes UIU-661.
 * Restore element id for password-toggle to simplify testing. Refs UITEST-55.
+* Specify a sort field to `<ControlledVocab>` for patron groups. Refs STSMACOM-139.
 
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)

--- a/src/settings/PatronGroupsSettings.js
+++ b/src/settings/PatronGroupsSettings.js
@@ -61,6 +61,7 @@ class PatronGroupsSettings extends React.Component {
         formatter={formatter}
         nameKey="group"
         id="patrongroups"
+        sortby="group"
       />
     );
   }


### PR DESCRIPTION
The default sort field in `<ControlledVocab>` is `name`, but patron
groups don't have a `name` field, so we specify the field they do have
instead.

Refs [STSMACOM-139](https://issues.folio.org/browse/STSMACOM-139)