### PR TITLE
replace legacy permission set

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,15 +149,6 @@
         "visible": true
       },
       {
-        "permissionName": "ui-users.editpermsets",
-        "displayName": "Settings (Users): Can create, edit and remove permission sets [LEGACY]",
-        "description": "",
-        "subPermissions": [
-          "ui-users.settings.permsets"
-        ],
-        "visible": true
-      },
-      {
         "permissionName": "ui-users.settings.usergroups",
         "displayName": "Settings (Users): Can create, edit and remove patron groups",
         "subPermissions": [

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const settingsGeneral = [
     route: 'perms',
     label: <FormattedMessage id="ui-users.settings.permissionSet" />,
     component: PermissionSets,
-    perm: 'ui-users.editpermsets',
+    perm: 'ui-users.settings.permsets',
   },
   {
     route: 'groups',


### PR DESCRIPTION
We had changed the naming conventions for permission sets related to
settings pages but did get those changes in place in the code.