### PR TITLE
Add ability to search by first and last name. Part of UIU-1068.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix notify patron to charge manual and pay modal. Fix UIU-953.
 * Fix comment column size. Fix UIU-954.
 * Add "Loan policy name" and "Loan ID" fields to Overdue loans report. Ref UIU-985
+* Add ability to search by first and last name. Part of UIU-1068.
 
 ## [2.22.0](https://github.com/folio-org/ui-users/tree/v2.22.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.22.0...v2.22.0)

--- a/src/Users.js
+++ b/src/Users.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, template } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -42,6 +42,8 @@ const filterConfig = [
   },
 ];
 
+const compileQuery = template('(username="%{query}*" or personal.firstName="%{query}*" or personal.lastName="%{query}*" or personal.email="%{query}*" or barcode="%{query}*" or id="%{query}*" or externalSystemId="%{query}*")', { interpolate: /%{([\s\S]+?)}/g });
+
 class Users extends React.Component {
   static manifest = Object.freeze({
     initializedFilterConfig: { initialValue: false },
@@ -57,7 +59,9 @@ class Users extends React.Component {
         params: {
           query: makeQueryFunction(
             'cql.allRecords=1',
-            '(username="%{query.query}*" or personal.firstName="%{query.query}*" or personal.lastName="%{query.query}*" or personal.email="%{query.query}*" or barcode="%{query.query}*" or id="%{query.query}*" or externalSystemId="%{query.query}*")',
+            (parsedQuery, props, localProps) => {
+              return localProps.query.query.split(' ').map(query => compileQuery({ query })).join(' or ');
+            },
             {
               // the keys in this object must match those passed to
               // SearchAndSort's columnMapping prop

--- a/src/Users.js
+++ b/src/Users.js
@@ -59,9 +59,7 @@ class Users extends React.Component {
         params: {
           query: makeQueryFunction(
             'cql.allRecords=1',
-            (parsedQuery, props, localProps) => {
-              return localProps.query.query.split(' ').map(query => compileQuery({ query })).join(' or ');
-            },
+            (parsedQuery, props, localProps) => localProps.query.query.split(' ').map(query => compileQuery({ query })).join(' or '),
             {
               // the keys in this object must match those passed to
               // SearchAndSort's columnMapping prop

--- a/src/Users.js
+++ b/src/Users.js
@@ -63,7 +63,7 @@ class Users extends React.Component {
           query: makeQueryFunction(
             'cql.allRecords=1',
             // TODO: Refactor/remove this after work on FOLIO-2066 and RMB-385 is done
-            (parsedQuery, props, localProps) => localProps.query.query.split(' ').map(query => compileQuery({ query })).join(' or '),
+            (parsedQuery, props, localProps) => localProps.query.query.split(' ').map(query => compileQuery({ query })).join(' and '),
             {
               // the keys in this object must match those passed to
               // SearchAndSort's columnMapping prop

--- a/src/Users.js
+++ b/src/Users.js
@@ -42,7 +42,10 @@ const filterConfig = [
   },
 ];
 
-const compileQuery = template('(username="%{query}*" or personal.firstName="%{query}*" or personal.lastName="%{query}*" or personal.email="%{query}*" or barcode="%{query}*" or id="%{query}*" or externalSystemId="%{query}*")', { interpolate: /%{([\s\S]+?)}/g });
+const compileQuery = template(
+  '(username="%{query}*" or personal.firstName="%{query}*" or personal.lastName="%{query}*" or personal.email="%{query}*" or barcode="%{query}*" or id="%{query}*" or externalSystemId="%{query}*")',
+  { interpolate: /%{([\s\S]+?)}/g }
+);
 
 class Users extends React.Component {
   static manifest = Object.freeze({
@@ -59,6 +62,7 @@ class Users extends React.Component {
         params: {
           query: makeQueryFunction(
             'cql.allRecords=1',
+            // TODO: Refactor/remove this after work on FOLIO-2066 and RMB-385 is done
             (parsedQuery, props, localProps) => localProps.query.query.split(' ').map(query => compileQuery({ query })).join(' or '),
             {
               // the keys in this object must match those passed to


### PR DESCRIPTION
This PR adds ability to search by both first and last name. This is a temporary fix until https://issues.folio.org/browse/RMB-385 is done on the server. 