### PR TITLE
Hide request count when request related permissions are not present. Part of UIU-741

### DIFF
--- a/src/LoanActionsHistory.js
+++ b/src/LoanActionsHistory.js
@@ -21,6 +21,7 @@ import {
   KeyValue,
   Row,
   Col,
+  IfPermission,
 } from '@folio/stripes/components';
 import { getFullName } from './util';
 import loanActionMap from './data/loanActionMap';
@@ -508,12 +509,14 @@ class LoanActionsHistory extends React.Component {
                 )}
               />
             </Col>
-            <Col xs={2}>
-              <KeyValue
-                label={<FormattedMessage id="ui-users.loans.details.requestQueue" />}
-                value={requestQueueValue}
-              />
-            </Col>
+            <IfPermission perm="ui-users.requests.all">
+              <Col xs={2}>
+                <KeyValue
+                  label={<FormattedMessage id="ui-users.loans.details.requestQueue" />}
+                  value={requestQueueValue}
+                />
+              </Col>
+            </IfPermission>
             <Col xs={2}>
               <KeyValue
                 label={<FormattedMessage id="ui-users.loans.details.lost" />}

--- a/src/LoanActionsHistory.js
+++ b/src/LoanActionsHistory.js
@@ -21,8 +21,8 @@ import {
   KeyValue,
   Row,
   Col,
-  IfPermission,
 } from '@folio/stripes/components';
+import { IfPermission } from '@folio/stripes/core';
 import { getFullName } from './util';
 import loanActionMap from './data/loanActionMap';
 import LoanActionsHistoryProxy from './LoanActionsHistoryProxy';

--- a/src/components/Loans/OpenLoans/OpenLoans.js
+++ b/src/components/Loans/OpenLoans/OpenLoans.js
@@ -21,9 +21,9 @@ import {
   Callout,
   IconButton,
   ExportCsv,
-  IfPermission,
 } from '@folio/stripes/components';
 import { ChangeDueDateDialog } from '@folio/stripes/smart-components';
+import { IfPermission } from '@folio/stripes/core';
 import BulkRenewalDialog from '../../BulkRenewalDialog';
 import Label from '../../Label';
 import css from './OpenLoans.css';

--- a/src/components/Loans/OpenLoans/OpenLoans.js
+++ b/src/components/Loans/OpenLoans/OpenLoans.js
@@ -393,13 +393,19 @@ class OpenLoans extends React.Component {
   }
 
   getVisibleColumns() {
+    const { stripes } = this.props;
     const { visibleColumns } = this.state;
     const visibleColumnsMap = visibleColumns.reduce((map, e) => {
       map[e.title] = e.status;
       return map;
     }, {});
 
-    const columnsToDisplay = this.possibleColumns.filter((e) => visibleColumnsMap[e] === undefined || visibleColumnsMap[e] === true);
+    let columnsToDisplay = this.possibleColumns.filter((e) => visibleColumnsMap[e] === undefined || visibleColumnsMap[e] === true);
+
+    if (!stripes.hasPerm('ui-users.requests.all')) {
+      columnsToDisplay = columnsToDisplay.filter(col => col !== 'requests');
+    }
+
     return columnsToDisplay;
   }
 


### PR DESCRIPTION
This PR hides request count on the open loan view and loan details view in cases when `ui-users.requests.all` permission is not present. 