### PR TITLE
specify sortby for entries without `name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Load proxies/sponsors on initial load. Fixes UIU-661.
 * Restore element id for password-toggle to simplify testing. Refs UITEST-55.
 * Add permissions for renewing loans. Fixes UIU-686.
-* Specify a sort field to `<ControlledVocab>` for patron groups. Refs STSMACOM-139.
+* Specify a sort field to `<ControlledVocab>` for entries without a `name` field. Refs STSMACOM-139.
 
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)

--- a/src/settings/AddressTypesSettings.js
+++ b/src/settings/AddressTypesSettings.js
@@ -31,6 +31,7 @@ class AddressTypesSettings extends React.Component {
         }}
         nameKey="addressType"
         id="addresstypes"
+        sortby="addressType"
       />
     );
   }

--- a/src/settings/OwnerSettings.js
+++ b/src/settings/OwnerSettings.js
@@ -36,6 +36,7 @@ class OwnerSettings extends React.Component {
         }}
         nameKey="ownerType"
         id="ownerstypes"
+        sortby="owner"
       />
     );
   }

--- a/src/settings/PaymentSettings.js
+++ b/src/settings/PaymentSettings.js
@@ -60,6 +60,7 @@ class PaymentSettings extends React.Component {
         nameKey="paymentMethods"
         hiddenFields={['numberOfObjects']}
         id="payments"
+        sortby="nameMethod"
       />
     );
   }

--- a/src/settings/RefundReasonsSettings.js
+++ b/src/settings/RefundReasonsSettings.js
@@ -36,6 +36,7 @@ class RefundReasonsSettings extends React.Component {
         nameKey="refund"
         hiddenFields={['numberOfObjects']}
         id="refunds"
+        sortby="nameReason"
       />
     );
   }

--- a/src/settings/WaiveSettings.js
+++ b/src/settings/WaiveSettings.js
@@ -36,6 +36,7 @@ class WaiveSettings extends React.Component {
         nameKey="waiveReasons"
         hiddenFields={['numberOfObjects']}
         id="waives"
+        sortby="nameReason"
       />
     );
   }


### PR DESCRIPTION
The default sort field in `<ControlledVocab>` is name, but many
entries don't have a `name` field, so we specify the field they do have
instead.

Refs [STSMACOM-139](https://issues.folio.org/browse/STSMACOM-139)