### PR TITLE
UIU-691: Apply internationalization to all hardcoded strings for Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Link to a user's requests. Fixes UIU-677.
 * Bring back handleSubmit when using submit button. Fixes UIU-743.
 * Fix permission menu after reopening. Fixes UIU-739.
+* Apply internationalization to all hardcoded strings for Settings. Fixes UIU-691.
 
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)

--- a/src/AccountActionsHistory.js
+++ b/src/AccountActionsHistory.js
@@ -3,11 +3,10 @@ import React from 'react';
 import {
   FormattedMessage,
   FormattedTime,
-  intlShape,
-  injectIntl,
 } from 'react-intl';
 import Link from 'react-router-dom/Link';
 import PropTypes from 'prop-types';
+
 import {
   Paneset,
   Pane,
@@ -17,8 +16,32 @@ import {
   KeyValue,
   MultiColumnList,
 } from '@folio/stripes/components';
+
 import { Actions } from './components/Accounts/Actions';
 import { getFullName } from './util';
+
+import css from './AccountsHistory.css';
+
+const columnWidths = {
+  'action': 250,
+  'amount': 100,
+  'balance': 100,
+  'transactioninfo': 200,
+  'created': 100,
+  'source': 200,
+  'comments': 700
+};
+
+const columns = [
+  'date',
+  'action',
+  'amount',
+  'balance',
+  'transactioninfo',
+  'created',
+  'source',
+  'comments',
+];
 
 class AccountActionsHistory extends React.Component {
   static manifest = Object.freeze({
@@ -62,13 +85,12 @@ class AccountActionsHistory extends React.Component {
     onCancel: PropTypes.func.isRequired,
     onClickViewLoanActionsHistory: PropTypes.func.isRequired,
     handleAddRecords: PropTypes.func.isRequired,
-    intl: intlShape.isRequired,
   };
 
   constructor(props) {
     super(props);
     const {
-      stripes : { connect },
+      stripes: { connect },
     } = props;
     this.onSort = this.onSort.bind(this);
     this.onChangeActions = this.onChangeActions.bind(this);
@@ -97,16 +119,7 @@ class AccountActionsHistory extends React.Component {
         comment: false,
         regular: false,
       },
-      sortOrder: [
-        'date',
-        'action',
-        'amount',
-        'balance',
-        'transactioninfo',
-        'created',
-        'source',
-        'comments',
-      ],
+      sortOrder: [...columns],
       sortDirection: ['desc', 'desc']
     };
   }
@@ -190,29 +203,28 @@ class AccountActionsHistory extends React.Component {
 
     const {
       onCancel,
-      intl,
     } = this.props;
+
     const account = _.get(this.props.resources, ['accountHistory', 'records', 0]) || this.props.account;
 
     const user = this.props.user;
     const patron = this.props.patronGroup;
 
     const columnMapping = {
-      date: intl.formatMessage({ id: 'ui-users.details.columns.date' }),
-      action: intl.formatMessage({ id: 'ui-users.details.columns.action' }),
-      amount: intl.formatMessage({ id: 'ui-users.details.columns.amount' }),
-      balance: intl.formatMessage({ id: 'ui-users.details.columns.balance' }),
-      transactioninfo: intl.formatMessage({ id: 'ui-users.details.columns.transactioninfo' }),
-      created: intl.formatMessage({ id: 'ui-users.details.columns.created' }),
-      source: intl.formatMessage({ id: 'ui-users.details.columns.source' }),
+      date: <FormattedMessage id="ui-users.details.columns.date" />,
+      action: <FormattedMessage id="ui-users.details.columns.action" />,
+      amount: <FormattedMessage id="ui-users.details.columns.amount" />,
+      balance: <FormattedMessage id="ui-users.details.columns.balance" />,
+      transactioninfo: <FormattedMessage id="ui-users.details.columns.transactioninfo" />,
+      created: <FormattedMessage id="ui-users.details.columns.created" />,
+      source: <FormattedMessage id="ui-users.details.columns.source" />,
       comments: (
-        <span>
+        <span className={css.commentsWrapper}>
           <FormattedMessage id="ui-users.details.columns.comments" />
           <Button
-            style={{ float: 'right', marginLeft: '50px' }}
+            buttonClass={css.buttonAddComment}
             onClick={this.comment}
           >
-            +
             <FormattedMessage id="ui-users.accounts.button.new" />
           </Button>
         </span>
@@ -253,11 +265,39 @@ class AccountActionsHistory extends React.Component {
         >
           <Row>
             <Col xs={12}>
-              <Button disabled={disabled} buttonStyle="primary" onClick={this.pay}><FormattedMessage id="ui-users.accounts.history.button.pay" /></Button>
-              <Button disabled={disabled} buttonStyle="primary" onClick={this.waive}><FormattedMessage id="ui-users.accounts.history.button.waive" /></Button>
-              <Button disabled buttonStyle="primary"><FormattedMessage id="ui-users.accounts.history.button.refund" /></Button>
-              <Button disabled buttonStyle="primary"><FormattedMessage id="ui-users.accounts.history.button.transfer" /></Button>
-              <Button disabled={disabled} buttonStyle="primary" onClick={this.error}><FormattedMessage id="ui-users.accounts.button.error" /></Button>
+              <Button
+                disabled={disabled}
+                buttonStyle="primary"
+                onClick={this.pay}
+              >
+                <FormattedMessage id="ui-users.accounts.history.button.pay" />
+              </Button>
+              <Button
+                disabled={disabled}
+                buttonStyle="primary"
+                onClick={this.waive}
+              >
+                <FormattedMessage id="ui-users.accounts.history.button.waive" />
+              </Button>
+              <Button
+                disabled
+                buttonStyle="primary"
+              >
+                <FormattedMessage id="ui-users.accounts.history.button.refund" />
+              </Button>
+              <Button
+                disabled
+                buttonStyle="primary"
+              >
+                <FormattedMessage id="ui-users.accounts.history.button.transfer" />
+              </Button>
+              <Button
+                disabled={disabled}
+                buttonStyle="primary"
+                onClick={this.error}
+              >
+                <FormattedMessage id="ui-users.accounts.button.error" />
+              </Button>
             </Col>
           </Row>
 
@@ -312,9 +352,16 @@ class AccountActionsHistory extends React.Component {
                 <KeyValue
                   label={<FormattedMessage id="ui-users.details.label.loanDetails" />}
                   value={(
-                    <button style={{ color: '#2b75bb' }} type="button" onClick={(e) => { this.props.onClickViewLoanActionsHistory(e, { id: loanId }); }}>
+                    <button
+                      buttonClass={css.buttonView}
+                      type="button"
+                      onClick={(e) => {
+                        this.props.onClickViewLoanActionsHistory(e, { id: loanId });
+                      }}
+                    >
                       <FormattedMessage id="ui-users.details.field.loan" />
-                    </button>)}
+                    </button>
+                  )}
                 />
                 :
                 <KeyValue
@@ -340,7 +387,13 @@ class AccountActionsHistory extends React.Component {
             <Col xs={1.5}>
               <KeyValue
                 label={<FormattedMessage id="ui-users.details.field.barcode" />}
-                value={<Link to={`/inventory/view/${_.get(account, ['itemId'], '')}?query=${_.get(account, ['itemId'], '')}`}>{_.get(account, ['barcode'], '-')}</Link>}
+                value={
+                  <Link
+                    to={`/inventory/view/${_.get(account, ['itemId'], '')}?query=${_.get(account, ['itemId'], '')}`}
+                  >
+                    {_.get(account, ['barcode'], '-')}
+                  </Link>
+                }
               />
             </Col>
             <Col xs={1.5}>
@@ -358,13 +411,27 @@ class AccountActionsHistory extends React.Component {
             <Col xs={1.5}>
               <KeyValue
                 label={<FormattedMessage id="ui-users.details.field.duedate" />}
-                value={<FormattedTime value={account.dueDate} day="numeric" month="numeric" year="numeric" /> || '-'}
+                value={
+                  <FormattedTime
+                    value={account.dueDate}
+                    day="numeric"
+                    month="numeric"
+                    year="numeric"
+                  /> || '-'
+                }
               />
             </Col>
             <Col xs={1.5}>
               <KeyValue
                 label={<FormattedMessage id="ui-users.details.field.returnedate" />}
-                value={<FormattedTime value={account.returnedDate} day="numeric" month="numeric" year="numeric" /> || '-'}
+                value={
+                  <FormattedTime
+                    value={account.returnedDate}
+                    day="numeric"
+                    month="numeric"
+                    year="numeric"
+                  /> || '-'
+                }
               />
             </Col>
           </Row>
@@ -373,22 +440,13 @@ class AccountActionsHistory extends React.Component {
             id="list-accountactions"
             formatter={accountActionsFormatter}
             columnMapping={columnMapping}
-            visibleColumns={[
-              'date',
-              'action',
-              'amount',
-              'balance',
-              'transactioninfo',
-              'created',
-              'source',
-              'comments',
-            ]}
+            visibleColumns={columns}
             contentData={(account.id === (actions[0] || {}).accountId) ? actionsSort : []}
             fullWidth
             onHeaderClick={this.onSort}
             sortOrder={sortOrder[0]}
             sortDirection={`${sortDirection[0]}ending`}
-            columnWidths={{ 'action': 250, 'amount': 100, 'balance': 100, 'transactioninfo': 200, 'created': 100, 'source': 200, 'comments': 700 }}
+            columnWidths={columnWidths}
           />
           <this.connectedActions
             actions={this.state.actions}
@@ -409,4 +467,4 @@ class AccountActionsHistory extends React.Component {
   }
 }
 
-export default injectIntl(AccountActionsHistory);
+export default AccountActionsHistory;

--- a/src/AccountActionsHistory.js
+++ b/src/AccountActionsHistory.js
@@ -23,13 +23,13 @@ import { getFullName } from './util';
 import css from './AccountsHistory.css';
 
 const columnWidths = {
-  'action': 250,
-  'amount': 100,
-  'balance': 100,
-  'transactioninfo': 200,
-  'created': 100,
-  'source': 200,
-  'comments': 700
+  action: 250,
+  amount: 100,
+  balance: 100,
+  transactioninfo: 200,
+  created: 100,
+  source: 200,
+  comments: 700
 };
 
 const columns = [
@@ -120,7 +120,7 @@ class AccountActionsHistory extends React.Component {
         regular: false,
       },
       sortOrder: [...columns],
-      sortDirection: ['desc', 'desc']
+      sortDirection: ['desc', 'desc'],
     };
   }
 
@@ -202,13 +202,16 @@ class AccountActionsHistory extends React.Component {
     } = this.state;
 
     const {
+      handleAddRecords,
       onCancel,
+      onClickViewLoanActionsHistory,
+      patronGroup: patron,
+      resources,
+      stripes,
+      user,
     } = this.props;
 
-    const account = _.get(this.props.resources, ['accountHistory', 'records', 0]) || this.props.account;
-
-    const user = this.props.user;
-    const patron = this.props.patronGroup;
+    const account = _.get(resources, ['accountHistory', 'records', 0]) || this.props.account;
 
     const columnMapping = {
       date: <FormattedMessage id="ui-users.details.columns.date" />,
@@ -222,7 +225,7 @@ class AccountActionsHistory extends React.Component {
         <span className={css.commentsWrapper}>
           <FormattedMessage id="ui-users.details.columns.comments" />
           <Button
-            buttonClass={css.buttonAddComment}
+            buttonClass={css.addCommentBtn}
             onClick={this.comment}
           >
             <FormattedMessage id="ui-users.accounts.button.new" />
@@ -249,6 +252,7 @@ class AccountActionsHistory extends React.Component {
     const remaining = (account.remaining) ? parseFloat(account.remaining).toFixed(2) : '0.00';
     const loanId = account.loanId || '';
     const disabled = (_.get(account, ['status', 'name'], '') === 'Closed');
+    const isAccountId = actions[0] && actions[0].accountId === account.id;
 
     return (
       <Paneset isRoot>
@@ -353,10 +357,10 @@ class AccountActionsHistory extends React.Component {
                   label={<FormattedMessage id="ui-users.details.label.loanDetails" />}
                   value={(
                     <button
-                      buttonClass={css.buttonView}
+                      buttonClass={css.btnView}
                       type="button"
                       onClick={(e) => {
-                        this.props.onClickViewLoanActionsHistory(e, { id: loanId });
+                        onClickViewLoanActionsHistory(e, { id: loanId });
                       }}
                     >
                       <FormattedMessage id="ui-users.details.field.loan" />
@@ -441,23 +445,23 @@ class AccountActionsHistory extends React.Component {
             formatter={accountActionsFormatter}
             columnMapping={columnMapping}
             visibleColumns={columns}
-            contentData={(account.id === (actions[0] || {}).accountId) ? actionsSort : []}
+            contentData={isAccountId ? actionsSort : []}
             fullWidth
-            onHeaderClick={this.onSort}
             sortOrder={sortOrder[0]}
             sortDirection={`${sortDirection[0]}ending`}
             columnWidths={columnWidths}
+            onHeaderClick={this.onSort}
           />
           <this.connectedActions
             actions={this.state.actions}
             onChangeActions={this.onChangeActions}
-            user={this.props.user}
-            stripes={this.props.stripes}
+            user={user}
+            stripes={stripes}
             balance={account.remaining || 0}
             accounts={[account]}
             handleEdit={() => {
               this.getAccountActions();
-              this.props.handleAddRecords();
+              handleAddRecords();
             }}
           />
 

--- a/src/AccountsHistory.css
+++ b/src/AccountsHistory.css
@@ -1,0 +1,16 @@
+@import "@folio/stripes-components/lib/variables";
+
+.commentsWrapper { 
+  display: flex; 
+  align-items: center;
+}
+
+.buttonView {
+  color: var(--primary);
+}
+
+.buttonAddComment {
+  float: right;
+  margin-left: 50px;
+  margin-bottom: 0;
+}

--- a/src/AccountsHistory.css
+++ b/src/AccountsHistory.css
@@ -5,11 +5,11 @@
   align-items: center;
 }
 
-.buttonView {
+.btnView {
   color: var(--primary);
 }
 
-.buttonAddComment {
+.addCommentBtn {
   float: right;
   margin-left: 50px;
   margin-bottom: 0;

--- a/src/AccountsHistory.js
+++ b/src/AccountsHistory.js
@@ -534,7 +534,10 @@ class AccountsHistory extends React.Component {
               <b>
                 <FormattedMessage
                   id="ui-users.accounts.header"
-                  values={{ userName: getFullName(user), patronGroup: _.upperFirst(patronGroup.group) }}
+                  values={{
+                    userName: getFullName(user),
+                    patronGroup: _.upperFirst(patronGroup.group),
+                  }}
                 />
               </b>
             </Col>

--- a/src/AccountsHistory.js
+++ b/src/AccountsHistory.js
@@ -7,6 +7,7 @@ import {
 } from 'react-intl';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
+
 import {
   Paneset,
   Pane,
@@ -28,7 +29,6 @@ import { getFullName } from './util';
 import { Actions } from './components/Accounts/Actions';
 import { count, handleFilterChange, handleFilterClear } from './components/Accounts/accountFunctions';
 
-
 import {
   Menu,
   Filters,
@@ -39,22 +39,22 @@ import {
 
 const filterConfig = [
   {
-    label: 'Fee/Fine Owner',
+    label: <FormattedMessage id="ui-users.feefines.ownerLabel" />,
     name: 'owner',
     cql: 'feeFineOwner',
     values: [],
   }, {
-    label: 'Payment Status',
+    label: <FormattedMessage id="ui-users.accounts.history.columns.status" />,
     name: 'status',
     cql: 'paymentStatus.name',
     values: [],
   }, {
-    label: 'Fee/Fine Type',
+    label: <FormattedMessage id="ui-users.details.field.feetype" />,
     name: 'type',
     cql: 'feeFineType',
     values: [],
   }, {
-    label: 'Item Type',
+    label: <FormattedMessage id="ui-users.details.field.type" />,
     name: 'material',
     cql: 'materialType',
     values: [],
@@ -74,6 +74,38 @@ const queryFunction = (findAll, queryTemplate, sortMap, fConfig, failOnCondition
     return cql;
   };
 };
+
+const controllableColumns = [
+  'created',
+  'updated',
+  'type',
+  'amount',
+  'remaining',
+  'status',
+  'owner',
+  'title',
+  'barcode',
+  'number',
+  'due',
+  'returned',
+];
+
+const possibleColumns = [
+  '  ',
+  'created',
+  'updated',
+  'type',
+  'amount',
+  'remaining',
+  'status',
+  'owner',
+  'title',
+  'barcode',
+  'number',
+  'due',
+  'returned',
+  ' ',
+];
 
 class AccountsHistory extends React.Component {
   static manifest = Object.freeze({
@@ -148,22 +180,7 @@ class AccountsHistory extends React.Component {
   constructor(props) {
     super(props);
 
-    this.controllableColumns = [
-      'created',
-      'updated',
-      'type',
-      'amount',
-      'remaining',
-      'status',
-      'owner',
-      'title',
-      'barcode',
-      'number',
-      'due',
-      'returned',
-    ];
-
-    const visibleColumns = this.controllableColumns.map(columnName => ({
+    const visibleColumns = controllableColumns.map(columnName => ({
       title: columnName,
       status: true,
     }));
@@ -204,22 +221,6 @@ class AccountsHistory extends React.Component {
     this.handleFilterChange = handleFilterChange.bind(this);
     this.handleFilterClear = handleFilterClear.bind(this);
     this.filterState = filterState.bind(this);
-    this.possibleColumns = [
-      '  ',
-      'created',
-      'updated',
-      'type',
-      'amount',
-      'remaining',
-      'status',
-      'owner',
-      'title',
-      'barcode',
-      'number',
-      'due',
-      'returned',
-      ' '
-    ];
     this.getVisibleColumns = this.getVisibleColumns.bind(this);
     this.renderCheckboxList = this.renderCheckboxList.bind(this);
     this.toggleColumn = this.toggleColumn.bind(this);
@@ -377,7 +378,7 @@ class AccountsHistory extends React.Component {
       return map;
     }, {});
 
-    const columnsToDisplay = this.possibleColumns.filter((e) => visibleColumnsMap[e] === undefined || visibleColumnsMap[e] === true);
+    const columnsToDisplay = possibleColumns.filter((e) => visibleColumnsMap[e] === undefined || visibleColumnsMap[e] === true);
     return columnsToDisplay;
   }
 
@@ -401,12 +402,15 @@ class AccountsHistory extends React.Component {
 
   render() {
     const {
+      onCancel,
+      location,
       user,
       patronGroup,
       resources,
       intl,
     } = this.props;
-    const query = this.props.location.search ? queryString.parse(this.props.location.search) : {};
+
+    const query = location.search ? queryString.parse(location.search) : {};
 
     let accounts = _.get(resources, ['feefineshistory', 'records'], []);
     if (query.loan) {
@@ -422,10 +426,22 @@ class AccountsHistory extends React.Component {
 
     const closeMenu = (
       <PaneMenu>
-        <button onClick={this.props.onCancel} type="button">
+        <button
+          onClick={onCancel}
+          type="button"
+        >
           <Row>
-            <Col><Icon icon="chevron-double-left" size="large" /></Col>
-            <Col><span style={{ fontSize: 'x-large' }}>Back</span></Col>
+            <Col>
+              <Icon
+                icon="chevron-double-left"
+                size="large"
+              />
+            </Col>
+            <Col>
+              <span style={{ fontSize: 'x-large' }}>
+                <FormattedMessage id="ui-users.accounts.cancellation.field.back" />
+              </span>
+            </Col>
           </Row>
         </button>
       </PaneMenu>
@@ -460,7 +476,12 @@ class AccountsHistory extends React.Component {
           group
           pullRight
         >
-          <Button data-role="toggle" bottomMargin2><FormattedMessage id="ui-users.accounts.history.button.select" /></Button>
+          <Button
+            data-role="toggle"
+            bottomMargin2
+          >
+            <FormattedMessage id="ui-users.accounts.history.button.select" />
+          </Button>
           <DropdownMenu data-role="menu">
             <ul>
               {this.renderCheckboxList(columnMapping)}
@@ -498,25 +519,31 @@ class AccountsHistory extends React.Component {
       balance += a.remaining;
     });
 
+    const outstandingBalance = (user.id === (accounts[0] || {}).userId)
+      ? parseFloat(balance || 0).toFixed(2)
+      : '0.00';
+
     const header1 = (
       <Row style={{ width: '80%' }}>
         <Col xs={7}>
-          {' '}
           {closeMenu}
-          {' '}
         </Col>
         <Col xs={4}>
           <Row>
             <Col>
-              <b>{`Fees/Fines - ${getFullName(user)} (${_.upperFirst(patronGroup.group)})`}</b>
+              <b>
+                <FormattedMessage
+                  id="ui-users.accounts.header"
+                  values={{ userName: getFullName(user), patronGroup: _.upperFirst(patronGroup.group) }}
+                />
+              </b>
             </Col>
           </Row>
           <Row>
             <Col>
               <div style={{ margin: '5px 5px 5px 40px' }}>
-              Outstanding Balance:
-                {' '}
-                { (user.id === (accounts[0] || {}).userId) ? parseFloat(balance || 0).toFixed(2) : '0.00'}
+                <FormattedMessage id="ui-users.accounts.outstandingBalance" />
+                {outstandingBalance}
               </div>
             </Col>
           </Row>
@@ -530,7 +557,7 @@ class AccountsHistory extends React.Component {
       <Paneset>
         <Pane
           defaultWidth="100%"
-          header={header1}
+          subheader={header1}
         >
           <Paneset>
             <Filters
@@ -545,7 +572,11 @@ class AccountsHistory extends React.Component {
               filters={filters}
               onChangeFilter={(e) => { this.handleFilterChange(e, 'f'); }}
             />
-            <Pane defaultWidth="fill" heigth="80%" header={header}>
+            <Pane
+              defaultWidth="fill"
+              heigth="80%"
+              subheader={header}
+            >
               <Menu
                 user={user}
                 showFilters={this.state.showFilters}
@@ -559,7 +590,6 @@ class AccountsHistory extends React.Component {
                 handleOptionsChange={this.handleOptionsChange}
                 onClickViewChargeFeeFine={this.props.onClickViewChargeFeeFine}
               />
-
               <Row>
                 {(query.layer === 'open-accounts') ?
                   (<this.connectedOpenAccounts

--- a/src/Users.js
+++ b/src/Users.js
@@ -23,7 +23,7 @@ const RESULT_COUNT_INCREMENT = 30;
 
 const filterConfig = [
   {
-    label: 'Status',
+    label: <FormattedMessage id="ui-users.status" />,
     name: 'active',
     cql: 'active',
     values: [
@@ -32,7 +32,7 @@ const filterConfig = [
     ],
   },
   {
-    label: 'Patron group',
+    label: <FormattedMessage id="ui-users.information.patronGroup" />,
     name: 'pg',
     cql: 'patronGroup',
     values: [], // will be filled in by componentWillUpdate
@@ -156,7 +156,7 @@ class Users extends React.Component {
 
   componentDidUpdate() {
     const pg = (this.props.resources.patronGroups || {}).records || [];
-    if (pg && pg.length) {
+    if (pg.length) {
       const pgFilterConfig = filterConfig.find(group => group.name === 'pg');
       const oldValuesLength = pgFilterConfig.values.length;
       pgFilterConfig.values = pg.map(rec => ({ name: rec.group, cql: rec.id }));
@@ -221,8 +221,8 @@ class Users extends React.Component {
       onComponentWillUnmount,
       showSingleResult,
       browseOnly,
-      intl,
     } = this.props;
+
     const patronGroups = (this.props.resources.patronGroups || {}).records || [];
 
     const resultsFormatter = {

--- a/src/Users.js
+++ b/src/Users.js
@@ -221,6 +221,7 @@ class Users extends React.Component {
       onComponentWillUnmount,
       showSingleResult,
       browseOnly,
+      intl,
     } = this.props;
 
     const patronGroups = (this.props.resources.patronGroups || {}).records || [];

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -398,7 +398,8 @@ class ViewUser extends React.Component {
   getUser() {
     const { resources, match: { params: { id } } } = this.props;
     const selUser = (resources.selUser || {}).records || [];
-    if (!selUser || selUser.length === 0 || !id) return null;
+
+    if (selUser.length === 0 || !id) return null;
     // Logging below shows this DOES sometimes find the wrong record. But why?
     // console.log(`getUser: found ${selUser.length} users, id '${selUser[0].id}' ${selUser[0].id === id ? '==' : '!='} '${id}'`);
     return selUser.find(u => u.id === id);
@@ -608,24 +609,25 @@ class ViewUser extends React.Component {
     const addresses = toListAddresses(get(user, ['personal', 'addresses'], []), addressTypes);
     const userFormData = this.getUserFormData(user, addresses, sponsors, proxies, permissions, servicePoints, preferredServicePoint);
 
-    const loansHistory = (<this.connectedLoansHistory
-      buildRecords={this.buildRecords}
-      user={user}
-      loansHistory={loans}
-      patronGroup={patronGroup}
-      stripes={stripes}
-      history={this.props.history}
-      onCancel={this.onClickCloseLoansHistory}
-      onClickViewOpenLoans={this.onClickViewOpenLoans}
-      onClickViewClosedLoans={this.onClickViewClosedLoans}
-      onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
-      onClickViewChargeFeeFine={this.onClickViewChargeFeeFine}
-      onClickViewOpenAccounts={this.onClickViewOpenAccounts}
-      onClickViewAccountActionsHistory={this.onClickViewAccountActionsHistory}
-      onClickViewClosedAccounts={this.onClickViewClosedAccounts}
-      onClickViewAllAccounts={this.onClickViewAllAccounts}
-      openLoans={query.layer === 'open-loans'}
-    />);
+    const loansHistory = (
+      <this.connectedLoansHistory
+        buildRecords={this.buildRecords}
+        user={user}
+        loansHistory={loans}
+        patronGroup={patronGroup}
+        stripes={stripes}
+        history={this.props.history}
+        onCancel={this.onClickCloseLoansHistory}
+        onClickViewOpenLoans={this.onClickViewOpenLoans}
+        onClickViewClosedLoans={this.onClickViewClosedLoans}
+        onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
+        onClickViewChargeFeeFine={this.onClickViewChargeFeeFine}
+        onClickViewOpenAccounts={this.onClickViewOpenAccounts}
+        onClickViewAccountActionsHistory={this.onClickViewAccountActionsHistory}
+        onClickViewClosedAccounts={this.onClickViewClosedAccounts}
+        onClickViewAllAccounts={this.onClickViewAllAccounts}
+        openLoans={query.layer === 'open-loans'}
+      />);
 
     const loanDetails = (
       <this.connectedLoanActionsHistory
@@ -815,7 +817,10 @@ class ViewUser extends React.Component {
               onClickCloseAccountActionsHistory={this.onClickCloseAccountActionsHistory}
             />
           </Layer>
-          <Layer isOpen={query.layer ? query.layer === 'charge' : false} label="Charge Fee/Fine">
+          <Layer
+            isOpen={query.layer ? query.layer === 'charge' : false}
+            label={<FormattedMessage id="ui-users.chargeFeefine" />}
+          >
             <this.connectedCharge
               servicePoints={servicePoints}
               preferredServicePoint={preferredServicePoint}
@@ -827,7 +832,10 @@ class ViewUser extends React.Component {
               handleAddRecords={this.handleAddRecords}
             />
           </Layer>
-          <Layer isOpen={query.layer ? query.layer === 'account' : false} label="Account Actions History">
+          <Layer
+            isOpen={query.layer ? query.layer === 'account' : false}
+            label={<FormattedMessage id="ui-users.accountActionHistory" />}
+          >
             <this.connectedAccountActionsHistory
               user={user}
               patronGroup={patronGroup}

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -534,6 +534,12 @@ class ViewUser extends React.Component {
     }
   }
 
+  isLayerOpen = value => {
+    const { layer } = this.props.resources.query;
+
+    return layer === value;
+  };
+
   render() {
     const {
       resources,
@@ -560,7 +566,7 @@ class ViewUser extends React.Component {
           {
             tagsEnabled &&
             <FormattedMessage id="ui-users.showTags">
-              { ariaLabel => (
+              {ariaLabel => (
                 <IconButton
                   icon="tag"
                   id="clickable-show-tags"
@@ -573,7 +579,7 @@ class ViewUser extends React.Component {
           }
           <IfPermission perm="users.item.put">
             <FormattedMessage id="ui-users.crud.editUser">
-              { ariaLabel => (
+              {ariaLabel => (
                 <IconButton
                   icon="edit"
                   id="clickable-edituser"
@@ -775,9 +781,9 @@ class ViewUser extends React.Component {
             </IfPermission>
           </AccordionSet>
           <FormattedMessage id="ui-users.editUserDialog">
-            { contentLabel => (
+            {contentLabel => (
               <Layer
-                isOpen={query.layer ? query.layer === 'edit' : false}
+                isOpen={this.isLayerOpen('edit')}
                 contentLabel={contentLabel}
                 afterClose={this.afterCloseEdit}
               >
@@ -796,7 +802,11 @@ class ViewUser extends React.Component {
             )}
           </FormattedMessage>
           <Layer
-            isOpen={query.layer ? query.layer === 'open-accounts' || query.layer === 'closed-accounts' || query.layer === 'all-accounts' : false}
+            isOpen={
+              this.isLayerOpen('open-accounts') || 
+              this.isLayerOpen('closed-accounts') || 
+              this.isLayerOpen('all-accounts')
+            }
             label={<FormattedMessage id="ui-users.accounts.title" />}
           >
             <this.connectedAccountsHistory
@@ -818,7 +828,7 @@ class ViewUser extends React.Component {
             />
           </Layer>
           <Layer
-            isOpen={query.layer ? query.layer === 'charge' : false}
+            isOpen={this.isLayerOpen('charge')}
             label={<FormattedMessage id="ui-users.chargeFeefine" />}
           >
             <this.connectedCharge
@@ -833,7 +843,7 @@ class ViewUser extends React.Component {
             />
           </Layer>
           <Layer
-            isOpen={query.layer ? query.layer === 'account' : false}
+            isOpen={this.isLayerOpen('account')}
             label={<FormattedMessage id="ui-users.accountActionHistory" />}
           >
             <this.connectedAccountActionsHistory
@@ -854,9 +864,9 @@ class ViewUser extends React.Component {
 
           <IfPermission perm="ui-users.loans.all">
             <FormattedMessage id="ui-users.loans.title">
-              { contentLabel => (
+              {contentLabel => (
                 <Layer
-                  isOpen={query.layer ? query.layer === 'open-loans' || query.layer === 'closed-loans' : false}
+                  isOpen={this.isLayerOpen('open-loans') || this.isLayerOpen('closed-loans')}
                   contentLabel={contentLabel}
                 >
                   {loansHistory}
@@ -865,9 +875,9 @@ class ViewUser extends React.Component {
             </FormattedMessage>
 
             <FormattedMessage id="ui-users.loanActionsHistory">
-              { contentLabel => (
+              {contentLabel => (
                 <Layer
-                  isOpen={query.layer ? query.layer === 'loan' : false}
+                  isOpen={this.isLayerOpen('loan')}
                   contentLabel={contentLabel}
                 >
                   {loanDetails}

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -803,8 +803,8 @@ class ViewUser extends React.Component {
           </FormattedMessage>
           <Layer
             isOpen={
-              this.isLayerOpen('open-accounts') || 
-              this.isLayerOpen('closed-accounts') || 
+              this.isLayerOpen('open-accounts') ||
+              this.isLayerOpen('closed-accounts') ||
               this.isLayerOpen('all-accounts')
             }
             label={<FormattedMessage id="ui-users.accounts.title" />}

--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,11 @@ class UsersRouting extends React.Component {
     this.connectedApp = props.stripes.connect(Users);
   }
 
-  NoMatch() {
+  noMatch() {
     const {
       location: { pathname },
     } = this.props;
+
     return (
       <div>
         <h2>
@@ -54,10 +55,10 @@ class UsersRouting extends React.Component {
       <CommandList commands={commands}>
         <Switch>
           <Route
-            path={`${this.props.match.path}`}
+            path={this.props.match.path}
             render={() => <this.connectedApp {...this.props} />}
           />
-          <Route component={() => { this.NoMatch(); }} />
+          <Route render={this.noMatch} />
         </Switch>
       </CommandList>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,12 @@ class UsersRouting extends React.Component {
   }
 
   render() {
-    if (this.props.showSettings) {
+    const {
+      showSettings,
+      match: { path },
+    } = this.props;
+
+    if (showSettings) {
       return <Settings {...this.props} />;
     }
 
@@ -55,7 +60,7 @@ class UsersRouting extends React.Component {
       <CommandList commands={commands}>
         <Switch>
           <Route
-            path={this.props.match.path}
+            path={path}
             render={() => <this.connectedApp {...this.props} />}
           />
           <Route render={this.noMatch} />

--- a/src/settings/CommentRequiredForm.js
+++ b/src/settings/CommentRequiredForm.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Field } from 'redux-form';
+
 import {
   Pane,
   Button,
@@ -7,9 +10,7 @@ import {
   Col,
   Select,
 } from '@folio/stripes/components';
-import { FormattedMessage } from 'react-intl';
 import stripesForm from '@folio/stripes/form';
-import { Field } from 'redux-form';
 
 const Setting = ({
   name,
@@ -50,6 +51,7 @@ class CommentRequiredForm extends React.Component {
       submitting,
       handleSubmit,
     } = this.props;
+
     const lastMenu = (
       <Button
         type="submit"
@@ -63,7 +65,10 @@ class CommentRequiredForm extends React.Component {
     );
 
     return (
-      <form id="require-comment" onSubmit={handleSubmit}>
+      <form
+        id="require-comment"
+        onSubmit={handleSubmit}
+      >
         <Pane
           defaultWidth="fill"
           paneTitle={<FormattedMessage id="ui-users.comment.title" />}

--- a/src/settings/FeeFinesTable/FeeFines.js
+++ b/src/settings/FeeFinesTable/FeeFines.js
@@ -44,15 +44,19 @@ function validate(type, props) {
       if (exist.find(e => e === ownerId)) {
         errors.items[i].feeFineType = <FormattedMessage id="ui-users.feefines.errors.exist" />;
       } else if (ownerId === shared.id) {
-        errors.items[i].feeFineType = <SafeHTMLMessage
-          id="ui-users.feefines.errors.existShared"
-          values={{ owner: (owners.find(o => o.id === exist[0]) || {}).owner }}
-        />;
+        errors.items[i].feeFineType = (
+          <FormattedMessage
+            id="ui-users.feefines.errors.existShared"
+            values={{ owner: (owners.find(o => o.id === exist[0]) || {}).owner }}
+          />
+        );
       } else if (exist.find(e => e === shared.id)) {
-        errors.items[i].feeFineType = <SafeHTMLMessage
-          id="ui-users.feefines.errors.existShared"
-          values={{ owner: 'Shared' }}
-        />;
+        errors.items[i].feeFineType = (
+          <FormattedMessage
+            id="ui-users.feefines.errors.existShared"
+            values={{ owner: 'Shared' }}
+          />
+        );
       }
     }
 

--- a/src/settings/FeeFinesTable/FeeFines.js
+++ b/src/settings/FeeFinesTable/FeeFines.js
@@ -308,7 +308,10 @@ class FeeFines extends React.Component {
 
     return (
       <div>
-        <Owners dataOptions={owners} onChange={this.onChangeOwner} />
+        <Owners
+          dataOptions={owners}
+          onChange={this.onChangeOwner}
+        />
         <EditableList
           {...this.props}
           label={intl.formatMessage({ id: 'ui-users.feefines.title' })}
@@ -332,7 +335,12 @@ class FeeFines extends React.Component {
         <ConfirmationModal
           open={this.state.confirming}
           heading={<FormattedMessage id="ui-users.feefines.modalHeader" />}
-          message={<SafeHTMLMessage id="ui-users.feefines.modalMessage" values={{ feefine: this.state.type.feeFineType }} />}
+          message={
+            <SafeHTMLMessage
+              id="ui-users.feefines.modalMessage"
+              values={{ feefine: this.state.type.feeFineType }}
+            />
+          }
           onConfirm={this.onDeleteType}
           onCancel={this.hideConfirm}
           confirmLabel="Delete"

--- a/src/settings/FeeFinesTable/Owners.js
+++ b/src/settings/FeeFinesTable/Owners.js
@@ -1,15 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Row, Col, Select } from '@folio/stripes/components';
+
+import {
+  Row,
+  Col,
+  Select,
+} from '@folio/stripes/components';
 
 const Owners = (props) => {
   const options = [];
   const shared = props.dataOptions.find(d => d.owner === 'Shared') || {};
-  if (shared.id) options.push(<option value={shared.id} key="0">{shared.owner}</option>);
+
+  if (shared.id) {
+    options.push(
+      <option
+        value={shared.id}
+        key="0"
+      >
+        {shared.owner}
+      </option>
+    );
+  }
+
   if (props.dataOptions) {
     props.dataOptions.forEach((option) => {
-      if (option.id !== shared.id)options.push(<option value={option.id} key={option.id}>{option.owner}</option>);
+      if (option.id !== shared.id) {
+        options.push(
+          <option
+            value={option.id}
+            key={option.id}
+          >
+            {option.owner}
+          </option>
+        );
+      }
     });
   }
 
@@ -22,7 +47,10 @@ const Owners = (props) => {
           </span>
         </Col>
         <Col>
-          <Select style={{ marginLeft: '20px' }} onChange={props.onChange}>
+          <Select
+            style={{ marginLeft: '20px' }}
+            onChange={props.onChange}
+          >
             {options}
           </Select>
         </Col>

--- a/src/settings/OwnerSettings.js
+++ b/src/settings/OwnerSettings.js
@@ -151,7 +151,7 @@ class OwnerSettings extends React.Component {
         const asp = item.servicePointOwner || [];
         asp.forEach(s => {
           if (s.value === none.id && asp.length > 1) {
-            itemErrors.servicePointOwner = 'Error';
+            itemErrors.servicePointOwner = <FormattedMessage id="ui-users.owners.error" />;
           }
         });
 
@@ -183,7 +183,7 @@ class OwnerSettings extends React.Component {
 
         asp.forEach(s => {
           if (s.value === none.id) {
-            itemWarning.servicePointOwner = 'Warning: Overdue fines/lost item fees will not be collected without a service point';
+            itemWarning.servicePointOwner = <FormattedMessage id="ui-users.owners.warning" />;
           }
         });
 

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,5 +1,11 @@
 import _ from 'lodash';
-import React from 'react';
+import React, { Component } from 'react';
+import {
+  FormattedMessage,
+  injectIntl,
+  intlShape,
+} from 'react-intl';
+
 import { Settings } from '@folio/stripes/smart-components';
 
 import PermissionSets from './permissions/PermissionSets';
@@ -13,80 +19,105 @@ import PaymentSettings from './PaymentSettings';
 import CommentRequiredSettings from './CommentRequiredSettings';
 import RefundReasonsSettings from './RefundReasonsSettings';
 
-const general = [
-  {
-    route: 'perms',
-    label: 'Permission sets',
-    component: PermissionSets,
-    perm: 'ui-users.editpermsets',
-  },
-  {
-    route: 'groups',
-    label: 'Patron groups',
-    component: PatronGroupsSettings,
-    perm: 'ui-users.settings.usergroups',
-  },
-  {
-    route: 'addresstypes',
-    label: 'Address Types',
-    component: AddressTypesSettings,
-    perm: 'ui-users.settings.addresstypes',
-  },
-  {
-    route: 'profilepictures',
-    label: 'Profile pictures',
-    component: ProfilePictureSettings,
-  },
-];
+class UsersSettings extends Component {
+  static propTypes = {
+    intl: intlShape.isRequired,
+  };
 
-const feefines = [
-  {
-    route: 'owners',
-    label: 'Owners',
-    component: OwnerSettings,
-    perm: 'ui-users.settings.owners',
-  },
-  {
-    route: 'feefinestable',
-    label: 'Manual charges',
-    component: FeeFineSettings,
-    perm: 'ui-users.settings.feefines',
-  },
-  {
-    route: 'waivereasons',
-    label: 'Waive reasons',
-    component: WaiveSettings,
-    perm: 'ui-users.settings.waives',
-  },
-  {
-    route: 'payments',
-    label: 'Payment methods',
-    component: PaymentSettings,
-    perm: 'ui-users.settings.payments',
-  },
-  {
-    route: 'refunds',
-    label: 'Refund reasons',
-    component: RefundReasonsSettings,
-    perm: 'ui-users.settings.refunds',
-  },
-  {
-    route: 'comments',
-    label: 'Comment required',
-    perm: 'ui-users.settings.comments',
-    component: CommentRequiredSettings,
-  },
-];
+  // eslint-disable-next-line react/sort-comp
+  render() {
+    return (
+      <Settings
+        {...this.props}
+        sections={this.getSections()}
+        paneTitle={<FormattedMessage id="ui-users.settings.label" />}
+      />
+    );
+  }
 
-const sections = [
-  {
-    label: 'General',
-    pages: _.sortBy(general, ['label']),
-  },
-  {
-    label: 'Fee/fine',
-    pages: _.sortBy(feefines, ['label']),
-  },
-];
+  getSections() {
+    return [
+      {
+        label: <FormattedMessage id="ui-users.settings.general" />,
+        pages: _.sortBy(this.getGeneral(), ['label']),
+      },
+      {
+        label: <FormattedMessage id="ui-users.settings.feefine" />,
+        pages: _.sortBy(this.getFeefines(), ['label']),
+      },
+    ];
+  }
 
-export default props => <Settings {...props} sections={sections} paneTitle="Users" />;
+  getGeneral() {
+    return [
+      {
+        route: 'perms',
+        label: <FormattedMessage id="ui-users.settings.permissionSet" />,
+        component: PermissionSets,
+        perm: 'ui-users.editpermsets',
+      },
+      {
+        route: 'groups',
+        label: <FormattedMessage id="ui-users.settings.patronGroups" />,
+        component: PatronGroupsSettings,
+        perm: 'ui-users.settings.usergroups',
+      },
+      {
+        route: 'addresstypes',
+        label: <FormattedMessage id="ui-users.settings.addressTypes" />,
+        component: AddressTypesSettings,
+        perm: 'ui-users.settings.addresstypes',
+      },
+      {
+        route: 'profilepictures',
+        label: <FormattedMessage id="ui-users.settings.profilePictures" />,
+        component: ProfilePictureSettings,
+      },
+    ];
+  }
+
+  getFeefines() {
+    const { intl: { formatMessage } } = this.props;
+
+    return [
+      {
+        route: 'owners',
+        label: formatMessage({ id: 'ui-users.settings.owners' }),
+        component: OwnerSettings,
+        perm: 'ui-users.settings.owners',
+      },
+      {
+        route: 'feefinestable',
+        label: <FormattedMessage id="ui-users.settings.manualCharges" />,
+        component: FeeFineSettings,
+        perm: 'ui-users.settings.feefines',
+      },
+      {
+        route: 'waivereasons',
+        label: <FormattedMessage id="ui-users.settings.waiveReasons" />,
+        component: WaiveSettings,
+        perm: 'ui-users.settings.waives',
+      },
+      {
+        route: 'payments',
+        label: <FormattedMessage id="ui-users.settings.paymentMethods" />,
+        component: PaymentSettings,
+        perm: 'ui-users.settings.payments',
+      },
+      {
+        route: 'refunds',
+        label: <FormattedMessage id="ui-users.settings.refundReasons" />,
+        component: RefundReasonsSettings,
+        perm: 'ui-users.settings.refunds',
+      },
+      {
+        route: 'comments',
+        label: <FormattedMessage id="ui-users.settings.commentRequired" />,
+        perm: 'ui-users.settings.comments',
+        component: CommentRequiredSettings,
+      },
+    ];
+  }
+}
+
+export default injectIntl(UsersSettings);

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -49,35 +49,37 @@ class UsersSettings extends Component {
   }
 
   getGeneral() {
+    const { formatMessage } = this.props.intl;
+
     return [
       {
         route: 'perms',
-        label: <FormattedMessage id="ui-users.settings.permissionSet" />,
+        label: formatMessage({ id: 'ui-users.settings.permissionSet' }),
         component: PermissionSets,
         perm: 'ui-users.editpermsets',
       },
       {
         route: 'groups',
-        label: <FormattedMessage id="ui-users.settings.patronGroups" />,
+        label: formatMessage({ id: 'ui-users.settings.patronGroups' }),
         component: PatronGroupsSettings,
         perm: 'ui-users.settings.usergroups',
       },
       {
         route: 'addresstypes',
-        label: <FormattedMessage id="ui-users.settings.addressTypes" />,
+        label: formatMessage({ id: 'ui-users.settings.addressTypes' }),
         component: AddressTypesSettings,
         perm: 'ui-users.settings.addresstypes',
       },
       {
         route: 'profilepictures',
-        label: <FormattedMessage id="ui-users.settings.profilePictures" />,
+        label: formatMessage({ id: 'ui-users.settings.profilePictures' }),
         component: ProfilePictureSettings,
       },
     ];
   }
 
   getFeefines() {
-    const { intl: { formatMessage } } = this.props;
+    const { formatMessage } = this.props.intl;
 
     return [
       {
@@ -88,33 +90,33 @@ class UsersSettings extends Component {
       },
       {
         route: 'feefinestable',
-        label: <FormattedMessage id="ui-users.settings.manualCharges" />,
+        label: formatMessage({ id: 'ui-users.settings.manualCharges' }),
         component: FeeFineSettings,
         perm: 'ui-users.settings.feefines',
       },
       {
         route: 'waivereasons',
-        label: <FormattedMessage id="ui-users.settings.waiveReasons" />,
+        label: formatMessage({ id: 'ui-users.settings.waiveReasons' }),
         component: WaiveSettings,
         perm: 'ui-users.settings.waives',
       },
       {
         route: 'payments',
-        label: <FormattedMessage id="ui-users.settings.paymentMethods" />,
+        label: formatMessage({ id: 'ui-users.settings.paymentMethods' }),
         component: PaymentSettings,
         perm: 'ui-users.settings.payments',
       },
       {
         route: 'refunds',
-        label: <FormattedMessage id="ui-users.settings.refundReasons" />,
+        label: formatMessage({ id: 'ui-users.settings.refundReasons' }),
         component: RefundReasonsSettings,
         perm: 'ui-users.settings.refunds',
       },
       {
         route: 'comments',
-        label: <FormattedMessage id="ui-users.settings.commentRequired" />,
-        perm: 'ui-users.settings.comments',
+        label: formatMessage({ id: 'ui-users.settings.commentRequired' }),
         component: CommentRequiredSettings,
+        perm: 'ui-users.settings.comments',
       },
     ];
   }

--- a/src/settings/permissions/PermissionSetDetails.js
+++ b/src/settings/permissions/PermissionSetDetails.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+
 import {
   KeyValue,
   Row,
@@ -56,18 +57,27 @@ class PermissionSetDetails extends React.Component {
   render() {
     const { initialValues: selectedSet } = this.props;
     const { sections } = this.state;
+    const untitledPermissionSetMessage = <FormattedMessage id="ui-users.permissions.untitledPermissionSet" />;
+
     return (
       <div>
         <Row end="xs">
           <Col xs>
-            <ExpandAllButton accordionStatus={sections} onToggle={this.handleExpandAll} />
+            <ExpandAllButton
+              accordionStatus={sections}
+              onToggle={this.handleExpandAll}
+            />
           </Col>
         </Row>
         <Accordion
           open={sections.generalInformation}
           id="generalInformation"
           onToggle={this.handleSectionToggle}
-          label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.permissions.generalInformation" /></Headline>}
+          label={
+            <Headline size="large" tag="h3">
+              <FormattedMessage id="ui-users.permissions.generalInformation" />
+            </Headline>
+          }
         >
           {selectedSet.metadata && selectedSet.metadata.createdDate &&
             <Row>
@@ -81,7 +91,7 @@ class PermissionSetDetails extends React.Component {
               <section>
                 <KeyValue
                   label={<FormattedMessage id="ui-users.permissions.permissionSetName" />}
-                  value={_.get(selectedSet, ['displayName'], <FormattedMessage id="ui-users.permissions.untitledPermissionSet" />)}
+                  value={_.get(selectedSet, ['displayName'], untitledPermissionSetMessage)}
                 />
                 <KeyValue
                   label={<FormattedMessage id="ui-users.description" />}

--- a/src/settings/permissions/PermissionSetDetails.js
+++ b/src/settings/permissions/PermissionSetDetails.js
@@ -73,11 +73,14 @@ class PermissionSetDetails extends React.Component {
           open={sections.generalInformation}
           id="generalInformation"
           onToggle={this.handleSectionToggle}
-          label={
-            <Headline size="large" tag="h3">
+          label={(
+            <Headline
+              size="large"
+              tag="h3"
+            >
               <FormattedMessage id="ui-users.permissions.generalInformation" />
             </Headline>
-          }
+          )}
         >
           {selectedSet.metadata && selectedSet.metadata.createdDate &&
             <Row>

--- a/src/settings/permissions/PermissionSetForm.js
+++ b/src/settings/permissions/PermissionSetForm.js
@@ -192,27 +192,47 @@ class PermissionSetForm extends React.Component {
     const disabled = !stripes.hasPerm('perms.permissions.item.put');
 
     const selectedName = selectedSet.displayName ||
-    <FormattedMessage id="ui-users.permissions.untitledPermissionSet" />;
+      <FormattedMessage id="ui-users.permissions.untitledPermissionSet" />;
 
     const confirmationMessage = <FormattedMessage
       id="ui-users.permissions.deletePermissionSetMessage"
       values={{ name: <strong>{selectedName}</strong> }}
     />;
 
+    const accordionLabel = (
+      <Headline
+        size="large"
+        tag="h3"
+      >
+        <FormattedMessage id="ui-users.permissions.generalInformation" />
+      </Headline>
+    );
+
     return (
-      <form id="form-permission-set" onSubmit={handleSubmit(this.saveSet)}>
+      <form
+        id="form-permission-set"
+        onSubmit={handleSubmit(this.saveSet)}
+      >
         <Paneset isRoot>
-          <Pane defaultWidth="100%" firstMenu={this.addFirstMenu()} lastMenu={this.saveLastMenu()} paneTitle={this.renderPaneTitle()}>
+          <Pane
+            defaultWidth="100%"
+            firstMenu={this.addFirstMenu()}
+            lastMenu={this.saveLastMenu()}
+            paneTitle={this.renderPaneTitle()}
+          >
             <Row end="xs">
               <Col xs>
-                <ExpandAllButton accordionStatus={sections} onToggle={this.handleExpandAll} />
+                <ExpandAllButton
+                  accordionStatus={sections}
+                  onToggle={this.handleExpandAll}
+                />
               </Col>
             </Row>
             <Accordion
               open={sections.generalSection}
               id="generalSection"
               onToggle={this.handleSectionToggle}
-              label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.permissions.generalInformation" /></Headline>}
+              label={accordionLabel}
             >
               {selectedSet.metadata && selectedSet.metadata.createdDate &&
                 <Row>

--- a/src/settings/permissions/PermissionSets.js
+++ b/src/settings/permissions/PermissionSets.js
@@ -4,8 +4,11 @@ import PropTypes from 'prop-types';
 import {
   injectIntl,
   intlShape,
+  FormattedMessage,
 } from 'react-intl';
+
 import { EntryManager } from '@folio/stripes/smart-components';
+
 import PermissionSetDetails from './PermissionSetDetails';
 import PermissionSetForm from './PermissionSetForm';
 
@@ -13,7 +16,7 @@ function validate(values) {
   const errors = {};
 
   if (!values.displayName) {
-    errors.displayName = 'Please fill this in to continue';
+    errors.displayName = <FormattedMessage id="ui-users.permissions.emptyField" />;
   }
 
   return errors;

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
+import { FormattedMessage } from 'react-intl';
 
 export function getFullName(user) {
   const lastName = _.get(user, ['personal', 'lastName'], '');
@@ -28,10 +28,12 @@ export function validate(item, index, items, field, label) {
   for (let i = 0; i < items.length; i++) {
     const obj = items[i];
     if ((index !== i) && ((obj[field] || '').localeCompare(item[field], 'sv', { sensitivity: 'base' }) === 0)) {
-      error[field] = <SafeHTMLMessage
-        id="ui-users.duplicated"
-        values={{ field: label }}
-      />;
+      error[field] = (
+        <FormattedMessage
+          id="ui-users.duplicated"
+          values={{ field: label }}
+        />
+      );
     }
   }
   return error;

--- a/src/withRenew.js
+++ b/src/withRenew.js
@@ -57,7 +57,6 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
           } else {
             resp.text().then((error) => {
               reject(error);
-              alert(error); // eslint-disable-line no-alert
             });
           }
         });
@@ -92,10 +91,20 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
 
       const policyName = this.getPolicyName(errors);
       let message = errors.reduce((msg, err) => ((msg) ? `${msg}, ${err.message}` : err.message), '');
-      message = `Loan cannot be renewed because: ${message}.`;
+      message = (
+        <FormattedMessage
+          id="ui-users.loanNotRenewedReason"
+          values={{ message }}
+        />
+      );
 
       if (policyName) {
-        message = `${message} Please review ${policyName} before retrying renewal.`;
+        message = (
+          <FormattedMessage
+            id="ui-users.reviewBeforeRenewal"
+            values={{ message, policyName }}
+          />
+        );
       }
 
       return message;
@@ -107,7 +116,10 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
 
       return (
         <div>
-          <WrappedComponent renew={this.renew} {...this.props} />
+          <WrappedComponent
+            renew={this.renew}
+            {...this.props}
+          />
           {errors &&
             <ErrorModal
               id="renewal-failure-modal"

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -299,6 +299,20 @@
   "loans.loanDetails": "Loan details",
   "loans.newFeeFine": "New fee/fine",
 
+  "settings.label": "Users",
+  "settings.general": "General",
+  "settings.feefine": "Fee/fine",
+  "settings.permissionSet": "Permission sets",
+  "settings.patronGroups": "Patron groups",
+  "settings.addressTypes": "Address Types",
+  "settings.profilePictures": "Profile pictures",
+  "settings.owners": "Owners",
+  "settings.manualCharges": "Manual charges",
+  "settings.waiveReasons": "Waive reasons",
+  "settings.paymentMethods": "Payment methods",
+  "settings.refundReasons": "Refund reasons",
+  "settings.commentRequired": "Comment required",
+
   "loans.columns.title": "Item title",
   "loans.columns.itemStatus": "Item status",
   "loans.columns.barcode": "Barcode",
@@ -341,6 +355,7 @@
   "requests.numOpenRequests": "{count, number} {count, plural, one {open request} other {open requests}}",
   "requests.numClosedRequests": "{count, number} {count, plural, one {closed request} other {closed requests}}",
 
+  "permissions.emptyField": "Please fill this in to continue",
   "permissions.noSponsorsFound": "No sponsors found",
   "permissions.noProxiesFound": "No proxies found",
   "permissions.empty": "No permissions found",
@@ -436,6 +451,9 @@
   "errors.proxies.expired": "Proxy user record expired",
   "errors.sponsors.expired": "Sponsor user record expired",
 
+  "error.reviewBeforeRenewal": "{message} Please review {policyName} before retrying renewal.",
+  "error.loanNotRenewedReason": "Loan cannot be renewed because: {message}.",
+
   "editUserDialog": "Edit User Dialog",
   "loanActionsHistory": "Loan Actions History",
   "hide": "Hide",
@@ -460,8 +478,13 @@
   "anonymize": "Anonymize all loans",
   "bulkActions.tooltip": "Multiple loans can be processed at the same time. Please select loans first.",
   "loanNotRenewed": "Loan not renewed",
+  "chargeFeefine": "Charge Fee/Fine",
+  "accountActionHistory": "Account Actions History",
+  "status": "Status",
 
   "accounts.title": "Fees/Fines",
+  "accounts.outstandingBalance": "Outstanding Balance: ",
+  "accounts.header": "Fee/fine details - {userName} ({patronGroup})",
   "accounts.outstanding": "Outstanding Balance:",
   "accounts.open": "Open",
   "accounts.closed": "Closed",
@@ -495,6 +518,8 @@
 
   "owners.label": "Fee/fine: Owners",
   "owners.singular": "Fee/fine Owner",
+  "owners.error": "Error",
+  "owners.warning": "Warning: Overdue fines/lost item fees will not be collected without a service point",
   "owners.columns.owner": "Owner*",
   "owners.columns.desc": "Description",
   "owners.columns.asp": "Associated service points",


### PR DESCRIPTION
## Purpose
According to [UIU-691](https://issues.folio.org/browse/UIU-691) all the hardcoded strings should be internationalized using the react-intl pattern.
react-intl constructs outlined at [here](https://github.com/folio-org/stripes-core/blob/master/doc/i18n.md) 

## Approach
Use` <FormattedMessage>`, `<FormattedDate>`, and `<FormattedTime>` as often as possible, only falling back to formatMessage(), formatDate(), and formatTime() (accompanied by injectIntl) when a bare string is absolutely necessary.

## Additional
This PR resolve [UIU-640](https://issues.folio.org/browse/UIU-640)
