### PR TITLE
correct proxy query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.22.0 (IN PROGRESS)
 
 * Suppress error on user-details pane when permissions record is missing. Fixes UIU-507.
+* Correct proxy-user query. Fixes UIU-952.
 
 ## [2.21.0](https://github.com/folio-org/ui-users/tree/v2.21.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.20.0...v2.21.0)

--- a/src/withProxy.js
+++ b/src/withProxy.js
@@ -147,7 +147,7 @@ const withProxy = WrappedComponent => class WithProxyComponent extends React.Com
       resourceFor.GET({ params: { query } }).then((recordsFor) => {
         if (!recordsFor.length) return;
         const ids = recordsFor.map(pf => `id==${pf[recordKey]}`).join(' or ');
-        resource.GET({ params: { query: `query=(${ids})` } });
+        resource.GET({ params: { query: `(${ids})` } });
       });
     }
 


### PR DESCRIPTION
Remove the extra `query=` clause from the proxy-users query.

Fixes [UIU-952](https://issues.folio.org/browse/UIU-952)