### PR TITLE
UIU-1092 use new loan-history shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix Payment Status from "Charge and pay now". Fixes UIU-931.
 * Fix UX Consistency owners. Fixes UIU-1050.
 * Handle address type validation issue after adding permission to user. Fixes UIU-912.
+* Accomodate changes in the shape of `/loan-storage/loan-history` data. Refs UIU-1092.
 
 ## [2.23.0](https://github.com/folio-org/ui-users/tree/v2.23.0) (2019-06-12)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.22.0...v2.23.0)

--- a/src/LoanActionsHistory.js
+++ b/src/LoanActionsHistory.js
@@ -52,7 +52,7 @@ class LoanActionsHistory extends React.Component {
     loanActions: {
       type: 'okapi',
       path: 'loan-storage/loan-history',
-      records: 'loans',
+      records: 'loansHistory',
       resourceShouldRefresh: true,
       accumulate: 'true',
       fetch: false,
@@ -212,12 +212,16 @@ class LoanActionsHistory extends React.Component {
       mutator,
       loan,
     } = this.props;
-    const query = `id==${loanid || loan.id}`;
+    const query = `(loan.id==${loanid || loan.id})`;
     const limit = 100;
 
     mutator.loanActions.reset();
     mutator.loanActions.GET({ params: { query, limit } })
-      .then(loanActions => this.getUsers(loanActions));
+      .then(loanActions => {
+        // the map unwraps the loanActions objects, returning an array of loans
+        // instead of an array of objects containing loans.
+        this.getUsers(loanActions.map(i => i.loan));
+      });
   };
 
   getFeeFine() {

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -167,7 +167,7 @@ export default function config() {
   });
 
   this.get('loan-storage/loan-history', {
-    loans: [],
+    loansHistory: [],
     totalRecords: 0,
   });
 


### PR DESCRIPTION
The shape of the response to queries against `loan-storage/loan-history`
has changed. Queries used to look like this:
```
GET loan-storage/loan-history?query=id=$LOAN_ID

{
    "loans" : [ {
        "id" : "$LOAN_ID",
        ...
    } ],
    "totalRecords" : 1
}
```
Then now look like this:
```
GET loan-storage/loan-history?query=loan.id=$LOAN_ID

{
    "loansHistory": [ {
        "id": "f1f72ec5-2e59-4607-8d24-52de0f8e56f9",
        "operation": "I",
        "loan": {
            "id": "$LOAN_ID",
            ...
        }
    } ],
    "totalRecords" : 1
}
```
Note the changes to both the query and the extra level of nesting of the
`loan` element in the response.

Refs [UIU-1092](https://issues.folio.org/browse/UIU-1092)