### PR TITLE
let strings be strings

### DIFF
--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -171,17 +171,19 @@ class UserForm extends React.Component {
   }
 
   getAddFirstMenu() {
-    const label = <FormattedMessage id="ui-users.crud.closeNewUserDialog" />;
     return (
       <PaneMenu>
-        <IconButton
-          id="clickable-closenewuserdialog"
-          onClick={this.props.onCancel}
-          ref={this.closeButton}
-          title={label}
-          ariaLabel={label}
-          icon="closeX"
-        />
+        <FormattedMessage id="ui-users.crud.closeNewUserDialog">
+          { ariaLabel => (
+            <IconButton
+              id="clickable-closenewuserdialog"
+              onClick={this.props.onCancel}
+              ref={this.closeButton}
+              ariaLabel={ariaLabel}
+              icon="closeX"
+            />
+          )}
+        </FormattedMessage>
       </PaneMenu>
     );
   }
@@ -194,7 +196,6 @@ class UserForm extends React.Component {
         <Button
           id={id}
           type="submit"
-          title={label}
           disabled={pristine || submitting}
           buttonStyle="primary paneHeaderNewButton"
           marginBottom0

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -559,25 +559,33 @@ class ViewUser extends React.Component {
       (
         <PaneMenu>
           {
-            tagsEnabled && <IconButton
-              icon="tag"
-              title={<FormattedMessage id="ui-users.showTags" />}
-              id="clickable-show-tags"
-              onClick={this.props.tagsToggle}
-              badgeCount={tags.length}
-              aria-label={<FormattedMessage id="ui-users.showTags" />}
-            />
+            tagsEnabled &&
+            <FormattedMessage id="ui-users.showTags">
+              { ariaLabel => (
+                <IconButton
+                  icon="tag"
+                  id="clickable-show-tags"
+                  onClick={this.props.tagsToggle}
+                  badgeCount={tags.length}
+                  aria-label={ariaLabel}
+                />
+              )}
+            </FormattedMessage>
           }
           <IfPermission perm="users.item.put">
-            <IconButton
-              icon="edit"
-              id="clickable-edituser"
-              style={{ visibility: !user ? 'hidden' : 'visible' }}
-              onClick={this.props.onEdit}
-              href={this.props.editLink}
-              ref={this.editButton}
-              aria-label={<FormattedMessage id="ui-users.crud.editUser" />}
-            />
+            <FormattedMessage id="ui-users.crud.editUser">
+              { ariaLabel => (
+                <IconButton
+                  icon="edit"
+                  id="clickable-edituser"
+                  style={{ visibility: !user ? 'hidden' : 'visible' }}
+                  onClick={this.props.onEdit}
+                  href={this.props.editLink}
+                  ref={this.editButton}
+                  aria-label={ariaLabel}
+                />
+              )}
+            </FormattedMessage>
           </IfPermission>
         </PaneMenu>
       );
@@ -766,24 +774,27 @@ class ViewUser extends React.Component {
               </IfInterface>
             </IfPermission>
           </AccordionSet>
-          <Layer
-            isOpen={query.layer ? query.layer === 'edit' : false}
-            contentLabel={<FormattedMessage id="ui-users.editUserDialog" />}
-            afterClose={this.afterCloseEdit}
-          >
-            <UserForm
-              stripes={stripes}
-              initialValues={userFormData}
-              onSubmit={(record) => { this.update(record); }}
-              onCancel={this.props.onCloseEdit}
-              parentResources={{
-                ...this.props.resources,
-                ...this.props.parentResources,
-              }}
-              parentMutator={this.props.parentMutator}
-            />
-          </Layer>
-
+          <FormattedMessage id="ui-users.editUserDialog">
+            { contentLabel => (
+              <Layer
+                isOpen={query.layer ? query.layer === 'edit' : false}
+                contentLabel={contentLabel}
+                afterClose={this.afterCloseEdit}
+              >
+                <UserForm
+                  stripes={stripes}
+                  initialValues={userFormData}
+                  onSubmit={(record) => { this.update(record); }}
+                  onCancel={this.props.onCloseEdit}
+                  parentResources={{
+                    ...this.props.resources,
+                    ...this.props.parentResources,
+                  }}
+                  parentMutator={this.props.parentMutator}
+                />
+              </Layer>
+            )}
+          </FormattedMessage>
           <Layer
             isOpen={query.layer ? query.layer === 'open-accounts' || query.layer === 'closed-accounts' || query.layer === 'all-accounts' : false}
             label={<FormattedMessage id="ui-users.accounts.title" />}
@@ -836,19 +847,27 @@ class ViewUser extends React.Component {
           </Layer>
 
           <IfPermission perm="ui-users.loans.all">
-            <Layer
-              isOpen={query.layer ? query.layer === 'open-loans' || query.layer === 'closed-loans' : false}
-              contentLabel={<FormattedMessage id="ui-users.loans.title" />}
-            >
-              {loansHistory}
-            </Layer>
+            <FormattedMessage id="ui-users.loans.title">
+              { contentLabel => (
+                <Layer
+                  isOpen={query.layer ? query.layer === 'open-loans' || query.layer === 'closed-loans' : false}
+                  contentLabel={contentLabel}
+                >
+                  {loansHistory}
+                </Layer>
+              )}
+            </FormattedMessage>
 
-            <Layer
-              isOpen={query.layer ? query.layer === 'loan' : false}
-              contentLabel={<FormattedMessage id="ui-users.loanActionsHistory" />}
-            >
-              {loanDetails}
-            </Layer>
+            <FormattedMessage id="ui-users.loanActionsHistory">
+              { contentLabel => (
+                <Layer
+                  isOpen={query.layer ? query.layer === 'loan' : false}
+                  contentLabel={contentLabel}
+                >
+                  {loanDetails}
+                </Layer>
+              )}
+            </FormattedMessage>
           </IfPermission>
         </Pane>
       </HasCommand>

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -567,7 +567,7 @@ class ViewUser extends React.Component {
                   id="clickable-show-tags"
                   onClick={this.props.tagsToggle}
                   badgeCount={tags.length}
-                  aria-label={ariaLabel}
+                  ariaLabel={ariaLabel}
                 />
               )}
             </FormattedMessage>
@@ -582,7 +582,7 @@ class ViewUser extends React.Component {
                   onClick={this.props.onEdit}
                   href={this.props.editLink}
                   ref={this.editButton}
-                  aria-label={ariaLabel}
+                  ariaLabel={ariaLabel}
                 />
               )}
             </FormattedMessage>

--- a/src/components/EditSections/EditProxy/EditProxy.js
+++ b/src/components/EditSections/EditProxy/EditProxy.js
@@ -25,8 +25,6 @@ const EditProxy = (props) => {
   } = initialValues;
   const fullName = getFullName(initialValues);
 
-  const isProxyFor = <FormattedMessage id="ui-users.permissions.isProxyFor" values={{ name: fullName }} />;
-  const isSponsorOf = <FormattedMessage id="ui-users.permissions.isSponsorOf" values={{ name: fullName }} />;
   const proxySponsor = <FormattedMessage id="ui-users.permissions.proxySponsor" />;
 
   return (
@@ -40,9 +38,17 @@ const EditProxy = (props) => {
           <Badge>{sponsors.length + proxies.length}</Badge>
         }
       >
-        <ProxyEditList itemComponent={ProxyEditItem} label={isProxyFor} name="sponsors" {...props} />
+        <FormattedMessage id="ui-users.permissions.isProxyFor" values={{ name: fullName }}>
+          { label => (
+            <ProxyEditList itemComponent={ProxyEditItem} label={label} name="sponsors" {...props} />
+          )}
+        </FormattedMessage>
         <br />
-        <ProxyEditList itemComponent={ProxyEditItem} label={isSponsorOf} name="proxies" {...props} />
+        <FormattedMessage id="ui-users.permissions.isSponsorOf" values={{ name: fullName }}>
+          { label => (
+            <ProxyEditList itemComponent={ProxyEditItem} label={label} name="proxies" {...props} />
+          )}
+        </FormattedMessage>
         <br />
       </Accordion>
     </IfPermission>

--- a/src/components/EditablePermissions/EditablePermissions.js
+++ b/src/components/EditablePermissions/EditablePermissions.js
@@ -138,7 +138,7 @@ class EditablePermissions extends React.Component {
   }
 
   render() {
-    const { accordionId, expanded, onToggle, initialValues } = this.props;
+    const { accordionId, expanded, onToggle, initialValues, intl: { formatMessage } } = this.props;
 
     const permissions = (initialValues || {}).subPermissions || [];
 
@@ -169,7 +169,7 @@ class EditablePermissions extends React.Component {
           <DropdownMenu
             data-role="menu"
             width="40em"
-            aria-label={this.props.intl.formatMessage({ id: 'ui-users.permissions.availablePermissions' })}
+            aria-label={formatMessage({ id: 'ui-users.permissions.availablePermissions' })}
             onToggle={this.onToggleAddPermDD}
           >
             {permissionsDD}

--- a/src/components/EditablePermissions/EditablePermissions.js
+++ b/src/components/EditablePermissions/EditablePermissions.js
@@ -1,6 +1,10 @@
 import _ from 'lodash';
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  injectIntl,
+  intlShape
+} from 'react-intl';
 import PropTypes from 'prop-types';
 import { FieldArray } from 'redux-form';
 import {
@@ -26,6 +30,7 @@ class EditablePermissions extends React.Component {
     permToModify: PropTypes.string.isRequired,
     availablePermissions: PropTypes.arrayOf(PropTypes.object),
     initialValues: PropTypes.object,
+    intl: intlShape,
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
       config: PropTypes.shape({
@@ -164,7 +169,7 @@ class EditablePermissions extends React.Component {
           <DropdownMenu
             data-role="menu"
             width="40em"
-            aria-label={<FormattedMessage id="ui-users.permissions.availablePermissions" />}
+            aria-label={this.props.intl.formatMessage({ id: 'ui-users.permissions.availablePermissions' })}
             onToggle={this.onToggleAddPermDD}
           >
             {permissionsDD}
@@ -190,4 +195,4 @@ class EditablePermissions extends React.Component {
   }
 }
 
-export default EditablePermissions;
+export default injectIntl(EditablePermissions);

--- a/src/settings/permissions/PermissionSetForm.js
+++ b/src/settings/permissions/PermissionSetForm.js
@@ -63,12 +63,16 @@ class PermissionSetForm extends React.Component {
   addFirstMenu() {
     return (
       <PaneMenu>
-        <IconButton
-          id="clickable-close-permission-set"
-          onClick={this.props.onCancel}
-          icon="closeX"
-          aria-label={<FormattedMessage id="ui-users.permissions.closePermissionSetDialog" />}
-        />
+        <FormattedMessage id="ui-users.permissions.closePermissionSetDialog">
+          { ariaLabel => (
+            <IconButton
+              id="clickable-close-permission-set"
+              onClick={this.props.onCancel}
+              icon="closeX"
+              aria-label={ariaLabel}
+            />
+          )}
+        </FormattedMessage>
       </PaneMenu>
     );
   }

--- a/src/settings/permissions/PermissionSetForm.js
+++ b/src/settings/permissions/PermissionSetForm.js
@@ -69,7 +69,7 @@ class PermissionSetForm extends React.Component {
               id="clickable-close-permission-set"
               onClick={this.props.onCancel}
               icon="closeX"
-              aria-label={ariaLabel}
+              ariaLabel={ariaLabel}
             />
           )}
         </FormattedMessage>


### PR DESCRIPTION
Some attributes really need to be strings, not `<FormattedMessage>`s. Most of the time you can use a render prop to `<FormattedMessage>` to accomplish that, but not always, e.g. a `<DropdownMenu>` won't render correctly when coded that way so we have to fall back to `injectIntl` and `props.intl.formatMessage()`.