### PR TITLE
instantiate new Nightmare instance for tests

### DIFF
--- a/test/ui-testing/new_permission_set.js
+++ b/test/ui-testing/new_permission_set.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-console */
 /* global it describe before after */
-module.exports.test = function foo(uiTestCtx, nightmare) {
+module.exports.test = function foo(uiTestCtx, nightmareX) {
   describe('Module test: users:new_permission_set', function bar() {
-    const { config, helpers: { login, openApp, logoutWithoutEnd }, meta: { testVersion } } = uiTestCtx;
+    const { config, helpers: { login, openApp, logout }, meta: { testVersion } } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
     this.timeout(Number(config.test_timeout));
 
     describe('Login > Create new permission set > Confirm creation > Delete permission set > Confirm deletion > Logout\n', () => {
@@ -14,7 +15,7 @@ module.exports.test = function foo(uiTestCtx, nightmare) {
         login(nightmare, config, done); // logs in with the default admin credentials
       });
       after((done) => {
-        logoutWithoutEnd(nightmare, config, done);
+        logout(nightmare, config, done);
       });
 
       it('should open app and find version tag', (done) => {

--- a/test/ui-testing/new_permission_set.js
+++ b/test/ui-testing/new_permission_set.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-/* global it describe before after */
-module.exports.test = function foo(uiTestCtx, nightmareX) {
+/* global it describe before after Nightmare */
+module.exports.test = function foo(uiTestCtx) {
   describe('Module test: users:new_permission_set', function bar() {
     const { config, helpers: { login, openApp, logout }, meta: { testVersion } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
@@ -14,6 +14,7 @@ module.exports.test = function foo(uiTestCtx, nightmareX) {
       before((done) => {
         login(nightmare, config, done); // logs in with the default admin credentials
       });
+
       after((done) => {
         logout(nightmare, config, done);
       });

--- a/test/ui-testing/new_service_point.js
+++ b/test/ui-testing/new_service_point.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-console */
-/* global it describe before after */
-module.exports.test = function foo(uiTestCtx, nightmare) {
+/* global it describe before after Nightmare */
+module.exports.test = function foo(uiTestCtx, nightmareX) {
   describe('Module test: users:new_service_point', function meh() {
-    const { config, helpers: { login, openApp, logoutWithoutEnd }, meta: { testVersion } } = uiTestCtx;
+    const { config, helpers: { login, openApp, logout }, meta: { testVersion } } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
     this.timeout(Number(config.test_timeout));
     const wait = 1111;
 
@@ -13,7 +14,7 @@ module.exports.test = function foo(uiTestCtx, nightmare) {
       const spName = `service_point_${Math.floor(Math.random() * 10000)}`;
 
       before(done => login(nightmare, config, done));
-      after(done => logoutWithoutEnd(nightmare, config, done));
+      after(done => logout(nightmare, config, done));
 
       it('should open app and find version tag', (done) => {
         nightmare

--- a/test/ui-testing/new_service_point.js
+++ b/test/ui-testing/new_service_point.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 /* global it describe before after Nightmare */
-module.exports.test = function foo(uiTestCtx, nightmareX) {
+module.exports.test = function foo(uiTestCtx) {
   describe('Module test: users:new_service_point', function meh() {
     const { config, helpers: { login, openApp, logout }, meta: { testVersion } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);

--- a/test/ui-testing/new_user.js
+++ b/test/ui-testing/new_user.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-/* global it describe before after Nightmare */
-module.exports.test = function meh(uitestctx, nightmareX) {
+/* global it describe after Nightmare */
+module.exports.test = function meh(uitestctx) {
   describe('Module test: users:new_user', function bar() {
     const { config, helpers: { namegen, openApp, logout }, meta: { testVersion } } = uitestctx;
     const nightmare = new Nightmare(config.nightmare);

--- a/test/ui-testing/patron_group.js
+++ b/test/ui-testing/patron_group.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 /* global it describe before after Nightmare */
-module.exports.test = function foo(uiTestCtx, nightmareX) {
+module.exports.test = function foo(uiTestCtx) {
   describe('Module test: users:patron_group', function meh() {
     const { config, helpers: { openApp, login, logout }, meta: { testVersion } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);


### PR DESCRIPTION
Using the passed-in instance of Nightmare leads to weird, weird results
where tests seem to run interleaved with one another and things
generally fall apart in strange, unpredictable ways that ultimately
result in tests that fail when run as part of a suite but succeed when
run individually.

It's like the instance of Nightmare gets tired and just can't keep
itself together. Sadly, this means we can't use Nightmare to collect
coverage data since it's using that single instance that allows us to
generate that data. Alas.

Fixes [UIU-777](https://issues.folio.org/browse/UIU-777), Refs [FOLIO-1660](https://issues.folio.org/browse/FOLIO-1660)