### PR TITLE
do not translate patron group names

### DIFF
--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -41,9 +41,7 @@ class EditUserInfo extends React.Component {
     } = this.props;
     const patronGroups = (parentResources.patronGroups || {}).records || [];
     const patronGroupOptions = (patronGroups).map(g => (
-      <FormattedMessage key={g.id} id={g.group.concat(g.desc ? ` (${g.desc})` : '')}>
-        {(message) => <option value={g.id}>{message}</option>}
-      </FormattedMessage>
+      <option key={g.id} value={g.id}>{g.group.concat(g.desc ? ` (${g.desc})` : '')}</option>
     ));
     const isUserExpired = () => {
       const expirationDate = new Date(initialValues.expirationDate);


### PR DESCRIPTION
Patron group names are runtime configuration values, not hard-coded
strings, hence they should not be translated. Translation was
inadvertently added in #574 as part of the general refactoring to use
better `react-intl` patterns. This reverts the patron group translation
portion of that work.

Refs [UIU-679](https://issues.folio.org/browse/UIU-679)