### PR TITLE
use the "status" formatter for the "active" attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Implement permission for CRUD Manual Patron Block. Ref UIU-674.
 * Provide `totalCount` to loan MCLs.
 * Support circulation v5.0, requiring service-point information on loans. Refs UIU-717.
+* Format the `active` attribute as `Status` on the find-proxy modal. Fixes UIU-726.
 
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)

--- a/src/components/ProxyGroup/ProxyEditList/ProxyEditList.js
+++ b/src/components/ProxyGroup/ProxyEditList/ProxyEditList.js
@@ -139,7 +139,7 @@ export default class ProxyEditList extends React.Component {
                 }
                 searchButtonStyle="default"
                 selectUser={user => this.onAdd(user)}
-                visibleColumns={['active', 'name', 'patronGroup', 'username', 'barcode']}
+                visibleColumns={['status', 'name', 'patronGroup', 'username', 'barcode']}
                 columnMapping={columnMapping}
                 disableRecordCreation={disableRecordCreation}
               >


### PR DESCRIPTION
`active` is the attribute on the user-object, but the formatter for this
field is named `status` because, um, I don't remember why but that's what
it's called now. So the `<Pluggable>` needs to ask for `status` rather
than `active` for that data to be correctly formatted in the modal.

Fixes [UIU-726](https://issues.folio.org/browse/UIU-726)