### PR TITLE
allow PropTypes.node for easier i18n

### DIFF
--- a/src/components/ProxyGroup/ProxyViewList/ProxyViewList.js
+++ b/src/components/ProxyGroup/ProxyViewList/ProxyViewList.js
@@ -25,7 +25,7 @@ ProxyViewList.propTypes = {
   records: PropTypes.arrayOf(PropTypes.object),
   itemComponent: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
   stripes: PropTypes.object.isRequired,
 };
 

--- a/src/components/RenderPermissions/RenderPermissions.js
+++ b/src/components/RenderPermissions/RenderPermissions.js
@@ -11,7 +11,7 @@ import {
 
 class RenderPermissions extends React.Component {
   static propTypes = {
-    heading: PropTypes.string.isRequired,
+    heading: PropTypes.node.isRequired,
     permToRead: PropTypes.string.isRequired,
     listedPermissions: PropTypes.arrayOf(PropTypes.object),
     stripes: PropTypes.shape({


### PR DESCRIPTION
Allow `PropTypes.node` instead of the more restrictive
`PropTypes.string` for labels that may be passed as `<FormattedMessage>`
objects.