### PR TITLE
Refetch loans when the ChangeDueDateDialog is reopened. Part of UIU-1065

### DIFF
--- a/src/components/Loans/OpenLoans/components/Modals/Modals.js
+++ b/src/components/Loans/OpenLoans/components/Modals/Modals.js
@@ -55,13 +55,15 @@ class Modals extends React.Component {
 
     return (
       <React.Fragment>
-        <this.connectedChangeDueDateDialog
-          user={user}
-          stripes={stripes}
-          loanIds={loanIds}
-          open={changeDueDateDialogOpen}
-          onClose={hideChangeDueDateDialog}
-        />
+        {changeDueDateDialogOpen &&
+          <this.connectedChangeDueDateDialog
+            user={user}
+            stripes={stripes}
+            loanIds={loanIds}
+            open={changeDueDateDialogOpen}
+            onClose={hideChangeDueDateDialog}
+          />
+        }
         <PatronBlockModal
           open={patronBlockedModal}
           patronBlocks={patronBlocks}


### PR DESCRIPTION
I noticed that when the `ChangeDueDateDialog` is reopened second time the loans were not being refetched (and were gone from the screen). This PR together with https://github.com/folio-org/stripes-smart-components/pull/549 should fix some of the issues found in: https://issues.folio.org/browse/UIU-1065