### PR TITLE
Pass <AppIcon> to <Pane>

### DIFF
--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -320,24 +320,15 @@ class UserForm extends React.Component {
           <Paneset isRoot>
             <Pane
               defaultWidth="100%"
+              actionMenu={this.getActionMenu}
               firstMenu={firstMenu}
               lastMenu={lastMenu}
+              appIcon={<AppIcon app="users" appIconKey="users" />}
               paneTitle={
-                <div
-                  style={{ textAlign: 'center' }}
-                  data-test-header-title
-                >
-                  <AppIcon
-                    app="users"
-                    appIconKey="users"
-                    size="small"
-                  />
-                  <span style={{ margin: '0 4px' }}>
-                    {paneTitle}
-                  </span>
-                </div>
+                <span data-test-header-title>
+                  {paneTitle}
+                </span>
               }
-              actionMenu={this.getActionMenu}
             >
               <div className={css.UserFormContent}>
                 <Headline

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -924,22 +924,12 @@ class ViewUser extends React.Component {
       <Pane
         data-test-instance-details
         id="pane-userdetails"
+        appIcon={<AppIcon app="users" appIconKey="users" />}
         defaultWidth={paneWidth}
         paneTitle={
-          <div
-            style={{ textAlign: 'center' }}
-            data-test-header-title
-          >
-            <AppIcon
-              iconAriaHidden
-              app="users"
-              appIconKey="users"
-              size="small"
-            />
-            <span style={{ margin: '0 4px' }}>
-              {getFullName(user)}
-            </span>
-          </div>
+          <span data-test-header-title>
+            {getFullName(user)}
+          </span>
         }
         lastMenu={detailMenu}
         dismissible

--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -183,13 +183,7 @@ class PatronBlockForm extends React.Component {
   render() {
     const user = this.props.user || {};
     const { intl } = this.props;
-    const title = this.props.query.layer === 'edit-block' ?
-      <div>
-        {' '}
-        <AppIcon app="users" size="small" />
-        {getFullName(user)}
-        {' '}
-      </div> : 'New Block';
+    const title = this.props.query.layer === 'edit-block' ? getFullName(user) : intl.formatMessage({ id: 'ui-users.blocks.layer.newBlockTitle' });
     const userD = this.props.query.layer !== 'edit-block' ? <UserDetails user={user} /> : '';
 
     const isSelectedItemMetadata = this.props.selectedItem || {};
@@ -198,8 +192,9 @@ class PatronBlockForm extends React.Component {
       <Pane
         defaultWidth="20%"
         firstMenu={this.renderFirstMenu()}
-        paneTitle={title}
         lastMenu={this.renderLastMenu()}
+        appIcon={<AppIcon app="users" size="small" />}
+        paneTitle={title}
       >
         <TitleManager />
         {userD}

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -780,6 +780,7 @@
   "blocks.layer.heading":"Delete patron block?",
   "blocks.layer.confirmLabel":"Delete",
   "blocks.layer.add":"Add Block",
+  "blocks.layer.newBlockTitle":"New Block",
   "blocks.layer.edit":"Edit Block",
 
   "blocks.message":"patron block will be removed",


### PR DESCRIPTION
In this PR I updated the AppIcon implementation in Pane's to use the dedicated `appIcon`-prop instead of rendering AppIcon's inside the PaneTitle.

This gives us better central control of the PaneHeader layout and ensures that RTL and text ellipsis are working as intended.