### PR TITLE
Show 'Close without saving' dialog after changes are made on the user form. Fixes UIU-749.

### DIFF
--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -539,10 +539,12 @@ class ViewUser extends React.Component {
       stripes,
       parentResources,
       tagsEnabled,
+      location
     } = this.props;
 
     const addressTypes = (parentResources.addressTypes || {}).records || [];
-    const query = resources.query;
+    const query = queryString.parse(location.search || '');
+
     const user = this.getUser();
     const tags = ((user && user.tags) || {}).tagList || [];
     const patronGroups = (resources.patronGroups || {}).records || [];


### PR DESCRIPTION
It looks like what was happening here is that after we hit 'X' on the edit form (after some changes were made) the `layer` in the redux store would be cleaned up by `SearchAndSort`:

https://github.com/folio-org/stripes-smart-components/blob/master/lib/SearchAndSort/SearchAndSort.js#L315

This would trigger a re-render of the `ViewUser` component without a `layer` present:

https://github.com/folio-org/ui-users/blob/master/src/ViewUser.js#L545

which would cause the `UserForm` to be destroyed completely (together with the `StripesFormWrapper` where the 'Close without saving' modal is implemented).

Switching to building a query from the current location solves this issue. This is similar to what `SearchAndSort` already does in a 'create' mode:

https://github.com/folio-org/stripes-smart-components/blob/master/lib/SearchAndSort/SearchAndSort.js#L531

https://github.com/folio-org/stripes-smart-components/blob/master/lib/SearchAndSort/SearchAndSort.js#L645





