### PR TITLE
don't choke when permissions record is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.22.0 (IN PROGRESS)
+
+* Suppress error on user-details pane when permissions record is missing. Fixes UIU-507.
+
 ## [2.21.0](https://github.com/folio-org/ui-users/tree/v2.21.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.20.0...v2.21.0)
 

--- a/src/ViewUser.js
+++ b/src/ViewUser.js
@@ -94,6 +94,7 @@ class ViewUser extends React.Component {
     permissions: {
       type: 'okapi',
       records: 'permissionNames',
+      throwErrors: false,
       DELETE: {
         pk: 'permissionName',
         path: 'perms/users/:{id}/permissions',


### PR DESCRIPTION
Suppress the error alert when a user's permissions record is missing.

Fixes [UIU-507](https://issues.folio.org/browse/UIU-507)