### PR TITLE
UIU-894: Handle "Active/Inactive" hard-code issue for the search filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.24.0 (IN PROGRESS)
 
 * Remove unnecessary settings. Refs UIORG-150.
+* Handle "Active/Inactive" hard-code issue for the search filter. Fixes UIU-894.
 
 ## [2.23.0](https://github.com/folio-org/ui-users/tree/v2.23.0) (2019-06-12)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.22.0...v2.23.0)

--- a/src/Users.js
+++ b/src/Users.js
@@ -30,8 +30,16 @@ const filterConfig = [
     name: 'active',
     cql: 'active',
     values: [
-      { name: 'inactive', cql: 'false' },
-      { name: 'active', cql: 'true' },
+      {
+        name: 'inactive',
+        cql: 'false',
+        displayName: <FormattedMessage id="ui-users.activeUserStatus" />,
+      },
+      {
+        name: 'active',
+        cql: 'true',
+        displayName: <FormattedMessage id="ui-users.inactiveUserStatus" />,
+      },
     ],
   },
   {

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -502,6 +502,8 @@
   "accountActionHistory": "Account Actions History",
   "status": "Status",
   "selectColumns": "Select Columns",
+  "activeUserStatus": "active",
+  "inactiveUserStatus": "inactive",
 
   "accounts.title": "Fees/Fines",
   "accounts.outstandingBalance": "Outstanding Balance: ",


### PR DESCRIPTION
Refers to the hardcode [issue](https://issues.folio.org/browse/UIU-894) for the active/inactive entries for the search filter in the *ui-users* application.