### PR TITLE
remove double asterisk

### DIFF
--- a/src/settings/permissions/PermissionSetForm.js
+++ b/src/settings/permissions/PermissionSetForm.js
@@ -243,11 +243,7 @@ class PermissionSetForm extends React.Component {
                 <Col xs={8}>
                   <section>
                     <Field
-                      label={(
-                        <FormattedMessage id="ui-users.permissions.permissionSetName">
-                          {(msg) => msg + ' *'}
-                        </FormattedMessage>
-                      )}
+                      label={<FormattedMessage id="ui-users.permissions.permissionSetName" />}
                       name="displayName"
                       id="input-permission-title"
                       component={TextField}


### PR DESCRIPTION
The field's `required` attribute automatically provides the asterisk;
there is no need to manually include it.