### PR TITLE
UIORG-150 remove unnecessary permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.24.0 (IN PROGRESS)
+
+* Remove unnecessary settings. Refs UIORG-150.
+
 ## [2.23.0](https://github.com/folio-org/ui-users/tree/v2.23.0) (2019-06-12)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.22.0...v2.23.0)
 

--- a/package.json
+++ b/package.json
@@ -189,14 +189,6 @@
         ]
       },
       {
-        "permissionName": "settings.users.enabled",
-        "displayName": "Settings (Users): display list of settings pages",
-        "subPermissions": [
-          "settings.enabled"
-        ],
-        "visible": true
-      },
-      {
         "permissionName": "ui-users.viewproxies",
         "displayName": "Users: Can view proxies assigned to users",
         "subPermissions": [


### PR DESCRIPTION
Settings permissions are more granular than "settings pages" so this
value was useless.

Refs [UIORG-150](https://issues.folio.org/browse/UIORG-150)