### PR TITLE
I18n-friendly shortcuts

### DIFF
--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -152,12 +152,12 @@ class UserForm extends React.Component {
       {
         name: 'expandAllSections',
         handler: this.expandAllSections,
-        shortcut: 'mod+['
+        shortcut: 'mod+alt+b'
       },
       {
         name: 'collapseAllSections',
         handler: this.collapseAllSections,
-        shortcut: 'mod+]'
+        shortcut: 'mod+alt+g'
       }
     ];
 

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -231,12 +231,12 @@ class ViewUser extends React.Component {
     {
       name: 'collapseAllSections',
       handler: this.collapseAllSections,
-      shortcut: 'mod+]'
+      shortcut: 'mod+alt+g'
     },
     {
       name: 'expandAllSections',
       handler: this.expandAllSections,
-      shortcut: 'mod+['
+      shortcut: 'mod+alt+b'
     },
     ];
   }


### PR DESCRIPTION
Turns out that `[` and `]` aren't so friendly to foreign keyboards since the `alt` key must be pressed to access them. This can also confuse javascript since bracket key will always have the `alt` key pressed (it may assume it's a different, unhandled shortcut.)
