### PR TITLE
Rely on url changes instead of query resource. Fixes UIU-878

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 yarn.lock
 yarn-error.log
 ModuleDescriptor.json
+artifacts

--- a/src/Users.js
+++ b/src/Users.js
@@ -8,7 +8,7 @@ import {
 } from 'react-intl';
 
 import { makeQueryFunction, SearchAndSort } from '@folio/stripes/smart-components';
-import { AppIcon } from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes-core/src/components';
 
 import uuid from 'uuid';
 import ViewUser from './ViewUser';

--- a/src/Users.js
+++ b/src/Users.js
@@ -8,7 +8,7 @@ import {
 } from 'react-intl';
 
 import { makeQueryFunction, SearchAndSort } from '@folio/stripes/smart-components';
-import { AppIcon } from '@folio/stripes-core/src/components';
+import { AppIcon } from '@folio/stripes/components';
 
 import uuid from 'uuid';
 import ViewUser from './ViewUser';

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -577,7 +577,9 @@ class ViewUser extends React.Component {
   };
 
   isLayerOpen = value => {
-    const { layer } = this.props.resources.query;
+    const { location: { search } } = this.props;
+    const query = queryString.parse(search || '');
+    const { layer } = query;
     return layer === value;
   };
 

--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -14,8 +14,9 @@ import {
   TextArea,
   Checkbox,
   Datepicker,
-  AppIcon
 } from '@folio/stripes/components';
+
+import { AppIcon } from '@folio/stripes-core/src/components';
 import { TitleManager } from '@folio/stripes/core';
 import { Field } from 'redux-form';
 import stripesForm from '@folio/stripes/form';

--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -14,9 +14,9 @@ import {
   TextArea,
   Checkbox,
   Datepicker,
+  AppIcon,
 } from '@folio/stripes/components';
 
-import { AppIcon } from '@folio/stripes-core/src/components';
 import { TitleManager } from '@folio/stripes/core';
 import { Field } from 'redux-form';
 import stripesForm from '@folio/stripes/form';

--- a/test/bigtest/interactors/users.js
+++ b/test/bigtest/interactors/users.js
@@ -7,6 +7,6 @@ import {
 export default @interactor class UsersInteractor {
   static defaultScope = '[data-test-user-instances]';
 
-  instances = collection('[role=listitem] a');
+  instances = collection('[role=row] a');
   instance = scoped('[data-test-instance-details]');
 }

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -185,4 +185,6 @@ export default function config() {
     owners: [],
     totalRecords: 0,
   });
+
+  this.get('/authn/credentials-existence', () => {});
 }


### PR DESCRIPTION
This PR fixes a bug where unsaved changes modal is not shown after a record is being changed and closed.

Here are couple more details about what is going on:

1. We click on an edit link and the query resource is updated with the `{ layer: edit }` which eventually propagates to `history.push` https://github.com/folio-org/stripes-core/blob/master/src/locationService.js#L74

2. The form is now visible. The stripes-form registers a block: https://github.com/folio-org/stripes-form/blob/master/lib/StripesFormWrapper.js#L25 

3. We make a change on the form and hit close. 

4. The query resource is updated to `{ layer: null }`. This triggers re-render of the `ViewUser`. Since the previous implementation relies on the state of the query resource the `ViewUser` will hide the user form: https://github.com/folio-org/ui-users/blob/master/src/ViewUser.js#L783 and eventually call `componentWillUnmount` on stripes-form: https://github.com/folio-org/stripes-form/blob/master/lib/StripesFormWrapper.js#L38-L42 which causes to unblock the previously registered block in 2) (the unsaved changes modal is now gone).

The change in the PR will rely on URL (browser history) changes instead of query resource.