### PR TITLE
REALLY correct proxiesfor query

### DIFF
--- a/src/withProxy.js
+++ b/src/withProxy.js
@@ -140,13 +140,13 @@ const withProxy = WrappedComponent => class WithProxyComponent extends React.Com
       const { mutator } = this.props;
       const resource = mutator[resourceName];
       const resourceFor = mutator[`${resourceName}For`];
-      const query = `query=(${queryKey}==${userId})`;
+      const query = `(${queryKey}=="${userId}")`;
 
       resourceFor.reset();
       resource.reset();
       resourceFor.GET({ params: { query } }).then((recordsFor) => {
         if (!recordsFor.length) return;
-        const ids = recordsFor.map(pf => `id==${pf[recordKey]}`).join(' or ');
+        const ids = recordsFor.map(pf => `id=="${pf[recordKey]}"`).join(' or ');
         resource.GET({ params: { query: `(${ids})` } });
       });
     }


### PR DESCRIPTION
Remove the extra `query=` clause from the `proxiesfor` query.
This was partially addressed in #786. It's now completely addressed.
Added correct quoting of the query value as a bonus.

Refs [UIU-952](https://issues.folio.org/browse/UIU-952)