### PR TITLE
provide unique ID to find-user plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update integration tests to accommodate MCL aria changes. Fixes UIU-880.
 * Don't pass `appIcon` to `<Pane>`.
 * Use static column labels, not their aliases, as keys to CQL sort table. Refs UIU-479, UIU-864, STSMACOM-93.
+* Provide unique ID for find-user plugin. Refs UIU-884.
 
 ## [2.20.0](https://github.com/folio-org/ui-users/tree/v2.20.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.19.0...v2.20.0)

--- a/src/components/ProxyGroup/ProxyEditList/ProxyEditList.js
+++ b/src/components/ProxyGroup/ProxyEditList/ProxyEditList.js
@@ -191,6 +191,7 @@ class ProxyEditList extends React.Component {
             <Layout>
               <Pluggable
                 aria-haspopup="true"
+                id={`clickable-plugin-find-${name === 'proxies' ? 'proxy' : 'sponsor'}`}
                 type="find-user"
                 {...this.props}
                 dataKey={name}


### PR DESCRIPTION
The edit-user page contains two instances of the find-user plugin. Each
needs a unique ID. This prevents us from generating invalid HTML and
also helps with tests which may want to distinguish adding a proxy from
adding a sponsor.

Refs [UIU-884](https://issues.folio.org/browse/UIU-884)