### PR TITLE
Bring back handleSubmit when using submit button. Fixes UIU-743

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix relationship created message. Fixes UIU-730.
 * Add sort by name to initial query resource. Fixes UIU-733.
 * Link to a user's requests. Fixes UIU-677.
+* Bring back handleSubmit when using submit button. Fixes UIU-743.
 
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -131,7 +131,6 @@ class UserForm extends React.Component {
     this.expandAllSections = this.expandAllSections.bind(this);
 
     this.ignoreEnterKey = this.ignoreEnterKey.bind(this);
-    this.executeSave = this.executeSave.bind(this);
     this.closeButton = React.createRef();
 
     this.keyboardCommands = [
@@ -256,6 +255,7 @@ class UserForm extends React.Component {
   render() {
     const {
       initialValues,
+      handleSubmit,
     } = this.props;
     const { sections } = this.state;
     const firstMenu = this.getAddFirstMenu();
@@ -268,7 +268,7 @@ class UserForm extends React.Component {
 
     return (
       <HasCommand commands={this.keyboardCommands}>
-        <form className={css.UserFormRoot} id="form-user" onSubmit={this.executeSave}>
+        <form className={css.UserFormRoot} id="form-user" onSubmit={handleSubmit}>
           <Paneset isRoot>
             <Pane defaultWidth="100%" firstMenu={firstMenu} lastMenu={lastMenu} paneTitle={paneTitle} appIcon={{ app: 'users' }}>
               <div className={css.UserFormContent}>


### PR DESCRIPTION
The work on shortcuts created a regression:
https://issues.folio.org/browse/UIU-743

This PR brings back the handleSubmit from redux-form while submitting the form via regular submit button.