### PR TITLE
don't use FormattedMessage for options

### DIFF
--- a/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.js
+++ b/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.js
@@ -2,8 +2,6 @@ import React from 'react';
 import {
   FormattedMessage,
   FormattedTime,
-  injectIntl,
-  intlShape
 } from 'react-intl';
 import moment from 'moment'; // eslint-disable-line import/no-extraneous-dependencies
 import {
@@ -34,7 +32,6 @@ import css from './ProxyEditItem.css';
 class ProxyEditItem extends React.Component {
   static propTypes = {
     index: PropTypes.number,
-    intl: intlShape,
     record: PropTypes.object,
     namespace: PropTypes.string, // sponsors or proxies
     name: PropTypes.string,
@@ -134,33 +131,26 @@ class ProxyEditItem extends React.Component {
     return this.toggleStatus(true);
   }
 
+  optionsFor = (list) => {
+    return list.map(option => (
+      <FormattedMessage id={`ui-users.${option}`}>
+        {(optionTranslated) => <option value={option}>{optionTranslated}</option>}
+      </FormattedMessage>
+    ));
+  }
+
   render() {
     const {
       name,
       record,
       onDelete,
-      intl: { formatMessage }
     } = this.props;
 
-    const relationStatusOptions = ['active', 'inactive'].map(option => ({
-      label: formatMessage({ id: `ui-users.${option}` }),
-      value: option,
-      selected: record.proxy && record.proxy.status === option,
-    }));
+    const relationStatusOptions = this.optionsFor(['active', 'inactive']);
+    const requestForSponsorOptions = this.optionsFor(['yes', 'no']);
+    const notificationsToOptions = this.optionsFor(['proxy', 'sponsor']);
 
-    const requestForSponsorOptions = ['yes', 'no'].map(option => ({
-      label: formatMessage({ id: `ui-users.${option}` }),
-      value: option,
-      selected: record.proxy && record.proxy.requestForSponsor === option,
-    }));
-
-    const notificationsToOptions = ['proxy', 'sponsor'].map(option => ({
-      label: formatMessage({ id: `ui-users.${option}` }),
-      value: option,
-      selected: record.proxy && record.proxy.notificationsTo === option,
-    }));
-
-    // const accrueToOptions = proxySponsorValues.map(option => ({
+    // const accrueToOptions = this.optionsFor(['proxy', 'sponsor']);
     //   label: formatMessage({ id: `ui-users.${option}` }),
     //   value: option,
     //   selected: record.proxy && record.proxy.accrueTo === option
@@ -200,9 +190,10 @@ class ProxyEditItem extends React.Component {
                     label={<FormattedMessage id="ui-users.proxy.relationshipStatus" />}
                     name={`${name}.proxy.status`}
                     component={Select}
-                    dataOptions={[{ label: 'Select status', value: '' }, ...relationStatusOptions]}
                     fullWidth
-                  />
+                  >
+                    {relationStatusOptions}
+                  </Field>
                 </Col>
               </Row>
             </Col>
@@ -229,9 +220,10 @@ class ProxyEditItem extends React.Component {
                     label={<FormattedMessage id="ui-users.proxy.requestForSponsor" />}
                     name={`${name}.proxy.requestForSponsor`}
                     component={Select}
-                    dataOptions={[...requestForSponsorOptions]}
                     fullWidth
-                  />
+                  >
+                    {requestForSponsorOptions}
+                  </Field>
                 </Col>
               </Row>
             </Col>
@@ -242,9 +234,10 @@ class ProxyEditItem extends React.Component {
                     label={<FormattedMessage id="ui-users.proxy.notificationsTo" />}
                     name={`${name}.proxy.notificationsTo`}
                     component={Select}
-                    dataOptions={[...notificationsToOptions]}
                     fullWidth
-                  />
+                  >
+                    {notificationsToOptions}
+                  </Field>
                 </Col>
               </Row>
             </Col>
@@ -271,4 +264,4 @@ class ProxyEditItem extends React.Component {
   }
 }
 
-export default injectIntl(ProxyEditItem);
+export default ProxyEditItem;

--- a/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.js
+++ b/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.js
@@ -2,6 +2,8 @@ import React from 'react';
 import {
   FormattedMessage,
   FormattedTime,
+  injectIntl,
+  intlShape
 } from 'react-intl';
 import moment from 'moment'; // eslint-disable-line import/no-extraneous-dependencies
 import {
@@ -32,6 +34,7 @@ import css from './ProxyEditItem.css';
 class ProxyEditItem extends React.Component {
   static propTypes = {
     index: PropTypes.number,
+    intl: intlShape,
     record: PropTypes.object,
     namespace: PropTypes.string, // sponsors or proxies
     name: PropTypes.string,
@@ -136,43 +139,31 @@ class ProxyEditItem extends React.Component {
       name,
       record,
       onDelete,
+      intl: { formatMessage }
     } = this.props;
 
-    const relationStatusValues = [
-      <FormattedMessage id="ui-users.active" />,
-      <FormattedMessage id="ui-users.inactive" />,
-    ];
-    const proxySponsorValues = [
-      <FormattedMessage id="ui-users.sponsor" />,
-      <FormattedMessage id="ui-users.proxy" />,
-    ];
-    const yesNoValues = [
-      <FormattedMessage id="ui-users.yes" />,
-      <FormattedMessage id="ui-users.no" />,
-    ];
-
-    const relationStatusOptions = relationStatusValues.map(val => ({
-      label: val,
-      value: val,
-      selected: record.proxy && record.proxy.status === val
+    const relationStatusOptions = ['active', 'inactive'].map(option => ({
+      label: formatMessage({ id: `ui-users.${option}` }),
+      value: option,
+      selected: record.proxy && record.proxy.status === option,
     }));
 
-    const requestForSponsorOptions = yesNoValues.map(val => ({
-      label: val,
-      value: val,
-      selected: record.proxy && record.proxy.requestForSponsor === val
+    const requestForSponsorOptions = ['yes', 'no'].map(option => ({
+      label: formatMessage({ id: `ui-users.${option}` }),
+      value: option,
+      selected: record.proxy && record.proxy.requestForSponsor === option,
     }));
 
-    const notificationsToOptions = proxySponsorValues.map(val => ({
-      label: val,
-      value: val,
-      selected: record.proxy && record.proxy.notificationsTo === val
+    const notificationsToOptions = ['proxy', 'sponsor'].map(option => ({
+      label: formatMessage({ id: `ui-users.${option}` }),
+      value: option,
+      selected: record.proxy && record.proxy.notificationsTo === option,
     }));
 
-    // const accrueToOptions = proxySponsorValues.map(val => ({
-    //   label: val,
-    //   value: val,
-    //   selected: record.proxy && record.proxy.accrueTo === val
+    // const accrueToOptions = proxySponsorValues.map(option => ({
+    //   label: formatMessage({ id: `ui-users.${option}` }),
+    //   value: option,
+    //   selected: record.proxy && record.proxy.accrueTo === option
     // }));
     const proxyLinkMsg = <FormattedMessage id="ui-users.proxy.relationshipCreated" />;
     const proxyCreatedDate = <FormattedTime
@@ -280,4 +271,4 @@ class ProxyEditItem extends React.Component {
   }
 }
 
-export default ProxyEditItem;
+export default injectIntl(ProxyEditItem);


### PR DESCRIPTION
The label for an `<option>` must be a string so we need to use
`formatMessage()` instead of `<FormattedMessage>`. This reverts that
portion of the work in #574.

Additionally, it sets the values for the `<option>`s in the
proxy-related fields to hard-coded strings consistent with the immutable
values on the backend.

Fixes [UIU-736](https://issues.folio.org/browse/UIU-736)