### PR TITLE
provide totalCount to MCL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Implement default Fee/Fine Owner for user. Ref UIU-610.
 * Implement associate Fee/Fine Owners to one or more Service Points. Ref UIU-611.
 * Implement permission for CRUD Manual Patron Block. Ref UIU-674.
+* Provide `totalCount` to loan MCLs.
 
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)

--- a/src/components/Loans/ClosedLoans/ClosedLoans.js
+++ b/src/components/Loans/ClosedLoans/ClosedLoans.js
@@ -308,6 +308,7 @@ class ClosedLoans extends React.Component {
           sortOrder={sortOrder[0]}
           sortDirection={`${sortDirection[0]}ending`}
           onRowClick={this.props.onClickViewLoanActionsHistory}
+          totalCount={loans.length}
         />
       </div>
     );

--- a/src/components/Loans/OpenLoans/OpenLoans.js
+++ b/src/components/Loans/OpenLoans/OpenLoans.js
@@ -755,6 +755,7 @@ class OpenLoans extends React.Component {
           sortOrder={sortOrder[0]}
           sortDirection={`${sortDirection[0]}ending`}
           contentData={loans}
+          totalCount={loans.length}
         />
         { this.renderBulkRenewalDialog() }
         { this.renderChangeDueDateDialog() }


### PR DESCRIPTION
Provide the `totalCount` prop to `<MultiColumnList>` so we can hang
tests off whether the table is populated.