### PR TITLE
use strict matching for patron-id query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * UX Consistency Fixes for Patron Blocks: User Information changes. Ref UIU-902.
 * Fix FF Details/History. Fixes UIU-968, UIU-961.
 * Fix Pay and Waive FF fixes. Fix UIU-958.
+* Use strict matching for user-ids when retrieving blocks. Fixes UIU-956.
 
 ## [2.21.0](https://github.com/folio-org/ui-users/tree/v2.21.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.20.0...v2.21.0)

--- a/src/components/PatronBlock/PatronBlockLayer.js
+++ b/src/components/PatronBlock/PatronBlockLayer.js
@@ -15,8 +15,12 @@ class PatronBlockLayer extends React.Component {
       type: 'okapi',
       records: 'manualblocks',
       path:'manualblocks',
+      // TODO: the use of activerecord here is very confusing.
+      // it specifically correspoonds to a userId in the GET query but
+      // is set to an item's ID in onUpdateItem and onDeleteItem.
+      // that's not wrong, but it's not clear.
       GET: {
-        path: 'manualblocks?query=userId=%{activeRecord.id}',
+        path: 'manualblocks?query=userId==%{activeRecord.id}',
       },
       PUT: {
         path: 'manualblocks/%{activeRecord.id}',


### PR DESCRIPTION
Strict matching is way more efficient.

Fixes [UIU-956](https://issues.folio.org/browse/UIU-956)