### PR TITLE
Fix failing users test

### DIFF
--- a/test/bigtest/interactors/users.js
+++ b/test/bigtest/interactors/users.js
@@ -1,12 +1,13 @@
 import {
   interactor,
   scoped,
-  collection
+  collection,
+  clickable
 } from '@bigtest/interactor';
 
 export default @interactor class UsersInteractor {
   static defaultScope = '[data-test-user-instances]';
-
+  clickInactiveUsersCheckbox = clickable('[name="active.Include inactive users"]');
   instances = collection('[role=row] a');
   instance = scoped('[data-test-instance-details]');
 }

--- a/test/bigtest/tests/users-show-all-test.js
+++ b/test/bigtest/tests/users-show-all-test.js
@@ -12,7 +12,9 @@ describe('Users', () => {
 
   beforeEach(async function () {
     this.server.createList('user', 3);
-    this.visit('/users?filters=active.Include%20inactive%20users&sort=Name');
+    this.visit('/users?sort=Name');
+
+    await users.clickInactiveUsersCheckbox();
   });
 
   it('shows the list of user items', () => {


### PR DESCRIPTION
It looks like selecting filter by entering a specific URL doesn't work. The test has been changed and the inactive users filter checkbox is clicked manually now.