### PR TITLE
UIU-984: Add borrower fields to overdue loans report

### DIFF
--- a/src/reports/OverdueLoanReport.js
+++ b/src/reports/OverdueLoanReport.js
@@ -2,6 +2,9 @@ import { get } from 'lodash';
 import { exportCsv } from '@folio/stripes/util';
 
 const columns = [
+  'borrower.name',
+  'borrower.barcode',
+  'borrowerId',
   'dueDate',
   'loanDate',
   'loanPolicyId',
@@ -30,6 +33,11 @@ class OverdueLoanReport {
   parse(records) {
     return records.map(r => ({
       ...r,
+      borrower: {
+        ...r.borrower,
+        name: `${r.borrower.lastName}, ${r.borrower.firstName} ${r.borrower.middleName || ''}`,
+      },
+      borrowerId: r.userId,
       item: {
         ...r.item,
         contributors: get(r, 'item.contributors', [])

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -881,6 +881,9 @@
   "transfers.nodata": "There are no Fee/fine: Transfer accounts",
 
   "reports.overdue.label": "Overdue loans report (CSV)",
+  "reports.overdue.borrower.name": "Borrower name",
+  "reports.overdue.borrower.barcode": "Borrower barcode",
+  "reports.overdue.borrowerId": "Borrower ID",
   "reports.overdue.dueDate": "Due date",
   "reports.overdue.loanDate": "Loan date",
   "reports.overdue.loanPolicyId": "Loan policy ID",


### PR DESCRIPTION
### Purpose: Include borrower information on overdue loans report.

**Response**
![Response](https://user-images.githubusercontent.com/49517355/58315387-26665180-7e1a-11e9-8457-e02a50328cfd.png)

**CSV file**
![csv_file](https://user-images.githubusercontent.com/49517355/58315439-3da53f00-7e1a-11e9-8cbc-3ed22cf42f4a.png)
