### PR TITLE
UIU-1100: Change showDueDatePicker flag.

### DIFF
--- a/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
+++ b/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
@@ -26,7 +26,7 @@ export default [
   },
   {
     message: 'renewal date falls outside of date ranges in rolling loan policy',
-    showDueDatePicker: false,
+    showDueDatePicker: true,
     shouldBeSingle: false,
   },
 ];


### PR DESCRIPTION
# Description
Allow the user to select a date using the date picker when the loan with rolling loan policy, renew from: due date, and a fixed due date schedule (due date limit), and a due date not falling within the range(s) in the fixed due date schedule
