### PR TITLE
UIU-985: Add loan policy name and loan id to overdue loans report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix sort patron blocks. Fix UIU-868.
 * Fix notify patron to charge manual and pay modal. Fix UIU-953.
 * Fix comment column size. Fix UIU-954.
+* Add "Loan policy name" and "Loan ID" fields to Overdue loans report. Ref UIU-985
 
 ## [2.22.0](https://github.com/folio-org/ui-users/tree/v2.22.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.22.0...v2.22.0)

--- a/src/reports/OverdueLoanReport.js
+++ b/src/reports/OverdueLoanReport.js
@@ -7,7 +7,9 @@ const columns = [
   'borrowerId',
   'dueDate',
   'loanDate',
+  'loanPolicy.name',
   'loanPolicyId',
+  'loanId',
   'item.title',
   'item.materialType.name',
   'item.status.name',
@@ -38,6 +40,7 @@ class OverdueLoanReport {
         name: `${r.borrower.lastName}, ${r.borrower.firstName} ${r.borrower.middleName || ''}`,
       },
       borrowerId: r.userId,
+      loanId: r.id,
       item: {
         ...r.item,
         contributors: get(r, 'item.contributors', [])

--- a/test/bigtest/interactors/user-form-page.js
+++ b/test/bigtest/interactors/user-form-page.js
@@ -41,7 +41,7 @@ import {
   isLoaded = isPresent('[class*=paneTitleLabel---]');
 
   whenLoaded() {
-    return this.when(() => this.isLoaded);
+    return this.when(() => this.isLoaded).timeout(3000);
   }
 
   title = text('[class*=paneTitleLabel---]');

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -887,6 +887,8 @@
   "reports.overdue.dueDate": "Due date",
   "reports.overdue.loanDate": "Loan date",
   "reports.overdue.loanPolicyId": "Loan policy ID",
+  "reports.overdue.loanPolicy.name": "Loan policy",
+  "reports.overdue.loanId": "Loan ID",
   "reports.overdue.item.title": "Item title",
   "reports.overdue.item.materialType.name": "Material type",
   "reports.overdue.item.status.name": "Item status",


### PR DESCRIPTION
## Purpose

Add "Loan policy name" and "Loan ID" fields to overdue loans report in the scope of the [story](https://issues.folio.org/browse/UIU-985)