### PR TITLE
UIU-1086 be more careful about query construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Remove unnecessary settings. Refs UIORG-150.
 * Handle "Active/Inactive" hard-code issue for the search filter. Fixes UIU-894.
+* Better search string construction won't accidentally match `*`. Fixes UIU-1086.
 
 ## [2.23.0](https://github.com/folio-org/ui-users/tree/v2.23.0) (2019-06-12)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.22.0...v2.23.0)

--- a/src/Users.js
+++ b/src/Users.js
@@ -72,7 +72,7 @@ class Users extends React.Component {
           query: makeQueryFunction(
             'cql.allRecords=1',
             // TODO: Refactor/remove this after work on FOLIO-2066 and RMB-385 is done
-            (parsedQuery, props, localProps) => localProps.query.query.split(' ').map(query => compileQuery({ query })).join(' and '),
+            (parsedQuery, props, localProps) => localProps.query.query.trim().split(/\s+/).map(query => compileQuery({ query })).join(' and '),
             {
               // the keys in this object must match those passed to
               // SearchAndSort's columnMapping prop


### PR DESCRIPTION
Trim whitespace and tokenize on whitespace instead of single space in
order to avoid constructing search strings like `*` that would match
every single row in the DB.

Fixes [UIU-1086](https://issues.folio.org/browse/UIU-1086)