### PR TITLE
UIU-916 - Patron Group Menu Caret Obscures Content

### DIFF
--- a/src/components/EditSections/EditUserInfo/EditUserInfo.css
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.css
@@ -20,3 +20,7 @@
   margin: auto;
   margin-bottom: 14px;
 }
+
+.patronGroup {
+  padding-right: 25px;
+}

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -1,7 +1,9 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
+import { FormattedMessage } from 'react-intl';
+
+import { ViewMetaData } from '@folio/stripes/smart-components';
 import {
   Select,
   TextField,
@@ -11,7 +13,8 @@ import {
   Datepicker,
   Headline
 } from '@folio/stripes/components';
-import { ViewMetaData } from '@folio/stripes/smart-components';
+
+import css from './EditUserInfo.css';
 
 class EditUserInfo extends React.Component {
   static propTypes = {
@@ -116,6 +119,7 @@ class EditUserInfo extends React.Component {
               name="patronGroup"
               id="adduser_group"
               component={Select}
+              selectClass={css.patronGroup}
               fullWidth
               defaultValue={initialValues.patronGroup}
             >


### PR DESCRIPTION
# Purpose
To fix incorrect displaying of patron group control.

# Link
https://issues.folio.org/browse/UIU-916

# Screenshot
<img width="786" alt="Screen Shot 2019-06-27 at 16 31 47" src="https://user-images.githubusercontent.com/43472449/60270471-2b2a9380-98f9-11e9-8337-9e606c76b1a0.png">

