### PR TITLE
Use packageInfo passed via props if present. Refs ERM-72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix prompted to copy Manual Charges. Fix UIU-858.
 * Fix labels on Pay and Waive modals. Fix UIU-845.
 * Update circulation v7.0 and request-storage v3.0 OKAPI interfaces. Part of UIU-889.
+* Use packageInfo passed via props if present. Part of ERM-72.
 
 ## [2.20.0](https://github.com/folio-org/ui-users/tree/v2.20.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.19.0...v2.20.0)

--- a/src/Users.js
+++ b/src/Users.js
@@ -135,6 +135,7 @@ class Users extends React.Component {
     showSingleResult: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
     browseOnly: PropTypes.bool,
     intl: intlShape.isRequired,
+    packageInfo: PropTypes.object,
   };
 
   static defaultProps = {
@@ -248,7 +249,7 @@ class Users extends React.Component {
       <div data-test-user-instances>
         <HasCommand commands={this.keyboardCommands}>
           <SearchAndSort
-            packageInfo={packageInfo}
+            packageInfo={this.props.packageInfo || packageInfo}
             objectName="user"
             filterConfig={filterConfig}
             initialResultCount={INITIAL_RESULT_COUNT}


### PR DESCRIPTION
This PR uses `packageInfo` passed as a prop instead of the one found in `ui-users` package.json. This is required in order to detect if we are dealing with the `app` or `plugin` module in `SearchAndSort` which will help with fixing https://issues.folio.org/browse/ERM-72.