### PR TITLE
UIU-914: Delete double asterisk.

### DIFF
--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -68,11 +68,7 @@ class EditUserInfo extends React.Component {
         <Row>
           <Col xs={12} md={3}>
             <Field
-              label={(
-                <FormattedMessage id="ui-users.information.lastName">
-                  {(msg) => msg + ' *'}
-                </FormattedMessage>
-              )}
+              label={<FormattedMessage id="ui-users.information.lastName" />}
               name="personal.lastName"
               id="adduser_lastname"
               component={TextField}


### PR DESCRIPTION
# Purpose:
Steps:

Log into FOLIO
Go to Users
Edit a user record
**Expected**: Required fields should have one indicator that they are required

**Actual**: Last name has two indicators (a black and a red asterisk). Not sure which is correct
# Screenshots:
## Current behaviour
![Screen Shot 2019-03-27 at 4 02 10 PM](https://user-images.githubusercontent.com/42577309/55082275-11837100-50aa-11e9-9e48-65285ad02a6e.png)
