### PR TITLE
import IfInterface, IfPermission from core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Fix permission menu after reopening. Fixes UIU-739.
 * Apply internationalization to all hardcoded strings for Settings. Fixes UIU-691.
 * Pass `userBarcode` to new requests. Fixes UIU-690. Refs UIREQ-146.
+* `IfInterface` and `IfPermission` are deprecated in components; import them from core.
 
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -5,7 +5,11 @@ import { compose } from 'redux';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import queryString from 'query-string';
-import { TitleManager } from '@folio/stripes/core';
+import {
+  IfInterface,
+  IfPermission,
+  TitleManager,
+} from '@folio/stripes/core';
 import {
   Pane,
   PaneMenu,
@@ -14,8 +18,6 @@ import {
   ExpandAllButton,
   Row,
   Col,
-  IfPermission,
-  IfInterface,
   Layer,
   Headline,
   AccordionSet,

--- a/src/components/EditSections/EditServicePoints/EditServicePoints.js
+++ b/src/components/EditSections/EditServicePoints/EditServicePoints.js
@@ -8,6 +8,10 @@ import PropTypes from 'prop-types';
 import { get, uniqBy } from 'lodash';
 import { Field, FieldArray } from 'redux-form';
 import {
+  IfPermission,
+  IfInterface,
+} from '@folio/stripes/core';
+import {
   Icon,
   Button,
   Select,
@@ -16,8 +20,6 @@ import {
   Accordion,
   Badge,
   List,
-  IfPermission,
-  IfInterface,
   Headline
 } from '@folio/stripes/components';
 

--- a/src/components/EditSections/EditUserPerms/EditUserPerms.js
+++ b/src/components/EditSections/EditUserPerms/EditUserPerms.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { IfPermission, IfInterface } from '@folio/stripes/components';
+import { IfPermission, IfInterface } from '@folio/stripes/core';
 
 import EditablePermissions from '../../EditablePermissions';
 


### PR DESCRIPTION
Yahoo! This is your deprecation!
Yahoo! This is your deprecation!
Deprecate stripes things, come on! Let's deprecate!
Deprecate stripes things, come on! LET'S DEPRECATE!

There's an import goin' on right here
Checks interfaces, checks access for yer,
Was in components, it's deprecated from there
We gonna get it now right straight from the core