### PR TITLE
always show explantion for renewal failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Correct proxy-user query. Fixes UIU-952.
 * UX Consistency Fixes for New Fee/Fine (aka Charge Manual Fee/Fine). Ref. UIU-903.
 * Fix cannot delete Fee/Fine Owner message. Ref UIU-841.
+* Show explanation when renewal fails for any reason. Fixes UIU-971.
 
 ## [2.21.0](https://github.com/folio-org/ui-users/tree/v2.21.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.20.0...v2.21.0)

--- a/src/components/BulkOverrideDialog/BulkOverrideLoansList.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideLoansList.js
@@ -66,7 +66,7 @@ class BulkOverrideLoansList extends Component {
   );
 
   getShortErrorMessage = (errorMessage) => {
-    return get(errorMessage, 'props.values.message.props.values.message', '');
+    return get(errorMessage, 'props.values.message', '');
   };
 
   render() {

--- a/src/components/BulkRenewalDialog/BulkRenewedLoansList.js
+++ b/src/components/BulkRenewalDialog/BulkRenewedLoansList.js
@@ -72,7 +72,7 @@ const BulkRenewedLoansList = (props) => {
       formatter={{
         renewalStatus: loan => {
           if (failedRenewals.filter(loanObject => loanObject.id === loan.id).length > 0) {
-            const errorMessage = get(errorMessages[loan.id], 'props.values.message.props.values.message', '');
+            const errorMessage = get(errorMessages[loan.id], 'props.values.message', '');
 
             return (errorMessages) ? (
               <div>

--- a/src/withRenew.js
+++ b/src/withRenew.js
@@ -155,8 +155,7 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
         .then((renewedLoan) => renewSuccess.push(renewedLoan))
         .catch((error) => {
           renewFailure.push(loan);
-          const stringErrorMessage = get(error, 'props.values.message.props.values.message', '');
-
+          const stringErrorMessage = get(error, 'props.values.message', '');
           errorMsg[loan.id] = {
             ...error,
             ...isOverridePossible(stringErrorMessage),
@@ -216,24 +215,19 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
     if (!errors || !errors.length) return '';
 
     const policyName = this.getPolicyName(errors);
-    let message = errors.reduce((msg, err) => ((msg) ? `${msg}, ${err.message}` : err.message), '');
-    message = (
+    const message = errors.reduce((msg, err) => ((msg) ? `${msg}, ${err.message}` : err.message), '');
+
+    return policyName ? (
+      <FormattedMessage
+        id="ui-users.errors.reviewBeforeRenewal"
+        values={{ message, policyName }}
+      />
+    ) : (
       <FormattedMessage
         id="ui-users.errors.loanNotRenewedReason"
         values={{ message }}
       />
     );
-
-    if (policyName) {
-      message = (
-        <FormattedMessage
-          id="ui-users.errors.reviewBeforeRenewal"
-          values={{ message, policyName }}
-        />
-      );
-    }
-
-    return message;
   };
 
   hideBulkRenewalDialog = () => this.setState({ bulkRenewalDialogOpen: false });


### PR DESCRIPTION
The bug report here was that when a renewal was denied to the item
having an open recall-request against it, the explanation was missing
from the alert box.

This occurred because the error handler in `withRenew` inadvertently
returned a `<FormattedMessage>` with nested props when the error
contained a policy-name, which it does when the loan-policy is the
reason for the denial. When the error is the result of an open recall,
no policy-name is present, hence no nested props.

This fix cleans up the error handling in `withRenew` so the return value
is consistently structured for an error of any type, and it updates the
explanation display accordingly.

This bug was introduced in #600 during internationalization when
the code changed from something like
```
message = `could not renew because ${message}`;
if (policyName) {
        message = `${message}; see ${policyName}`;
}
```
to 
```
message = <FormattedMessage key="foo" values={{message}} />;
if (policyName) {
    message = <FormattedMessage key="bar" values={{message, policyName}} />;
}
```
Reusing the `message` variable was fine in first case when it always resolves
to a string. After refactoring, it is passed as a `string` to the first 
`<FormattedMessage>` object but then is passed as a `<FormattedMessage>` 
to the second `<FormattedMessage>` object, causing the nested props. 

Fixes [UIU-971](https://issues.folio.org/browse/UIU-971)