### PR TITLE
link to open requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Create permission "Fees/Fines: All Actions permissions". Ref UIU-673.
 * Implement CRUD Manual Patron Block. Ref UIU-674.
 * Create permission "Patron blocks: All permissions". Ref UIU-728.
+* Request queue link should include only open requests. Fixes UIU-716.
 
 ## [2.17.0](https://github.com/folio-org/ui-users/tree/v2.17.0) (2018-10-5)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.16.0...v2.17.0)

--- a/src/components/Loans/OpenLoans/OpenLoans.js
+++ b/src/components/Loans/OpenLoans/OpenLoans.js
@@ -576,9 +576,13 @@ class OpenLoans extends React.Component {
     if (e) e.preventDefault();
     const q = {};
     Object.keys(this.props.resources.query).forEach((k) => { q[k] = null; });
-    const barcode = _.get(loan, ['item', 'barcode']);
+
+    q.query = _.get(loan, ['item', 'barcode']);
+    q.filters = 'requestStatus.open - not yet filled,requestStatus.open - awaiting pickup';
+    q.sort = 'Request Date';
+
     this.props.mutator.query.update({
-      _path: `/requests?&query=${barcode}&sort=Request%20Date`,
+      _path: '/requests',
       ...q,
     });
   }
@@ -650,7 +654,7 @@ class OpenLoans extends React.Component {
           { requestQueue &&
             (
             <MenuItem itemMeta={{ loan, action: 'showRequestQueue' }}>
-              <Button buttonStyle="dropdownItem" href={`/requests?&query=${_.get(loan, ['item', 'barcode'])}&sort=Request%20Date`}><FormattedMessage id="ui-users.loans.details.requestQueue" /></Button>
+              <Button buttonStyle="dropdownItem" href={`/requests?&query=${_.get(loan, ['item', 'barcode'])}&filters=requestStatus.open%20-%20not%20yet%20filled%2CrequestStatus.open%20-%20awaiting%20pickup&sort=Request%20Date`}><FormattedMessage id="ui-users.loans.details.requestQueue" /></Button>
             </MenuItem>
             )
           }


### PR DESCRIPTION
The request-queue link from the ellipses menu of the open-loans pane
should include filters to show only open loans.

Fixes [UIU-716](https://issues.folio.org/browse/UIU-716)