### PR TITLE
don't pass appIcon to Pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support login v5, bl-users v4 in parallel with previous releases.
 * Add "all actions" permission from Closed Loans. Fix UIU-867.
 * Update integration tests to accommodate MCL aria changes. Fixes UIU-880.
+* Don't pass `appIcon` to `<Pane>`.
 
 ## [2.20.0](https://github.com/folio-org/ui-users/tree/v2.20.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.19.0...v2.20.0)

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
+import { AppIcon } from '@folio/stripes/core';
 import {
   Paneset,
   Pane,
@@ -321,8 +322,21 @@ class UserForm extends React.Component {
               defaultWidth="100%"
               firstMenu={firstMenu}
               lastMenu={lastMenu}
-              paneTitle={paneTitle}
-              appIcon={{ app: 'users' }}
+              paneTitle={
+                <div
+                  style={{ textAlign: 'center' }}
+                  data-test-header-title
+                >
+                  <AppIcon
+                    app="users"
+                    appIconKey="users"
+                    size="small"
+                  />
+                  <span style={{ margin: '0 4px' }}>
+                    {paneTitle}
+                  </span>
+                </div>
+              }
               actionMenu={this.getActionMenu}
             >
               <div className={css.UserFormContent}>

--- a/src/Users.js
+++ b/src/Users.js
@@ -8,7 +8,7 @@ import {
 } from 'react-intl';
 
 import { makeQueryFunction, SearchAndSort } from '@folio/stripes/smart-components';
-import { AppIcon } from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes/core';
 
 import uuid from 'uuid';
 import ViewUser from './ViewUser';

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import queryString from 'query-string';
 import {
+  AppIcon,
   IfInterface,
   IfPermission,
   TitleManager,
@@ -924,15 +925,25 @@ class ViewUser extends React.Component {
         data-test-instance-details
         id="pane-userdetails"
         defaultWidth={paneWidth}
-        paneTitle={(
-          <span data-test-header-title>
-            {getFullName(user)}
-          </span>
-        )}
+        paneTitle={
+          <div
+            style={{ textAlign: 'center' }}
+            data-test-header-title
+          >
+            <AppIcon
+              iconAriaHidden
+              app="users"
+              appIconKey="users"
+              size="small"
+            />
+            <span style={{ margin: '0 4px' }}>
+              {getFullName(user)}
+            </span>
+          </div>
+        }
         lastMenu={detailMenu}
         dismissible
         onClose={onClose}
-        appIcon={{ app: 'users' }}
         actionMenu={this.getActionMenu}
       >
         <TitleManager record={getFullName(user)} />

--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -13,11 +13,12 @@ import {
   IconButton,
   TextArea,
   Checkbox,
-  Datepicker,
-  AppIcon,
+  Datepicker
 } from '@folio/stripes/components';
-
-import { TitleManager } from '@folio/stripes/core';
+import {
+  AppIcon,
+  TitleManager
+} from '@folio/stripes/core';
 import { Field } from 'redux-form';
 import stripesForm from '@folio/stripes/form';
 import { ViewMetaData } from '@folio/stripes/smart-components';


### PR DESCRIPTION
`<Pane>` eventually causes its `appIcon` prop to create a new
`<AppIcon>` by importing from `@folio/stripes/components`, which has
been deprecated. So, instead of allowing that to happen, these changes
instantiate their own `<AppIcon>` instances from `@folio/stripes/core`
and push it through the `paneTitle` prop.

Look, ma! No more console warnings!