### PR TITLE
avoid clipping service point menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Link to a user's requests. Fixes UIU-677.
 * Bring back handleSubmit when using submit button. Fixes UIU-743.
 * Fix permission menu after reopening. Fixes UIU-739.
+* Provide `renderToOverlay` to `<MultiSelection>` to avoid clipping. Fixes STSMACOM-149.
 
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/users",
-  "version": "2.17.7",
+  "version": "2.17.8",
   "description": "User management",
   "repository": "folio-org/ui-users",
   "publishConfig": {

--- a/src/settings/OwnerSettings.js
+++ b/src/settings/OwnerSettings.js
@@ -224,6 +224,7 @@ class OwnerSettings extends React.Component {
           component={MultiSelection}
           onChange={this.onChangeSelection}
           dataOptions={options}
+          renderToOverlay
         />
       )
     };


### PR DESCRIPTION
Provide `renderToOverlay` to `<MultiSelection>` to avoid clipping the
service points menu.

Fixes [STSMACOM-149](https://issues.folio.org/browse/STSMACOM-149)