### PR TITLE
Fix outdated comment

### DIFF
--- a/src/Users.js
+++ b/src/Users.js
@@ -35,7 +35,7 @@ const filterConfig = [
     label: <FormattedMessage id="ui-users.information.patronGroup" />,
     name: 'pg',
     cql: 'patronGroup',
-    values: [], // will be filled in by componentWillUpdate
+    values: [], // will be filled in by componentDidUpdate
   },
 ];
 


### PR DESCRIPTION
Emtpy list of values on filterConfig for patron-groups claimed that
the list would be filled in by componentWillUpdate. In fact,
componentDidUpdate is responsible for this, and the comment now
reflects that.