### PR TITLE
STCOM-391 Remove plus sign from translation strings

### DIFF
--- a/src/components/ViewSections/PatronBlock/PatronBlock.js
+++ b/src/components/ViewSections/PatronBlock/PatronBlock.js
@@ -123,7 +123,6 @@ class PatronBlock extends React.Component {
       onToggle,
       accordionId,
       patronBlocks,
-      intl : { formatMessage }
     } = props;
     const {
       sortOrder,
@@ -138,7 +137,9 @@ class PatronBlock extends React.Component {
 
     const displayWhenOpen =
       <Button onClick={e => { props.onClickViewPatronBlock(e, 'add'); }}>
-        {formatMessage({ id: 'ui-users.blocks.buttons.add' })}
+        <Icon icon="plus-sign">
+          <FormattedMessage id="ui-users.blocks.buttons.add" />
+        </Icon>
       </Button>;
     const items =
       <MultiColumnList

--- a/translations/ui-users/ar.json
+++ b/translations/ui-users/ar.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Borrowing",
     "blocks.columns.requests": "Requests",
     "blocks.columns.renewals": "Renewals",
-    "blocks.buttons.add": "+Add Block",
+    "blocks.buttons.add": "Add Block",
     "blocks.label": "Patron Blocks",
     "blocks.form.label.information": "Block information",
     "blocks.form.label.display": "Display Description*",

--- a/translations/ui-users/ca.json
+++ b/translations/ui-users/ca.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Borrowing",
     "blocks.columns.requests": "Requests",
     "blocks.columns.renewals": "Renewals",
-    "blocks.buttons.add": "+Add Block",
+    "blocks.buttons.add": "Add Block",
     "blocks.label": "Patron Blocks",
     "blocks.form.label.information": "Block information",
     "blocks.form.label.display": "Display Description*",

--- a/translations/ui-users/da.json
+++ b/translations/ui-users/da.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Borrowing",
     "blocks.columns.requests": "Requests",
     "blocks.columns.renewals": "Renewals",
-    "blocks.buttons.add": "+Add Block",
+    "blocks.buttons.add": "Add Block",
     "blocks.label": "Patron Blocks",
     "blocks.form.label.information": "Block information",
     "blocks.form.label.display": "Display Description*",

--- a/translations/ui-users/de.json
+++ b/translations/ui-users/de.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Borrowing",
     "blocks.columns.requests": "Requests",
     "blocks.columns.renewals": "Renewals",
-    "blocks.buttons.add": "+Add Block",
+    "blocks.buttons.add": "Add Block",
     "blocks.label": "Patron Blocks",
     "blocks.form.label.information": "Block information",
     "blocks.form.label.display": "Display Description*",

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -724,7 +724,7 @@
   "blocks.columns.borrowing":"Borrowing",
   "blocks.columns.requests":"Requests",
   "blocks.columns.renewals":"Renewals",
-  "blocks.buttons.add":"+ Add Block",
+  "blocks.buttons.add":"Add Block",
   "blocks.label":"Patron Blocks",
   "blocks.reason": "Reason for block:",
   "blocks.modal.header": "Patron blocked from renewing",

--- a/translations/ui-users/es.json
+++ b/translations/ui-users/es.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Borrowing",
     "blocks.columns.requests": "Requests",
     "blocks.columns.renewals": "Renewals",
-    "blocks.buttons.add": "+Add Block",
+    "blocks.buttons.add": "Add Block",
     "blocks.label": "Patron Blocks",
     "blocks.form.label.information": "Block information",
     "blocks.form.label.display": "Display Description*",

--- a/translations/ui-users/es_ES.json
+++ b/translations/ui-users/es_ES.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Borrowing",
     "blocks.columns.requests": "Requests",
     "blocks.columns.renewals": "Renewals",
-    "blocks.buttons.add": "+Add Block",
+    "blocks.buttons.add": "Add Block",
     "blocks.label": "Patron Blocks",
     "blocks.form.label.information": "Block information",
     "blocks.form.label.display": "Display Description*",

--- a/translations/ui-users/fr.json
+++ b/translations/ui-users/fr.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Borrowing",
     "blocks.columns.requests": "Requests",
     "blocks.columns.renewals": "Renewals",
-    "blocks.buttons.add": "+Add Block",
+    "blocks.buttons.add": "Add Block",
     "blocks.label": "Patron Blocks",
     "blocks.form.label.information": "Block information",
     "blocks.form.label.display": "Display Description*",

--- a/translations/ui-users/fr_FR.json
+++ b/translations/ui-users/fr_FR.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Borrowing",
     "blocks.columns.requests": "Requests",
     "blocks.columns.renewals": "Renewals",
-    "blocks.buttons.add": "+Add Block",
+    "blocks.buttons.add": "Add Block",
     "blocks.label": "Patron Blocks",
     "blocks.form.label.information": "Block information",
     "blocks.form.label.display": "Display Description*",

--- a/translations/ui-users/hu.json
+++ b/translations/ui-users/hu.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Borrowing",
     "blocks.columns.requests": "Requests",
     "blocks.columns.renewals": "Renewals",
-    "blocks.buttons.add": "+Add Block",
+    "blocks.buttons.add": "Add Block",
     "blocks.label": "Patron Blocks",
     "blocks.form.label.information": "Block information",
     "blocks.form.label.display": "Display Description*",

--- a/translations/ui-users/it_IT.json
+++ b/translations/ui-users/it_IT.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Prendere in prestito",
     "blocks.columns.requests": "Richieste",
     "blocks.columns.renewals": "Rinnovi",
-    "blocks.buttons.add": "+ Aggiungi blocco",
+    "blocks.buttons.add": "Aggiungi blocco",
     "blocks.label": "Blocchi dell'utente",
     "blocks.form.label.information": "Informazioni sul blocco",
     "blocks.form.label.display": "Descrizione da mostrare",

--- a/translations/ui-users/pt_BR.json
+++ b/translations/ui-users/pt_BR.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Emprestando",
     "blocks.columns.requests": "Solicitações de compra",
     "blocks.columns.renewals": "Renovações",
-    "blocks.buttons.add": "+ Adicionar suspensão",
+    "blocks.buttons.add": "Adicionar suspensão",
     "blocks.label": "Suspensões do usuário",
     "blocks.form.label.information": "Informação sobre suspensão",
     "blocks.form.label.display": "Exibir descrição*",

--- a/translations/ui-users/pt_PT.json
+++ b/translations/ui-users/pt_PT.json
@@ -666,7 +666,7 @@
     "blocks.columns.borrowing": "Borrowing",
     "blocks.columns.requests": "Requests",
     "blocks.columns.renewals": "Renewals",
-    "blocks.buttons.add": "+Add Block",
+    "blocks.buttons.add": "Add Block",
     "blocks.label": "Patron Blocks",
     "blocks.form.label.information": "Block information",
     "blocks.form.label.display": "Display Description*",


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STCOM-391

Related to https://github.com/folio-org/stripes-components/pull/775

## Approach
Instead of having the "+" directly in the translation file, we'll now do:
```
<Icon icon="plus-sign">
  <FormattedMessage id="ui-module.translationId" />
</Icon>
```
