### PR TITLE
fix new-permission-set test

### DIFF
--- a/src/components/EditablePermissions/EditablePermissions.js
+++ b/src/components/EditablePermissions/EditablePermissions.js
@@ -100,7 +100,7 @@ class EditablePermissions extends React.Component {
 
   renderItem(item, index, showPerms) {
     return (
-      <li key={item.permissionName}>
+      <li key={item.permissionName} data-permission-name={`${item.permissionName}`}>
         {
           (showPerms ?
             `${item.permissionName} (${item.displayName})` :
@@ -113,7 +113,7 @@ class EditablePermissions extends React.Component {
                 buttonStyle="fieldControl"
                 align="end"
                 type="button"
-                id="clickable-remove-permission"
+                id={`clickable-remove-permission-${item.permissionName}`}
                 onClick={() => this.removePermission(index)}
                 aria-label={`${aria}: ${item.permissionName}`}
               >

--- a/src/components/PermissionList/PermissionList.js
+++ b/src/components/PermissionList/PermissionList.js
@@ -25,7 +25,7 @@ function PermissionList(props) {
   const showPerms = _.get(stripes, ['config', 'showPerms']);
   const permissionDDFormatter = item => (
     <li key={item.permissionName}>
-      <button type="button" className={css.itemControl} onClick={() => { handleItemClick(item); }}>
+      <button type="button" className={css.itemControl} onClick={() => { handleItemClick(item); }} data-permission-name={`${item.permissionName}`}>
         {(!item.displayName ?
           item.permissionName :
           (!showPerms ? item.displayName :

--- a/test/ui-testing/new-permission-set.js
+++ b/test/ui-testing/new-permission-set.js
@@ -6,6 +6,13 @@ module.exports.test = function foo(uiTestCtx) {
     const nightmare = new Nightmare(config.nightmare);
     this.timeout(Number(config.test_timeout));
 
+    const waitText = (label) => {
+      return Array.from(
+        document.querySelectorAll('ul[class*="PermissionList"] li')
+      )
+        .findIndex(e => e.textContent === label) >= 0;
+    };
+
     describe('Login > Create new permission set > Confirm creation > Delete permission set > Confirm deletion > Logout\n', () => {
       const displayName = 'Circulation employee';
       const description = 'Contains permissions to execute basic circ functions.';
@@ -36,20 +43,19 @@ module.exports.test = function foo(uiTestCtx) {
           .insert('#input-permission-description', description)
           .wait('#clickable-add-permission')
           .click('#clickable-add-permission')
-          .wait('button[class^="itemControl"]')
-          .xclick('//button[contains(.,"Users: Can create new user")]')
-          .then(() => {
-            nightmare
-              .wait('#clickable-add-permission')
-              .click('#clickable-add-permission')
-              .wait('button[class^="itemControl"]')
-              .xclick('//button[contains(.,"Users: Can view proxies")]')
-              .wait('#clickable-save-permission-set')
-              .click('#clickable-save-permission-set')
-              .wait(parseInt(process.env.FOLIO_UI_DEBUG, 10) ? parseInt(config.debug_sleep, 10) : 555) // debugging
-              .then(done)
-              .catch(done);
-          })
+          .wait('ul[class*="PermissionList"] li button[data-permission-name="ui-users.create"]')
+          .click('ul[class*="PermissionList"] li button[data-permission-name="ui-users.create"]')
+          .wait('#permSection ul li[data-permission-name="ui-users.create"]')
+          .click('#clickable-add-permission')
+          .wait('ul[class*="PermissionList"] li button[data-permission-name="ui-users.viewproxies"]')
+          .click('ul[class*="PermissionList"] li button[data-permission-name="ui-users.viewproxies"]')
+          .wait('#permSection ul li[data-permission-name="ui-users.viewproxies"]')
+          .wait(() => Array.from(document.querySelectorAll('#permSection ul li').length === 2))
+          .wait('#clickable-save-permission-set')
+          .wait(() => !document.querySelector('#clickable-save-permission-set[disabled]'))
+          .click('#clickable-save-permission-set')
+          .wait(() => !document.querySelector('#clickable-save-permission-set'))
+          .then(done)
           .catch(done);
       });
 


### PR DESCRIPTION
This test relied on `xclick`, which was removed from stripes-testing in
`v1.6.0`, which means that should've been tagged `v2.0.0`, but here we
are. `xclick` has been a known bad actor for ages now and should have
been removed from this test long ago.

In support of removing `xclick`, `data-` attributes were added to both
permission-add buttons and the permissions-in-this-set list in order to
provide unique selectors, and the non-unique `id` attribute that was
used for _every_ permission's delete button was made to be unique,
because, well, that's how `id` attributes are supposed to work.