### PR TITLE
provide necessary typehint to Checkbox

### DIFF
--- a/src/settings/ProfilePictureSettings.js
+++ b/src/settings/ProfilePictureSettings.js
@@ -40,6 +40,7 @@ class ProfilePictureSettings extends React.Component {
           <Col xs={12}>
             <Field
               component={Checkbox}
+              type="checkbox"
               id="profile_pictures"
               name="profile_pictures"
               label={this.props.stripes.intl.formatMessage({ id: 'ui-users.information.profile.label' })}


### PR DESCRIPTION
`<Checkbox>` needs the `type="checkbox"` typehint to kick it into
boolean mode and treat `value` correctly. I think.