### PR TITLE
support "Open - In transit" status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Add feature "Notify patron of new manual fee/fine charge". Fix UIU-710.
 * Add feature "Notify patron of fee/fine payment received". Fix UIU-711.
 * Add feature "Charge notice and action notice options to manual fee/fine settings screen". Fix UIU-713.
+* Support "Open - In transit" status. Fixes UIU-682.
 
 ## [2.20.0](https://github.com/folio-org/ui-users/tree/v2.20.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.19.0...v2.20.0)

--- a/src/LoanActionsHistory.js
+++ b/src/LoanActionsHistory.js
@@ -373,7 +373,7 @@ class LoanActionsHistory extends React.Component {
 
     const requestCount = this.state.requestsCount[this.props.loan.itemId] || 0;
     const requestQueueValue = (requestCount && stripes.hasPerm('ui-users.requests.all,ui-requests.all'))
-      ? (<Link to={`/requests?filters=requestStatus.open%20-%20not%20yet%20filled%2CrequestStatus.open%20-%20awaiting%20pickup&query=${loan.item.barcode}&sort=Request%20Date`}>{requestCount}</Link>)
+      ? (<Link to={`/requests?filters=requestStatus.Open%20-%20Not%20yet%20filled%2CrequestStatus.Open%20-%20Awaiting%20pickup%2CrequestStatus.Open%20-%20In%20transit&query=${loan.item.barcode}&sort=Request%20Date`}>{requestCount}</Link>)
       : requestCount;
     const contributorsList = this.getContributorslist(loan);
     const contributorsListString = contributorsList.join(' ');

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -119,7 +119,7 @@ class ActionsDropdown extends React.Component {
             >
               <Button
                 buttonStyle="dropdownItem"
-                href={`/requests?&query=${get(loan, ['item', 'barcode'])}&filters=requestStatus.open%20-%20not%20yet%20filled%2CrequestStatus.open%20-%20awaiting%20pickup&sort=Request%20Date`}
+                href={`/requests?&query=${get(loan, ['item', 'barcode'])}&filters=requestStatus.Open%20-%20Not%20yet%20filled%2CrequestStatus.Open%20-%20Awaiting%20pickup%2CrequestStatus.Open%20-%20Awaiting%20pickup%2CrequestStatus.Open%20-%20In%20transit&sort=Request%20Date`}
               >
                 <FormattedMessage id="ui-users.loans.details.requestQueue" />
               </Button>

--- a/src/components/ViewSections/UserRequests/UserRequests.js
+++ b/src/components/ViewSections/UserRequests/UserRequests.js
@@ -34,7 +34,7 @@ class UserRequests extends React.Component {
       GET: {
         path: 'request-storage/requests',
         params: {
-          query: 'query=(requesterId==:{id}) and (status="Open - Not yet filled" or status="Open - Awaiting pickup")',
+          query: 'query=(requesterId==:{id}) and (status="Open")',
           limit: '1',
         },
       },
@@ -44,7 +44,7 @@ class UserRequests extends React.Component {
       GET: {
         path: 'request-storage/requests',
         params: {
-          query: 'query=(requesterId==:{id}) and (status="Closed - Cancelled" or status="Closed - Filled" or status="Closed - Unfilled" or status="Closed - Pickup expired")',
+          query: 'query=(requesterId==:{id}) and (status="Closed")',
           limit: '1',
         },
       },
@@ -137,13 +137,13 @@ class UserRequests extends React.Component {
                 id: 'clickable-viewopenrequests',
                 count: openRequestsCount,
                 formattedMessageId: 'ui-users.requests.numOpenRequests',
-                query: { query: barcode, filters: 'requestStatus.open - awaiting pickup,requestStatus.open - not yet filled' },
+                query: { query: barcode, filters: 'requestStatus.Open - Awaiting pickup,requestStatus.Open - Not yet filled,requestStatus.Open - In transit' },
               },
               {
                 id: 'clickable-viewclosedrequests',
                 count: closedRequestsCount,
                 formattedMessageId: 'ui-users.requests.numClosedRequests',
-                query: { query: barcode, filters: 'requestStatus.closed - cancelled,requestStatus.closed - filled,requestStatus.closed - unfilled,requestStatus.closed - pickup expired' },
+                query: { query: barcode, filters: 'requestStatus.Closed - Cancelled,requestStatus.Closed - Filled,requestStatus.Closed - Unfilled,requestStatus.Closed - Pickup expired' },
               },
             ]}
           /> : <Icon icon="spinner-ellipsis" width="10px" />


### PR DESCRIPTION
Outbound links to the requests app now include the filter "Open - In
transit" in addition to other "open request" fiters".

Additionally, outbound links to the requests app exactly match the case
of the filters, causing the filter-checkboxes to properly appear in the
checked or unchecked state.

Additionally, queries for open or closed requests within this app to
use a substring match for "open" or "closed" rather than substring
matches on the full filter, e.g. "Open - In transit" which will
automatically handle additional statuses beginning with "Open" or
"Closed" in the future.

Fixes [UIU-682](https://issues.folio.org/browse/UIU-682)