### PR TITLE
UIU-724: Show failure reason on bulk action confirmation modal

### DIFF
--- a/src/components/BulkRenewalDialog/BulkRenewedLoansList.js
+++ b/src/components/BulkRenewalDialog/BulkRenewedLoansList.js
@@ -10,7 +10,6 @@ import {
 import {
   Icon,
   MultiColumnList,
-  Popover,
 } from '@folio/stripes/components';
 
 const propTypes = {
@@ -38,11 +37,6 @@ const BulkRenewedLoansList = (props) => {
   const iconAlignStyle = {
     display: 'flex',
     alignItems: 'center'
-  };
-  const pointerStyle = { cursor: 'pointer' };
-  const popoverStyle = {
-    maxWidth: '300px',
-    textAlign: 'justify'
   };
 
   const visibleColumns = [
@@ -79,31 +73,19 @@ const BulkRenewedLoansList = (props) => {
         renewalStatus: loan => {
           if (failedRenewals.filter(loanObject => loanObject.id === loan.id).length > 0) {
             return (errorMessages) ? (
-              <Popover
-                position="bottom"
-                alignment="start"
-              >
-                <span
-                  style={{
-                    ...iconAlignStyle,
-                    ...pointerStyle,
-                  }}
-                  data-role="target"
-                >
+              <div>
+                <div>
                   <Icon
                     size="medium"
                     icon="exclamation-circle"
                     status="warn"
                   />
                   <FormattedMessage id="ui-users.brd.failedRenewal" />
-                </span>
-                <p
-                  data-role="popover"
-                  style={popoverStyle}
-                >
+                </div>
+                <div>
                   {errorMessages[loan.id]}
-                </p>
-              </Popover>
+                </div>
+              </div>
             ) : null;
           } else {
             return (


### PR DESCRIPTION
# Purpose
As a circulation staff member, I want to see the reason why a renewal has failed at a glance, so that I know whether or not I want to override the failure.
# Screenshots
![screen shot 2018-12-19 at 6 12 06 pm](https://user-images.githubusercontent.com/42577309/50228736-b90d4b00-03b9-11e9-9b6f-f00ccc021dce.png)
