### PR TITLE
Removed .only from 'user-page-edit-test'

### DIFF
--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -10,7 +10,7 @@ import UserFormPage from '../interactors/user-form-page';
 import InstanceViewPage from '../interactors/user-view-page';
 import UsersInteractor from '../interactors/users';
 
-describe.only('ItemEditPage', () => {
+describe('ItemEditPage', () => {
   setupApplication();
 
   const users = new UsersInteractor();


### PR DESCRIPTION
I spotted a lonely `.only` in the wild.

![image](https://i.giphy.com/media/120kDB2lOrYnV6/giphy.webp)


