### PR TITLE
allow PropTypes.node for easier i18n

### DIFF
--- a/src/components/EditablePermissions/EditablePermissions.js
+++ b/src/components/EditablePermissions/EditablePermissions.js
@@ -24,7 +24,7 @@ import css from './EditablePermissions.css';
 
 class EditablePermissions extends React.Component {
   static propTypes = {
-    heading: PropTypes.string.isRequired,
+    heading: PropTypes.node.isRequired,
     permToRead: PropTypes.string.isRequired,
     permToDelete: PropTypes.string.isRequired,
     permToModify: PropTypes.string.isRequired,


### PR DESCRIPTION
Allow `PropTypes.node` instead of the more restrictive
`PropTypes.string` for values that may be passed as `<FormattedMessage>`
objects.