### PR TITLE
UIU-1017: Add override possible message. Add tests.

### DIFF
--- a/src/components/BulkOverrideDialog/BulkOverrideDialog.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideDialog.js
@@ -47,6 +47,7 @@ class BulkOverrideDialog extends React.Component {
 
     return (
       <Modal
+        id="bulk-override-modal"
         size="large"
         dismissible
         closeOnBackgroundClick

--- a/src/components/BulkOverrideDialog/BulkOverrideInfo.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideInfo.js
@@ -193,13 +193,15 @@ class BulkOverrideInfo extends React.Component {
         </Layout>
         {
           showDueDatePicker &&
-          <DueDatePicker
-            initialValues={this.datePickerDefaults}
-            stripes={stripes}
-            dateProps={{ label: <FormattedMessage id="ui-users.cddd.dateRequired" /> }}
-            timeProps={{ label: <FormattedMessage id="ui-users.cddd.timeRequired" /> }}
-            onChange={this.handleDateTimeChanged}
-          />
+            <div data-test-due-date-picker>
+              <DueDatePicker
+                initialValues={this.datePickerDefaults}
+                stripes={stripes}
+                dateProps={{ label: <FormattedMessage id="ui-users.cddd.dateRequired" /> }}
+                timeProps={{ label: <FormattedMessage id="ui-users.cddd.timeRequired" /> }}
+                onChange={this.handleDateTimeChanged}
+              />
+            </div>
         }
         <this.connectedLoanList
           allChecked={allChecked}

--- a/src/components/BulkRenewalDialog/BulkRenewInfo.js
+++ b/src/components/BulkRenewalDialog/BulkRenewInfo.js
@@ -139,7 +139,10 @@ class BulkRenewInfo extends React.Component {
           <Layout className="textRight">
             {
               !isEmpty(overridableLoans) &&
-              <Button onClick={this.openBulkOverrideDialog}>
+              <Button
+                data-test-override-button
+                onClick={this.openBulkOverrideDialog}
+              >
                 <FormattedMessage id="ui-users.button.override" />
               </Button>
             }

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -67,7 +67,10 @@ class ActionsDropdown extends React.Component {
             action: 'renew',
           }}
           >
-            <Button buttonStyle="dropdownItem">
+            <Button
+              buttonStyle="dropdownItem"
+              data-test-dropdown-content-renew-button
+            >
               <FormattedMessage id="ui-users.renew" />
             </Button>
           </MenuItem>

--- a/src/components/Loans/OpenLoans/helpers/isOverridePossible/isOverridePossible.js
+++ b/src/components/Loans/OpenLoans/helpers/isOverridePossible/isOverridePossible.js
@@ -5,9 +5,11 @@ const data = {
   autoNewDueDate: true,
 };
 
-const isOverridableMessage = (errorMessage) => {
-  for (const { message, showDueDatePicker } of overridePossibleMessages) {
-    if (errorMessage.includes(message)) {
+const isOverridableMessage = (errorMessage, errorsAmount) => {
+  for (const { message, showDueDatePicker, shouldBeSingle } of overridePossibleMessages) {
+    const canBeOverridden = errorMessage.includes(message) && (!shouldBeSingle || errorsAmount === 1);
+
+    if (canBeOverridden) {
       if (showDueDatePicker) {
         data.autoNewDueDate = false;
       }
@@ -22,7 +24,7 @@ const isOverridableMessage = (errorMessage) => {
 export default (text) => {
   const errorMessages = text.split(',');
 
-  data.overridable = errorMessages.every((errorMessage) => isOverridableMessage(errorMessage));
+  data.overridable = errorMessages.every((errorMessage) => isOverridableMessage(errorMessage, errorMessages.length));
 
   return data;
 };

--- a/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
+++ b/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
@@ -2,21 +2,31 @@ export default [
   {
     message: 'loan is not renewable',
     showDueDatePicker: true,
+    shouldBeSingle: false,
   },
   {
     message: 'item is not loanable',
     showDueDatePicker: true,
+    shouldBeSingle: false,
   },
   {
     message: 'renewal date falls outside of date ranges in fixed loan policy',
     showDueDatePicker: true,
+    shouldBeSingle: false,
+  },
+  {
+    message: 'items cannot be renewed when there is an active recall request',
+    showDueDatePicker: true,
+    shouldBeSingle: true,
   },
   {
     message: 'loan at maximum renewal number',
     showDueDatePicker: false,
+    shouldBeSingle: false,
   },
   {
     message: 'renewal date falls outside of date ranges in rolling loan policy',
     showDueDatePicker: false,
+    shouldBeSingle: false,
   },
 ];

--- a/test/bigtest/interactors/open-loans.js
+++ b/test/bigtest/interactors/open-loans.js
@@ -6,6 +6,18 @@ import {
   Interactor,
 } from '@bigtest/interactor';
 
+@interactor class BulkOverrideModal {
+  static defaultScope = '#bulk-override-modal';
+
+  dueDatePicker = scoped('[data-test-due-date-picker]')
+}
+
+@interactor class BulkRenewalModal {
+  static defaultScope = '#bulk-renewal-modal';
+
+  overrideButton = scoped('[data-test-override-button]')
+}
+
 @interactor class OpenLoans {
   static defaultScope = '[data-test-open-loans]';
 
@@ -13,7 +25,11 @@ import {
   requests = collection('[data-test-list-requests]');
   actionDropdowns = collection('[data-test-actions-dropdown]');
   actionDropdownRequestQueue = new Interactor('[data-test-dropdown-content-request-queue]');
+  actionDropdownRenewButton = new Interactor('[data-test-dropdown-content-renew-button]');
   requestsCount = count('[data-test-list-requests]');
+
+  bulkRenewalModal = new BulkRenewalModal();
+  bulkOverrideModal = new BulkOverrideModal();
 }
 
 export default new OpenLoans();

--- a/test/bigtest/network/scenarios/request-related-failure-multiple-errors.js
+++ b/test/bigtest/network/scenarios/request-related-failure-multiple-errors.js
@@ -1,0 +1,21 @@
+/* istanbul ignore file */
+
+export default (server) => {
+  server.post('/circulation/renew-by-barcode', {
+    'errors' : [{
+      'message' : 'items cannot be renewed when there is an active recall request',
+      'parameters' : [{
+        'key' : 'request id',
+        'value' : 'b67e73a8-b6b7-46fd-a918-77ce907dd3aa'
+      }]
+    },
+    {
+      'message' : 'item is not loanable',
+      'parameters' : [{
+        'key' : 'request id',
+        'value' : 'b67e73a8-b6b7-46fd-a918-77ce907dd3aa'
+      }]
+    },
+    ]
+  }, 422);
+};

--- a/test/bigtest/network/scenarios/request-related-failure.js
+++ b/test/bigtest/network/scenarios/request-related-failure.js
@@ -1,0 +1,13 @@
+/* istanbul ignore file */
+
+export default (server) => {
+  server.post('/circulation/renew-by-barcode', {
+    'errors' : [{
+      'message' : 'items cannot be renewed when there is an active recall request',
+      'parameters' : [{
+        'key' : 'request id',
+        'value' : 'b67e73a8-b6b7-46fd-a918-77ce907dd3aa'
+      }]
+    }]
+  }, 422);
+};

--- a/test/bigtest/tests/open-loan-override-test.js
+++ b/test/bigtest/tests/open-loan-override-test.js
@@ -1,0 +1,137 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import OpenLoansInteractor from '../interactors/open-loans';
+
+describe('open loans override', () => {
+  describe('request related failure', () => {
+    setupApplication({
+      scenarios: ['request-related-failure'],
+      permissions: {
+        'manualblocks.collection.get': true,
+        'circulation.loans.collection.get': true,
+      },
+    });
+
+    beforeEach(async function () {
+      const user = this.server.create('user');
+      this.server.create('loan', { status: { name: 'Open' } });
+
+      this.visit(`/users/view/${user.id}?layer=open-loans&query=%20&sort=requests`);
+    });
+
+    it('should be presented', () => {
+      expect(OpenLoansInteractor.isPresent).to.be.true;
+    }).timeout(4000);
+
+    describe('action dropdown', () => {
+      it('icon button should be presented', () => {
+        expect(OpenLoansInteractor.actionDropdowns(0).isPresent).to.be.true;
+      });
+
+      describe('action dropdown click', () => {
+        beforeEach(async () => {
+          await OpenLoansInteractor.actionDropdowns(0).click('button');
+        });
+
+        it('override button should be presented', () => {
+          expect(OpenLoansInteractor.actionDropdownRenewButton.isPresent).to.be.true;
+        });
+
+        describe('click override button', () => {
+          beforeEach(async () => {
+            await OpenLoansInteractor.actionDropdownRenewButton.click();
+          });
+
+          describe('bulk renew modal', () => {
+            it('should be presented', () => {
+              expect(OpenLoansInteractor.bulkRenewalModal.isPresent).to.be.true;
+            });
+
+            describe('override button', () => {
+              it('should be presented', () => {
+                expect(OpenLoansInteractor.bulkRenewalModal.overrideButton.isPresent).to.be.true;
+              });
+
+              describe('override button click', () => {
+                beforeEach(async () => {
+                  await OpenLoansInteractor.bulkRenewalModal.overrideButton.click();
+                });
+
+                describe('bulk override modal', () => {
+                  it('should be presented', () => {
+                    expect(OpenLoansInteractor.bulkOverrideModal.isPresent).to.be.true;
+                  });
+
+                  it('due date picker should be presented', () => {
+                    expect(OpenLoansInteractor.bulkOverrideModal.dueDatePicker.isPresent).to.be.true;
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('multiple errors: request related failure, item is not loanable', () => {
+    setupApplication({
+      scenarios: ['request-related-failure-multiple-errors'],
+      permissions: {
+        'manualblocks.collection.get': true,
+        'circulation.loans.collection.get': true,
+      },
+    });
+
+    beforeEach(async function () {
+      const user = this.server.create('user');
+      this.server.create('loan', { status: { name: 'Open' } });
+
+      this.visit(`/users/view/${user.id}?layer=open-loans&query=%20&sort=requests`);
+    });
+
+    it('should be presented', () => {
+      expect(OpenLoansInteractor.isPresent).to.be.true;
+    }).timeout(4000);
+
+    describe('action dropdown', () => {
+      it('icon button should be presented', () => {
+        expect(OpenLoansInteractor.actionDropdowns(0).isPresent).to.be.true;
+      });
+
+      describe('action dropdown click', () => {
+        beforeEach(async () => {
+          await OpenLoansInteractor.actionDropdowns(0).click('button');
+        });
+
+        it('override button should be presented', () => {
+          expect(OpenLoansInteractor.actionDropdownRenewButton.isPresent).to.be.true;
+        });
+
+        describe('click override button', () => {
+          beforeEach(async () => {
+            await OpenLoansInteractor.actionDropdownRenewButton.click();
+          });
+
+          describe('bulk renew modal', () => {
+            it('should be presented', () => {
+              expect(OpenLoansInteractor.bulkRenewalModal.isPresent).to.be.true;
+            });
+
+            describe('override button', () => {
+              it('should not be presented', () => {
+                expect(OpenLoansInteractor.bulkRenewalModal.overrideButton.isPresent).to.be.false;
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Description
As a staff member, I want to override renewals that have failed because of pending requests, because I want to provide better customer service on a case-by-case basis.

# Scenarios

## Scenario

- Given an attempted renewal

- When the renewal only fails because the item has an open recall on it

- Then give the user the ability to override

## Scenario

- Given a renewal that has failed for only the reasons in scenarios given above

- When the user overrides the renewal

- Then display the renewal override window

# Screenshots
![Screen Shot 2019-06-14 at 1 23 47 PM](https://user-images.githubusercontent.com/42577309/59508963-586a5100-8eb8-11e9-9bba-8aa24f9743d6.png)
![Screen Shot 2019-06-14 at 3 08 56 PM](https://user-images.githubusercontent.com/42577309/59508966-599b7e00-8eb8-11e9-989a-61ba157cf53e.png)

