### PR TITLE
UIU-906: Change buttons, delete asterisk.

### DIFF
--- a/src/components/BulkOverrideDialog/BulkOverrideInfo.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideInfo.js
@@ -228,16 +228,16 @@ class BulkOverrideInfo extends React.Component {
         </Row>
         <Layout className="textRight">
           <Button
+            onClick={onCancel}
+          >
+            <FormattedMessage id="ui-users.cancel" />
+          </Button>
+          <Button
+            buttonStyle="primary"
             disabled={!canBeSubmitted}
             onClick={this.submitOverride}
           >
             <FormattedMessage id="ui-users.button.override" />
-          </Button>
-          <Button
-            buttonStyle="primary"
-            onClick={onCancel}
-          >
-            <FormattedMessage id="ui-users.cancel" />
           </Button>
         </Layout>
       </div>

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -810,7 +810,7 @@
   "blocks.message":"patron block will be removed",
   "blocks.textField.place":"Patron has blocks in place",
 
-  "additionalInfo.label": "Additional information*",
+  "additionalInfo.label": "Additional information",
   "additionalInfo.placeholder": "Enter more information about the override (required)",
 
   "button.override": "Override",


### PR DESCRIPTION
# Description 
## Steps to repro
1. On bugfest.folio.ebsco.com, with a user who has permission set folio-admin
2. Using bulk renewal, renew an open loan that cannot be renewed (e.g., loan policy says it is not renewable)
3. Click override

**Expected**: Additional information displays with one asterisk. The Override button is the primary button and is placed rightmost and styled accordingly, once fields are filled out.

**Actual**: Additional information displays with two asterisks. The Cancel button is placed rightmost and is styled as the primary button.
# Result
![Screen Shot 2019-03-18 at 12 21 56 PM](https://user-images.githubusercontent.com/42577309/54523822-109b6280-4979-11e9-8582-e92a793cf545.png)
