### PR TITLE
retrieve 1000 service points by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.23.0 (IN PROGRESS)
+
+* Retrieve 1000 service points by default. Fixes UIU-1053.
+
 ## [2.22.0](https://github.com/folio-org/ui-users/tree/v2.22.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.22.0...v2.22.0)
 

--- a/src/withServicePoints.js
+++ b/src/withServicePoints.js
@@ -15,7 +15,7 @@ const withServicePoints = WrappedComponent => class WithServicePointsComponent e
       ...WrappedComponent.manifest,
       servicePoints: {
         type: 'okapi',
-        path: 'service-points',
+        path: 'service-points?query=cql.allRecords=1 sortby name&limit=1000',
         records: 'servicepoints',
         accumulate: true,
         fetch: false,


### PR DESCRIPTION
There was no limit clause previously, which meant we only got 10, which
was never enough.

Fixes [UIU-1053](https://issues.folio.org/browse/UIU-1053)