### PR TITLE
correctly display proxy/sponsor relationship date

### DIFF
--- a/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.js
+++ b/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.js
@@ -175,8 +175,9 @@ class ProxyEditItem extends React.Component {
     //   selected: record.proxy && record.proxy.accrueTo === val
     // }));
     const proxyLinkMsg = <FormattedMessage id="ui-users.proxy.relationshipCreated" />;
+    const proxyCreatedValue = get(record, 'proxy.metadata.createdDate', null);
     const proxyCreatedDate = <FormattedTime
-      value={get(record, 'proxy.metadata.createdDate', null)}
+      value={proxyCreatedValue}
       day="numeric"
       month="numeric"
       year="numeric"
@@ -184,7 +185,7 @@ class ProxyEditItem extends React.Component {
     const proxyLink = (
       <div>
         <Link to={`/users/view/${record.user.id}`}>{getFullName(record.user)}</Link>
-        {proxyCreatedDate && (
+        {proxyCreatedValue && (
           <span className={css.creationLabel}>
             (
               {proxyLinkMsg}


### PR DESCRIPTION
When a proxy or sponsor is newly-added, the `proxy.metadata.createdDate`
field is empty. Sending `null` to `<FormattedTime>` results in a display
corresponding to the start of the unix epoch, midnight on 1970-01-01
whereas `stripes.formatDateTime` returned an empty string. This change uses
`<FormattedTime>` but correctly checks the value of the field before
displaying it, fixing the bug introduced in #574.

Refs [UIU-679](https://issues.folio.org/browse/UIU-679)