### PR TITLE
support updated okapi interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.21.0 (IN PROGRESS)
+
+* Support login v5, bl-users v4 in parallel with previous releases.
+
 ## [2.20.0](https://github.com/folio-org/ui-users/tree/v2.20.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.19.0...v2.20.0)
 

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
       "permissions": "5.0",
       "loan-policy-storage": "1.0",
       "loan-storage": "4.0 5.0",
-      "login": "4.7",
+      "login": "4.7 5.0",
       "feesfines": "15.0",
       "request-storage": "2.2",
-      "users-bl": "3.2"
+      "users-bl": "3.2 4.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
New features were added in users-bl that necessitated bumping its
interface, but without support for the new interface in the UI, we
couldn't build folio-snapshot. Providing parallel support for the old
interface (since no functionality here is changing) and the new
interface (so that backend dependencies can be satisfied) seems like the
least painful solution.

Refs [FOLIO-1735](https://issues.folio.org/browse/FOLIO-1735), [MODLOGIN-103](https://issues.folio.org/browse/MODLOGIN-103), [MODUSERBL-62](https://issues.folio.org/browse/MODUSERBL-62)