### PR TITLE
STCOM-387 Proof of concept: Eject from Settings smart component

### DIFF
--- a/package.json
+++ b/package.json
@@ -643,9 +643,9 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^1.1.0",
+    "@folio/stripes": "^2.0.0",
     "@folio/stripes-cli": "^1.6.0",
-    "@folio/stripes-core": "^2.17.0",
+    "@folio/stripes-core": "^3.0.0",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
@@ -671,7 +671,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^1.0.0",
+    "@folio/stripes": "^2.0.0",
     "react": "*"
   },
   "optionalDependencies": {

--- a/src/components/AddServicePointModal/AddServicePointModal.js
+++ b/src/components/AddServicePointModal/AddServicePointModal.js
@@ -6,6 +6,7 @@ import {
   intlShape,
 } from 'react-intl';
 import {
+  Button,
   MultiColumnList,
   Checkbox,
   Layout,
@@ -69,17 +70,18 @@ class AddServicePointModal extends React.Component {
 
   renderModalFooter() {
     return (
-      <ModalFooter
-        primaryButton={{
-          id: 'save-service-point-btn',
-          label: <FormattedMessage id="ui-users.saveAndClose" />,
-          onClick: this.onSaveAndClose,
-        }}
-        secondaryButton={{
-          label: <FormattedMessage id="stripes-core.button.cancel" />,
-          onClick: this.onCancel,
-        }}
-      />
+      <ModalFooter>
+        <Button
+          buttonStyle="primary"
+          id="save-service-point-btn"
+          onClick={this.onSaveAndClose}
+        >
+          <FormattedMessage id="ui-users.saveAndClose" />
+        </Button>
+        <Button onClick={this.onCancel}>
+          <FormattedMessage id="stripes-core.button.cancel" />
+        </Button>
+      </ModalFooter>
     );
   }
 

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -2,18 +2,21 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import {
+  Button,
   Modal,
   ModalFooter,
 } from '@folio/stripes/components';
 
 const ErrorModal = (props) => {
   const footer = (
-    <ModalFooter
-      primaryButton={{
-        'label': <FormattedMessage id="ui-users.okay" />,
-        'onClick': props.onClose,
-      }}
-    />
+    <ModalFooter>
+      <Button
+        buttonStyle="primary"
+        onClick={props.onClose}
+      >
+        <FormattedMessage id="ui-users.okay" />
+      </Button>
+    </ModalFooter>
   );
 
   return (

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,0 +1,21 @@
+import React, { Component } from 'react';
+import { stripesShape, withStripes } from '@folio/stripes/core';
+
+export default function stripesConnect(WrappedComponent) {
+  class ConnectedComponent extends Component {
+    static propTypes = {
+      stripes: stripesShape.isRequired
+    }
+
+    constructor(props) {
+      super(props);
+      this.connectedComponent = props.stripes.connect(WrappedComponent);
+    }
+
+    render() {
+      return <this.connectedComponent {...this.props} />;
+    }
+  }
+
+  return withStripes(ConnectedComponent);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,21 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import Route from 'react-router-dom/Route';
-import Switch from 'react-router-dom/Switch';
 import { hot } from 'react-hot-loader';
+
+import { Route, Switch } from './router';
 import Users from './Users';
 import Settings from './settings';
+import PermissionSets from './settings/permissions/PermissionSets';
+import PatronGroupsSettings from './settings/PatronGroupsSettings';
+import AddressTypesSettings from './settings/AddressTypesSettings';
+import ProfilePictureSettings from './settings/ProfilePictureSettings';
+import OwnerSettings from './settings/OwnerSettings';
+import FeeFineSettings from './settings/FeeFineSettings';
+import WaiveSettings from './settings/WaiveSettings';
+import PaymentSettings from './settings/PaymentSettings';
+import CommentRequiredSettings from './settings/CommentRequiredSettings';
+import RefundReasonsSettings from './settings/RefundReasonsSettings';
 import { CommandList } from './components/Commander';
 import commands from './commands';
 
@@ -48,12 +58,47 @@ class UsersRouting extends React.Component {
 
   render() {
     const {
-      showSettings,
       match: { path },
+      showSettings,
+      stripes,
     } = this.props;
 
     if (showSettings) {
-      return <Settings {...this.props} />;
+      return (
+        <Route path={path} component={Settings}>
+          <Switch>
+            {stripes.hasPerm('ui-users.settings.addresstypes') && (
+              <Route path={`${path}/addresstypes`} exact component={AddressTypesSettings} />
+            )}
+            {stripes.hasPerm('ui-users.settings.usergroups') && (
+              <Route path={`${path}/groups`} exact component={PatronGroupsSettings} />
+            )}
+            {stripes.hasPerm('ui-users.editpermsets') && (
+              <Route path={`${path}/perms`} exact component={PermissionSets} />
+            )}
+            <Route path={`${path}/profilepictures`} exact component={ProfilePictureSettings} />
+
+            {stripes.hasPerm('ui-users.settings.feefine') && (
+              <Route path={`${path}/comments`} exact component={CommentRequiredSettings} />
+            )}
+            {stripes.hasPerm('ui-users.settings.feefine') && (
+              <Route path={`${path}/feefinestable`} exact component={FeeFineSettings} />
+            )}
+            {stripes.hasPerm('ui-users.settings.feefine') && (
+              <Route path={`${path}/owners`} exact component={OwnerSettings} />
+            )}
+            {stripes.hasPerm('ui-users.settings.feefine') && (
+              <Route path={`${path}/payments`} exact component={PaymentSettings} />
+            )}
+            {stripes.hasPerm('ui-users.settings.feefine') && (
+              <Route path={`${path}/refunds`} exact component={RefundReasonsSettings} />
+            )}
+            {stripes.hasPerm('ui-users.settings.feefine') && (
+              <Route path={`${path}/waivereasons`} exact component={WaiveSettings} />
+            )}
+          </Switch>
+        </Route>
+      );
     }
 
     return (

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Route as RouterRoute } from 'react-router-dom';
+
+export { Switch, Redirect } from 'react-router-dom';
+
+/**
+ * Pass the children of a Route to the component that is responsible for rendering it.
+ * This allows us to have a single route hierarchy, where the routing
+ * components are responsible for marshalling data, and providing high
+ * level layout:
+ *
+ *   // routes.js
+ *   <Route component={ParentRoute}>
+ *     <Route component={ChildRoute}/>
+ *   </Route>
+ *
+ *   // parent-route.js
+ *   import Layout from './layout';
+ *   export default class ParentRoute extends Component {
+ *     render() {
+ *       return (<Layout>{children}</Layout>);
+ *     }
+ *   }
+ *
+ * will take all of the children of the top level `Route` component,
+ * and pass them as the children of the `ParentRoute` component.
+ */
+export function Route({ component: Component, children, ...props }) {
+  // we currently always provide a component
+  /* istanbul ignore else */
+  if (Component) {
+    return (
+      <RouterRoute {...props} render={props => (<Component {...props}>{children}</Component>)} /> // eslint-disable-line no-shadow
+    );
+  } else {
+    return (<RouterRoute {...props}>{children}</RouterRoute>);
+  }
+}
+
+Route.propTypes = {
+  children: PropTypes.node,
+  component: PropTypes.func
+};

--- a/src/settings/AddressTypesSettings.js
+++ b/src/settings/AddressTypesSettings.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { compose } from 'redux';
 import {
   FormattedMessage,
   injectIntl,
   intlShape,
 } from 'react-intl';
+import { withStripes } from '@folio/stripes/core';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
 class AddressTypesSettings extends React.Component {
@@ -47,4 +49,7 @@ class AddressTypesSettings extends React.Component {
   }
 }
 
-export default injectIntl(AddressTypesSettings);
+export default compose(
+  injectIntl,
+  withStripes,
+)(AddressTypesSettings);

--- a/src/settings/CommentRequiredSettings.js
+++ b/src/settings/CommentRequiredSettings.js
@@ -1,8 +1,10 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { compose } from 'redux';
 import { Callout } from '@folio/stripes/components';
 import { injectIntl, FormattedMessage } from 'react-intl';
+import stripesConnect from '../connect';
 
 import CommentRequiredForm from './CommentRequiredForm';
 
@@ -82,4 +84,8 @@ class CommentRequiredSettings extends React.Component {
     );
   }
 }
-export default injectIntl(CommentRequiredSettings);
+
+export default compose(
+  injectIntl,
+  stripesConnect,
+)(CommentRequiredSettings);

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
+import { compose } from 'redux';
 import {
   injectIntl,
   FormattedMessage
@@ -17,6 +18,7 @@ import {
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { EditableList } from '@folio/stripes/smart-components';
 import { validate } from '../util';
+import stripesConnect from '../connect';
 
 import {
   Owners,
@@ -332,4 +334,7 @@ class FeefineSettings extends React.Component {
   }
 }
 
-export default injectIntl(FeefineSettings);
+export default compose(
+  injectIntl,
+  stripesConnect,
+)(FeefineSettings);

--- a/src/settings/OwnerSettings.js
+++ b/src/settings/OwnerSettings.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
+import { compose } from 'redux';
 import {
   FormattedMessage,
   intlShape,
@@ -20,6 +21,7 @@ import { Field } from 'redux-form';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { EditableList } from '@folio/stripes/smart-components';
 import { validate } from '../util';
+import stripesConnect from '../connect';
 
 class OwnerSettings extends React.Component {
   static manifest = Object.freeze({
@@ -333,4 +335,7 @@ class OwnerSettings extends React.Component {
   }
 }
 
-export default injectIntl(OwnerSettings);
+export default compose(
+  injectIntl,
+  stripesConnect,
+)(OwnerSettings);

--- a/src/settings/PatronGroupsSettings.js
+++ b/src/settings/PatronGroupsSettings.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { compose } from 'redux';
 import {
   FormattedMessage,
   injectIntl,
   intlShape,
 } from 'react-intl';
+import { withStripes } from '@folio/stripes/core';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
 import PatronGroupNumberOfUsers from '../components/PatronGroupNumberOfUsers';
+import stripesConnect from '../connect';
 
 class PatronGroupsSettings extends React.Component {
   // adding the desired-count parameter, :50, to this query is an egregious
@@ -76,4 +79,8 @@ class PatronGroupsSettings extends React.Component {
   }
 }
 
-export default injectIntl(PatronGroupsSettings);
+export default compose(
+  injectIntl,
+  stripesConnect,
+  withStripes,
+)(PatronGroupsSettings);

--- a/src/settings/PaymentSettings.js
+++ b/src/settings/PaymentSettings.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
+import { compose } from 'redux';
 import {
   injectIntl,
   FormattedMessage,
@@ -24,6 +25,7 @@ import {
   UserName
 } from '@folio/stripes/smart-components';
 import { validate } from '../util';
+import stripesConnect from '../connect';
 
 import {
   Owners,
@@ -324,4 +326,7 @@ class PaymentSettings extends React.Component {
   }
 }
 
-export default injectIntl(PaymentSettings);
+export default compose(
+  injectIntl,
+  stripesConnect,
+)(PaymentSettings);

--- a/src/settings/ProfilePictureSettings.js
+++ b/src/settings/ProfilePictureSettings.js
@@ -7,11 +7,11 @@ import {
   Checkbox,
 } from '@folio/stripes/components';
 import { Field } from 'redux-form';
+import { withStripes } from '@folio/stripes/core';
 import { ConfigManager } from '@folio/stripes/smart-components';
 
 class ProfilePictureSettings extends React.Component {
   static propTypes = {
-    label: PropTypes.string,
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
     }).isRequired,
@@ -29,11 +29,10 @@ class ProfilePictureSettings extends React.Component {
   }
 
   render() {
-    const { label } = this.props;
     return (
       <this.configManager
         getInitialValues={this.getInitialValues}
-        label={label}
+        label={<FormattedMessage id="ui-users.settings.profilePictures" />}
         moduleName="USERS"
         configName="profile_pictures"
       >
@@ -53,4 +52,4 @@ class ProfilePictureSettings extends React.Component {
   }
 }
 
-export default ProfilePictureSettings;
+export default withStripes(ProfilePictureSettings);

--- a/src/settings/RefundReasonsSettings.js
+++ b/src/settings/RefundReasonsSettings.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { compose } from 'redux';
 import {
   injectIntl,
   intlShape,
 } from 'react-intl';
+import { withStripes } from '@folio/stripes/core';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { validate } from '../util';
 
@@ -47,4 +49,7 @@ class RefundReasonsSettings extends React.Component {
   }
 }
 
-export default injectIntl(RefundReasonsSettings);
+export default compose(
+  injectIntl,
+  withStripes,
+)(RefundReasonsSettings);

--- a/src/settings/WaiveSettings.js
+++ b/src/settings/WaiveSettings.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { compose } from 'redux';
 import {
   injectIntl,
   intlShape,
 } from 'react-intl';
+import { withStripes } from '@folio/stripes/core';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { validate } from '../util';
 
@@ -51,4 +53,7 @@ class WaiveSettings extends React.Component {
   }
 }
 
-export default injectIntl(WaiveSettings);
+export default compose(
+  injectIntl,
+  withStripes,
+)(WaiveSettings);

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,125 +1,88 @@
-import _ from 'lodash';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { IfPermission } from '@folio/stripes/core';
 import {
-  FormattedMessage,
-  injectIntl,
-  intlShape,
-} from 'react-intl';
+  Headline,
+  NavList,
+  NavListItem,
+  NavListSection,
+  Pane,
+  PaneBackLink,
+} from '@folio/stripes/components';
 
-import { Settings } from '@folio/stripes/smart-components';
-
-import PermissionSets from './permissions/PermissionSets';
-import PatronGroupsSettings from './PatronGroupsSettings';
-import AddressTypesSettings from './AddressTypesSettings';
-import ProfilePictureSettings from './ProfilePictureSettings';
-import OwnerSettings from './OwnerSettings';
-import FeeFineSettings from './FeeFineSettings';
-import WaiveSettings from './WaiveSettings';
-import PaymentSettings from './PaymentSettings';
-import CommentRequiredSettings from './CommentRequiredSettings';
-import RefundReasonsSettings from './RefundReasonsSettings';
-
-class UsersSettings extends Component {
+export default class UsersSettings extends Component {
   static propTypes = {
-    intl: intlShape.isRequired,
+    children: PropTypes.node,
   };
 
-  // eslint-disable-next-line react/sort-comp
   render() {
+    const { children } = this.props;
+
     return (
-      <Settings
-        {...this.props}
-        sections={this.getSections()}
-        paneTitle={<FormattedMessage id="ui-users.settings.label" />}
-      />
+      <Fragment>
+        <Pane
+          defaultWidth="20%"
+          paneTitle={
+            <Headline tag="h3" margin="none">
+              <FormattedMessage id="ui-users.settings.label" />
+            </Headline>
+          }
+          firstMenu={(
+            <PaneBackLink to="/settings" />
+          )}
+        >
+          <NavList>
+            <NavListSection
+              label={<FormattedMessage id="ui-users.settings.general" />}
+            >
+              <IfPermission perm="ui-users.settings.addresstypes">
+                <NavListItem to="/settings/users/addresstypes">
+                  <FormattedMessage id="ui-users.settings.addressTypes" />
+                </NavListItem>
+              </IfPermission>
+              <IfPermission perm="ui-users.settings.usergroups">
+                <NavListItem to="/settings/users/groups">
+                  <FormattedMessage id="ui-users.settings.patronGroups" />
+                </NavListItem>
+              </IfPermission>
+              <IfPermission perm="ui-users.editpermsets">
+                <NavListItem to="/settings/users/perms">
+                  <FormattedMessage id="ui-users.settings.permissionSet" />
+                </NavListItem>
+              </IfPermission>
+              <NavListItem to="/settings/users/profilepictures">
+                <FormattedMessage id="ui-users.settings.profilePictures" />
+              </NavListItem>
+            </NavListSection>
+            <NavListSection
+              label={<FormattedMessage id="ui-users.settings.feefine" />}
+            >
+              <IfPermission perm="ui-users.settings.feefine">
+                <NavListItem to="/settings/users/comments">
+                  <FormattedMessage id="ui-users.settings.commentRequired" />
+                </NavListItem>
+                <NavListItem to="/settings/users/feefinestable">
+                  <FormattedMessage id="ui-users.settings.manualCharges" />
+                </NavListItem>
+                <NavListItem to="/settings/users/owners">
+                  <FormattedMessage id="ui-users.settings.owners" />
+                </NavListItem>
+                <NavListItem to="/settings/users/payments">
+                  <FormattedMessage id="ui-users.settings.paymentMethods" />
+                </NavListItem>
+                <NavListItem to="/settings/users/refunds">
+                  <FormattedMessage id="ui-users.settings.refundReasons" />
+                </NavListItem>
+                <NavListItem to="/settings/users/waivereasons">
+                  <FormattedMessage id="ui-users.settings.waiveReasons" />
+                </NavListItem>
+              </IfPermission>
+            </NavListSection>
+          </NavList>
+        </Pane>
+        {children}
+      </Fragment>
     );
   }
-
-  getSections() {
-    return [
-      {
-        label: <FormattedMessage id="ui-users.settings.general" />,
-        pages: _.sortBy(this.getGeneral(), ['label']),
-      },
-      {
-        label: <FormattedMessage id="ui-users.settings.feefine" />,
-        pages: _.sortBy(this.getFeefines(), ['label']),
-      },
-    ];
-  }
-
-  getGeneral() {
-    const { formatMessage } = this.props.intl;
-
-    return [
-      {
-        route: 'perms',
-        label: formatMessage({ id: 'ui-users.settings.permissionSet' }),
-        component: PermissionSets,
-        perm: 'ui-users.editpermsets',
-      },
-      {
-        route: 'groups',
-        label: formatMessage({ id: 'ui-users.settings.patronGroups' }),
-        component: PatronGroupsSettings,
-        perm: 'ui-users.settings.usergroups',
-      },
-      {
-        route: 'addresstypes',
-        label: formatMessage({ id: 'ui-users.settings.addressTypes' }),
-        component: AddressTypesSettings,
-        perm: 'ui-users.settings.addresstypes',
-      },
-      {
-        route: 'profilepictures',
-        label: formatMessage({ id: 'ui-users.settings.profilePictures' }),
-        component: ProfilePictureSettings,
-      },
-    ];
-  }
-
-  getFeefines() {
-    const { formatMessage } = this.props.intl;
-
-    return [
-      {
-        route: 'owners',
-        label: formatMessage({ id: 'ui-users.settings.owners' }),
-        component: OwnerSettings,
-        perm: 'ui-users.settings.feefine',
-      },
-      {
-        route: 'feefinestable',
-        label: formatMessage({ id: 'ui-users.settings.manualCharges' }),
-        component: FeeFineSettings,
-        perm: 'ui-users.settings.feefine',
-      },
-      {
-        route: 'waivereasons',
-        label: formatMessage({ id: 'ui-users.settings.waiveReasons' }),
-        component: WaiveSettings,
-        perm: 'ui-users.settings.feefine',
-      },
-      {
-        route: 'payments',
-        label: formatMessage({ id: 'ui-users.settings.paymentMethods' }),
-        component: PaymentSettings,
-        perm: 'ui-users.settings.feefine',
-      },
-      {
-        route: 'refunds',
-        label: formatMessage({ id: 'ui-users.settings.refundReasons' }),
-        component: RefundReasonsSettings,
-        perm: 'ui-users.settings.feefine',
-      },
-      {
-        route: 'comments',
-        label: formatMessage({ id: 'ui-users.settings.commentRequired' }),
-        component: CommentRequiredSettings,
-        perm: 'ui-users.settings.feefine',
-      },
-    ];
-  }
 }
-
-export default injectIntl(UsersSettings);

--- a/src/settings/permissions/PermissionSets.js
+++ b/src/settings/permissions/PermissionSets.js
@@ -1,16 +1,13 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  injectIntl,
-  intlShape,
-  FormattedMessage,
-} from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { EntryManager } from '@folio/stripes/smart-components';
 
 import PermissionSetDetails from './PermissionSetDetails';
 import PermissionSetForm from './PermissionSetForm';
+import stripesConnect from '../../connect';
 
 function validate(values) {
   const errors = {};
@@ -44,7 +41,6 @@ class PermissionSets extends React.Component {
   });
 
   static propTypes = {
-    label: PropTypes.string.isRequired,
     resources: PropTypes.shape({
       entries: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
@@ -57,15 +53,12 @@ class PermissionSets extends React.Component {
         DELETE: PropTypes.func,
       }),
     }).isRequired,
-    intl: intlShape.isRequired,
   };
 
   render() {
     const {
       mutator,
       resources: { entries },
-      label,
-      intl,
     } = this.props;
 
     return (
@@ -74,8 +67,8 @@ class PermissionSets extends React.Component {
         parentMutator={mutator}
         entryList={_.sortBy((entries || {}).records || [], ['displayName'])}
         detailComponent={PermissionSetDetails}
-        paneTitle={label}
-        entryLabel={intl.formatMessage({ id: 'ui-users.permissionSet' })}
+        paneTitle={<FormattedMessage id="ui-users.settings.permissionSet" />}
+        entryLabel={<FormattedMessage id="ui-users.permissionSet" />}
         entryFormComponent={PermissionSetForm}
         validate={validate}
         nameKey="displayName"
@@ -89,4 +82,4 @@ class PermissionSets extends React.Component {
   }
 }
 
-export default injectIntl(PermissionSets);
+export default stripesConnect(PermissionSets);


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STCOM-387

The `<Settings>` smart component contains routing glue, which is at odds with the routing-based architecture strategy outlined in https://issues.folio.org/browse/STRIPES-589.

## Approach
We have all the UI we need from `stripes-components` to be able to construct this functionality with the `<Settings>` smart component, in a way that `ui-users` is in complete control of its settings routing.

This PR does _not_ rearrange `ui-users`'s `src/settings` file organization to clearly delineate route/container components from purely presentational view components. That should be a future scope of work.

I created a `stripesConnect()` function that makes it easier for route/container components to do their own connection to the data layer, instead of a parent component needing to do it for them.

### Breaking change
The `<Settings>` smart component attempts to programmatically alphabetize the items in each `<NavListSection>` - this PR does not maintain that functionality.

## Blocking issue
The permission sets UI uses `<EntryManager>`, which also defines routes. With this PR, the permission set routes don't work, since they're nested (and don't use the nested route fork presented here). We'll need to figure out an alternate strategy for `ui-users` to be able to own those route definitions instead: https://issues.folio.org/browse/STSMACOM-161