### PR TITLE
navigate via the app-menu instead of icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -644,7 +644,7 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
     "@folio/stripes": "^2.0.0",
-    "@folio/stripes-cli": "^1.6.0",
+    "@folio/stripes-cli": "^1.11.0",
     "@folio/stripes-core": "^3.0.1",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",

--- a/test/ui-testing/new-permission-set.js
+++ b/test/ui-testing/new-permission-set.js
@@ -2,7 +2,7 @@
 /* global it describe before after Nightmare */
 module.exports.test = function foo(uiTestCtx) {
   describe('Module test: users:new-permission-set', function bar() {
-    const { config, helpers: { login, openApp, logout }, meta: { testVersion } } = uiTestCtx;
+    const { config, helpers: { login, openApp, logout, clickSettings }, meta: { testVersion } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
     this.timeout(Number(config.test_timeout));
 
@@ -25,9 +25,13 @@ module.exports.test = function foo(uiTestCtx) {
           .then(result => result)
           .catch(done);
       });
+
+      it('should navigate to settings', (done) => {
+        clickSettings(nightmare, done);
+      });
+
       it('should create a new permission set', (done) => {
         nightmare
-          .click(config.select.settings)
           .wait('a[href="/settings/users"]')
           .click('a[href="/settings/users"]')
           .wait('a[href="/settings/users/perms"]')
@@ -55,9 +59,13 @@ module.exports.test = function foo(uiTestCtx) {
           })
           .catch(done);
       });
+
+      it('should navigate to settings', (done) => {
+        clickSettings(nightmare, done);
+      });
+
       it('should confirm creation of new permission set', (done) => {
         nightmare
-          .click(config.select.settings)
           .wait('a[href="/settings/users"]')
           .click('a[href="/settings/users"]')
           .wait('a[href="/settings/users/perms"]')
@@ -82,6 +90,7 @@ module.exports.test = function foo(uiTestCtx) {
           })
           .catch(done);
       });
+
       it('should delete new permission set', (done) => {
         nightmare
           .click('#clickable-edit-item')
@@ -99,6 +108,7 @@ module.exports.test = function foo(uiTestCtx) {
           })
           .catch(done);
       });
+
       it('should confirm deletion', (done) => {
         nightmare
           .wait('a[href^="/settings/users/groups"]')

--- a/test/ui-testing/new-user.js
+++ b/test/ui-testing/new-user.js
@@ -2,7 +2,7 @@
 /* global it describe after Nightmare */
 module.exports.test = function meh(uitestctx) {
   describe('Module test: users:new-user', function bar() {
-    const { config, helpers: { namegen, openApp, logout }, meta: { testVersion } } = uitestctx;
+    const { config, helpers: { namegen, openApp, logout, clickApp }, meta: { testVersion } } = uitestctx;
     const nightmare = new Nightmare(config.nightmare);
     this.timeout(Number(config.test_timeout));
     let pgroup = null;
@@ -74,10 +74,12 @@ module.exports.test = function meh(uitestctx) {
           .then(result => result);
       });
 
+      it('should navigate to users', (done) => {
+        clickApp(nightmare, done, 'users');
+      });
+
       it('should extract a patron group value', (done) => {
         nightmare
-          .wait('#clickable-users-module')
-          .click('#clickable-users-module')
           .wait('#input-user-search')
           .type('#input-user-search', '0')
           .wait('button[type=submit]')
@@ -148,10 +150,12 @@ module.exports.test = function meh(uitestctx) {
 
       flogin(config.username, config.password);
 
+      it('should navigate to users', (done) => {
+        clickApp(nightmare, done, 'users');
+      });
+
       it(`should change username for ${user.id}`, (done) => {
         nightmare
-          .wait('#clickable-users-module')
-          .click('#clickable-users-module')
           .wait('#input-user-search')
           .insert('#input-user-search', user.id)
           .wait('button[type=submit]')

--- a/test/ui-testing/patron-group.js
+++ b/test/ui-testing/patron-group.js
@@ -2,7 +2,7 @@
 /* global it describe before after Nightmare */
 module.exports.test = function foo(uiTestCtx) {
   describe('Module test: users:patron-group', function meh() {
-    const { config, helpers: { openApp, login, logout }, meta: { testVersion } } = uiTestCtx;
+    const { config, helpers: { openApp, login, logout, clickApp, clickSettings }, meta: { testVersion } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 
     this.timeout(Number(config.test_timeout));
@@ -31,9 +31,12 @@ module.exports.test = function foo(uiTestCtx) {
           .then(result => result);
       });
 
+      it('should navigate to settings', (done) => {
+        clickSettings(nightmare, done);
+      });
+
       it(`should create a patron group for "${gidlabel}"`, (done) => {
         nightmare
-          .click(config.select.settings)
           .wait('a[href="/settings/users"]')
           .click('a[href="/settings/users"]')
           .wait('a[href="/settings/users/groups"]')
@@ -56,10 +59,12 @@ module.exports.test = function foo(uiTestCtx) {
           .catch(done);
       });
 
+      it('should navigate to users', (done) => {
+        clickApp(nightmare, done, 'users');
+      });
+
       it('should find an active user to edit', (done) => {
         nightmare
-          .wait('#clickable-users-module')
-          .click('#clickable-users-module')
           .wait('#clickable-filter-pg-faculty')
           .click('#clickable-filter-pg-faculty')
           .wait('#list-users div[role="row"]:nth-of-type(2) > a > div:nth-of-type(3)')
@@ -173,10 +178,13 @@ module.exports.test = function foo(uiTestCtx) {
           .catch(done);
       });
 
+      it('should navigate to settings', (done) => {
+        clickSettings(nightmare, done);
+      });
+
       it(`should delete "${gid}" patron group`, (done) => {
         nightmare
           .wait(1111)
-          .click(config.select.settings)
           .wait('a[href="/settings/users"]')
           .click('a[href="/settings/users"]')
           .wait('a[href="/settings/users/groups"]')


### PR DESCRIPTION
Apps are guaranteed to show up in the app-menu but not on the navigation
bar, so tests need to navigate by clicking menu items.

Refs [UITEST-65](https://issues.folio.org/browse/UITEST-65)