### PR TITLE
'Loan: All permissions' should not include request-related permissions. Part of UIU-741.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/users",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "description": "User management",
   "repository": "folio-org/ui-users",
   "publishConfig": {
@@ -467,7 +467,6 @@
           "ui-users.view",
           "ui-users.loans.renew",
           "ui-users.settings.feefines",
-          "ui-users.requests.all",
           "circulation.loans.item.put",
           "circulation.renew-by-barcode.post",
           "circulation-storage.loans-history.collection.get",

--- a/src/components/Loans/OpenLoans/OpenLoans.js
+++ b/src/components/Loans/OpenLoans/OpenLoans.js
@@ -343,13 +343,19 @@ class OpenLoans extends React.Component {
   }
 
   getOpenRequestsCount() {
+    const { stripes, mutator } = this.props;
+
+    if (!stripes.hasPerm('ui-users.requests.all')) {
+      return;
+    }
+
     const q = this.state.loans.map(loan => {
       return `itemId==${loan.itemId}`;
     }).join(' or ');
 
     const query = `(${q}) and status==("Open - Awaiting pickup" or "Open - Not yet filled") sortby requestDate desc`;
-    this.props.mutator.requests.reset();
-    this.props.mutator.requests.GET({ params: { query } }).then((requestRecords) => {
+    mutator.requests.reset();
+    mutator.requests.GET({ params: { query } }).then((requestRecords) => {
       const requestCountObject = requestRecords.reduce((map, record) => {
         map[record.itemId] = map[record.itemId] ? ++map[record.itemId] : 1;
         return map;


### PR DESCRIPTION
Couple notes about this:

1. Currently if the user doesn't have the request related permissions the requests counter will just show `0`.
2. I couldn't use `permissionsRequired` inside the manifest because we are using `accumulate` type queries and there is currently no support for `permissionsRequired` for these type of queries in `stripes-connect`
3. It looks like both `LoanActionsHistory` and `OpenLoans` have some code duplication. It would be nice to refactor it at some point.

Given all these I would still like to move forward with this PR so we can finalize work on https://issues.folio.org/browse/UIU-686

