### PR TITLE
address edit enhancement

### DIFF
--- a/src/components/EditSections/EditContactInfo/AddressEdit.css
+++ b/src/components/EditSections/EditContactInfo/AddressEdit.css
@@ -1,0 +1,110 @@
+@import '@folio/stripes-components/lib/variables';
+
+.addressEditList {
+  margin-bottom: 1rem;
+}
+
+.legend {
+  display: block;
+  width: 100%;
+  font-size: var(--font-size-large);
+  color: #333;
+  border: 0;
+  margin-bottom: 6px;
+  padding-bottom: 2px;
+}
+
+.subLegend {
+  composes: legend;
+  font-size: var(--font-size-medium);
+  color: #777;
+}
+
+.indent {
+  padding: 0 6px;
+}
+
+.removeAddress {
+  padding: 0;
+  text-align: center;
+  -webkit-appearance: none;
+  cursor: pointer;
+  color: #555;
+  border-radius: 6px;
+  transition: all 0.25s ease;
+  background-color: transparent;
+  border: 1px solid transparent;
+  width: auto;
+  height: auto;
+  margin: 0;
+
+  & :global .stripes__icon {
+    fill: #aaa;
+    transition: fill 0.25s ease;
+  }
+
+  &:hover {
+    & :global .stripes__icon {
+      fill: color(#900 blend(#aaa 50%));
+    }
+  }
+}
+
+.addressFormList {
+  list-style: none;
+  padding: 0;
+}
+
+.addressFormListItem {
+  width: 100%;
+  border-color: var(--color-border-p2);
+  border-width: 1px 1px 0;
+  border-style: solid;
+
+  &:last-of-type {
+    border-bottom: 1px solid var(--color-border-p2);
+    margin-bottom: 4px;
+  }
+}
+
+.addressFormHeader {
+  background-color: var(--bg-hover);
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 0 14px;
+}
+
+.addressHeaderActions {
+  margin: 0 0 0 auto; /* align to end of header */
+  padding: 4px 0;
+}
+
+.addressLabel {
+  font-weight: var(--text-weight-headline-basis);
+}
+
+.addressFormBody {
+  padding: 14px;
+  background-color: color(var(--bg) blend(var(--bg-hover) 20%));
+  width: 100%;
+}
+
+.primaryToggle {
+  padding: 4px 8px;
+  color: #555;
+  font-size: var(--font-size-medium);
+  cursor: pointer;
+  margin-bottom: 0;
+
+  & input[type="radio"] {
+    margin: 0 4px;
+    vertical-align: text-top;
+  }
+}
+
+[dir="rtl"] {
+  .addressHeaderActions {
+    margin: 0 auto 0 0;
+  }
+}

--- a/src/components/EditSections/EditContactInfo/AddressEditList.js
+++ b/src/components/EditSections/EditContactInfo/AddressEditList.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FieldArray } from 'redux-form';
+import { Button, Col, Layout, Row } from '@folio/stripes-components';
+import { FormattedMessage } from 'react-intl';
+import AddressSel from './AddressSel';
+import css from './AddressEdit.css';
+
+const propTypes = {
+  label: PropTypes.node,
+  name: PropTypes.string,
+  onAdd: PropTypes.func,
+  onDelete: PropTypes.func,
+};
+
+const defaultProps = {
+  label: 'Addresses',
+};
+
+class AddressEditList extends React.Component {
+  constructor(props) {
+    super(props);
+    this.renderFieldGroups = this.renderFieldGroups.bind(this);
+    this.onAdd = this.onAdd.bind(this);
+    this.onDelete = this.onDelete.bind(this);
+  }
+
+  onAdd(fields) {
+    fields.push({});
+    if (this.props.onAdd) {
+      this.props.onAdd(fields.length - 1);
+    }
+  }
+
+  onDelete(fields, index) {
+    fields.remove(index);
+    if (this.props.onDelete) {
+      this.props.onDelete(index);
+    }
+  }
+
+  renderFieldGroups({ fields }) {
+    return (
+
+      <div className={css.addressEditList}>
+        <Row>
+          <Col xs>
+            <div className={css.legend} id="addressGroupLabel">{this.props.label}</div>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs>
+            {fields.length === 0 &&
+              <div><em>- No addresses stored -</em></div>
+            }
+            <ul className={css.addressFormList} aria-labelledby="addressGroupLabel">
+              {fields.map((fieldName, i) => (
+                <li className={css.addressFormListItem} key={i}>
+                  <AddressSel
+                    fieldKey={i}
+                    addressFieldName={fieldName}
+                    handleDelete={(index) => { this.onDelete(fields, index); }}
+                    {...this.props}
+                  />
+                </li>
+              ))}
+            </ul>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs>
+            <Layout>
+              <Button type="button" onClick={() => { this.onAdd(fields); }}>
+                <FormattedMessage
+                  id="stripes-smart-components.address.addAddress"
+                />
+              </Button>
+            </Layout>
+          </Col>
+        </Row>
+      </div>
+
+    );
+  }
+
+  render() {
+    return (
+      <FieldArray name={this.props.name} component={this.renderFieldGroups} />
+    );
+  }
+}
+
+AddressEditList.propTypes = propTypes;
+AddressEditList.defaultProps = defaultProps;
+
+export default AddressEditList;

--- a/src/components/EditSections/EditContactInfo/AddressSel.js
+++ b/src/components/EditSections/EditContactInfo/AddressSel.js
@@ -1,0 +1,263 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Field } from 'redux-form';
+import findIndex from 'lodash/findIndex';
+import cloneDeep from 'lodash/cloneDeep';
+import { FormattedMessage } from 'react-intl';
+import { Button, Col, Icon, Row, Select, TextField } from '@folio/stripes-components';
+import css from './AddressEdit.css';
+import { datas } from '../../../data/addressData';
+
+const omitUsedOptions = (list, usedValues, key, id) => {
+    const unUsedValues = cloneDeep(list);
+    usedValues.forEach((item, i) => {
+        if (id !== i) {
+            const usedValueIndex = findIndex(unUsedValues, v => v.value === item[key]);
+            if (usedValueIndex !== -1) {
+                unUsedValues.splice(usedValueIndex, 1);
+            }
+        }
+    });
+    return unUsedValues;
+};
+
+class AddressSel extends React.Component {
+    static propTypes = {
+        addressFieldName: PropTypes.string,
+        addressLabel: PropTypes.node,
+        canDelete: PropTypes.bool,
+        displayKey: PropTypes.bool,
+        displayPrimary: PropTypes.bool,
+        fieldComponents: PropTypes.object,
+        fieldKey: PropTypes.number,
+        handleDelete: PropTypes.func,
+        headerFields: PropTypes.arrayOf(PropTypes.string),
+        primary: PropTypes.func,
+    }
+
+    static contextTypes = {
+        _reduxForm: PropTypes.object,
+    }
+
+    static defaultProps = {
+        addressLabel: <FormattedMessage id="stripes-smart-components.address.addressLabel" />,
+        fieldComponents: {
+            addressType: Select,
+        },
+        headerFields: ['primaryAddress'],
+        displayKey: true,
+        displayPrimary: true,
+    }
+
+    constructor(props) {
+        super(props);
+        this.singlePrimary = this.singlePrimary.bind(this);
+        this.state = {
+            provinceList: datas,
+            cityList: [],
+            areaList: [],
+            selectProvince: '',
+            selectCity: '',
+            selectArea: '',
+        };
+        this.handleChangeProvince = this.handleChangeProvince.bind(this);
+        this.handleChangeCity = this.handleChangeCity.bind(this);
+        this.handleChangeArea = this.handleChangeArea.bind(this);
+    }
+
+    singlePrimary(id) {
+        const { values, dispatch, change } = this.context._reduxForm;
+        values.personal.addresses.forEach((a, i) => {
+            if (i === id) {
+                dispatch(change(`personal.addresses[${i}].primaryAddress`, true));
+                dispatch(change(`personal.addresses[${i}].primary`, true));
+            } else {
+                dispatch(change(`personal.addresses[${i}].primaryAddress`, false));
+                dispatch(change(`personal.addresses[${i}].primary`, false));
+            }
+        });
+    }
+
+    handleChangeProvince(e){
+        let cityList = []
+        let areaList = []
+
+        datas.map((item) => {
+            if (e.target.value == item.name) {
+                cityList = item.cityList
+            }
+        })
+
+        this.setState({
+            selectProvince: e.target.value,
+            selectCity: '',
+            selectArea: '',
+            cityList: cityList,
+            areaList: areaList,
+        })
+    }
+
+    handleChangeCity(e){
+        const cityList = this.state.cityList
+        let areas = []
+
+        cityList.map((item) => {
+            if (e.target.value == item.name) {
+                areas = item.areaList
+            }
+        })
+
+        this.setState({
+            selectCity: e.target.value,
+            selectArea: '',
+            areaList: areas,
+        })
+    }
+
+    handleChangeArea(e){
+        this.setState({
+            selectArea: e.target.value,
+        })
+    }
+
+    render() {
+        const {
+            addressFieldName,
+            addressLabel,
+            fieldKey,
+            canDelete,
+            fieldComponents,
+            displayKey,
+            displayPrimary,
+        } = this.props;
+
+        const {
+            selectProvince,
+            selectCity,
+            selectArea,
+            provinceList,
+            cityList, 
+            areaList,
+        } = this.state;
+
+        const {
+            values,
+        } = this.context._reduxForm;
+
+        const PrimaryRadio = ({ input, ...props }) => (
+            <label className={css.primaryToggle} htmlFor={props.id}>
+                <input
+                    type="radio"
+                    checked={input.value}
+                    id={props.id}
+                    onChange={() => { this.singlePrimary(fieldKey); }}
+                    name="primary"
+                    aria-labelledby={`Use address ${fieldKey + 1} as primary address`}
+                />
+                Use as primary address
+            </label>
+        );
+
+        const mergedFieldComponents = Object.assign(AddressSel.defaultProps.fieldComponents, fieldComponents);
+
+        const list = omitUsedOptions(
+            mergedFieldComponents['addressType'].props.dataOptions,
+            values.personal.addresses,
+            'addressType',
+            fieldKey,
+        );
+
+        const provinces = provinceList.map(i => (
+            { value: i.name, label: i.name }
+          ));
+
+        const cities = (cityList || {}).map(i => (
+            { value: i.name, label: i.name }
+          ));
+
+        const areas = (areaList || {}).map(i => (
+            { value: i, label: i }
+          ));
+
+        return (
+            <div className={css.addressForm}>
+                <div className={css.addressFormHeader} start="xs">
+                    <div className={css.addressLabel}>
+                        {addressLabel}
+                        {displayKey && (this.props.fieldKey + 1)}
+                    </div>
+                    <div>
+                        {displayPrimary &&
+                            <Field
+                                component={PrimaryRadio}
+                                name={`${addressFieldName}.primary`}
+                                id={`PrimaryAddress---${addressFieldName}`}
+                                fieldKey={this.props.fieldKey}
+                            />
+                        }
+                    </div>
+                    <div className={css.addressHeaderActions}>
+                        {
+                            canDelete &&
+                            <Button
+                                buttonStyle="link slim"
+                                style={{ margin: 0, padding: 0 }}
+                                onClick={() => { this.props.handleDelete(fieldKey); }}
+                            >
+                                <Icon icon="trash" width="24px" height="24px" />
+                                <span className="sr-only">
+                                    Remove Address
+                                    {this.props.fieldKey + 1}
+                                </span>
+                            </Button>
+                        }
+                    </div>
+                </div>
+                <div className={css.addressFormBody}>
+                    <Row key={fieldKey}>
+                        <Col xs={12} md={3}>
+                            <Field
+                                label={<FormattedMessage id="ui-users.contact.addressType" />}
+                                name={`${addressFieldName}.addressType`}
+                                component={Select}
+                                dataOptions={list}
+                            />
+                        </Col>
+                        <Col xs={12} md={3}>
+                            <Field
+                                label="State/Prov/Region"
+                                name={`${addressFieldName}.stateRegion`}
+                                value={selectProvince}
+                                component={Select}
+                                dataOptions={[{label:'Select region', value:''}, ...provinces]}
+                                onChange={this.handleChangeProvince}
+                            />
+                        </Col>
+                        <Col xs={12} md={3}>
+                            <Field 
+                                label="City"
+                                name={`${addressFieldName}.city`}
+                                value={selectCity}
+                                component={Select}
+                                dataOptions={[{label:'Select city', value:''}, ...cities]}
+                                onChange={this.handleChangeCity}
+                            />
+                        </Col>
+                        <Col xs={12} md={3}>
+                            <Field 
+                                label="Zip/Postal Code"
+                                name={`${addressFieldName}.zipCode`}
+                                value={selectArea}
+                                component={Select}
+                                dataOptions={[{label:'Select postal code', value:''}, ...areas]}
+                                onChange={this.handleChangeArea}
+                            />
+                        </Col>
+                    </Row>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default AddressSel;

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.js
@@ -14,7 +14,8 @@ import {
   Accordion,
   Headline
 } from '@folio/stripes/components';
-import { AddressEditList } from '@folio/stripes/smart-components';
+import AddressEditList from './AddressEditList';
+// import { AddressEditList } from '@folio/stripes/smart-components';
 
 import { toAddressTypeOptions } from '../../../converters/address_type';
 import contactTypes from '../../../data/contactTypes';

--- a/src/data/addressData.js
+++ b/src/data/addressData.js
@@ -1,0 +1,35 @@
+export const datas = [
+    {name:'Shang Hai', cityList:[		   
+    {name:'Shang Hai', areaList:['Huang Pu','Lu Wan','Xu Hui','Chang Ning','Jing An','Pu Tuo','Zha Bei','Hong Kou','Yang Pu','Min Hang','Bao Shan','Jia Ding']},		   
+    ]},
+    {name:'Si Chuan', cityList:[		   
+    {name:'Cheng Du', areaList:['Jing Jiang','Qing Yang','Jin Niu','Wu Hou','Cheng Hua','Xin Du','Wen Jiang','Jin Tang','Shuang Liu']},		   
+    {name:'Zi Gong', areaList:['Gong Jing','Da An','Yan Tan','Fu Shun']},	   
+    {name:'Lu Zhou', areaList:['Jiang Yang','Na Xi','Ma Long Tan','He Jiang','Xu Yong','Gu Lin']},		   
+    {name:'De Yang', areaList:['Jing Yang','Zhong Jiang','Luo Jiang','Guang Han','Mian Zhu']},		   	   
+    {name:'Da Zhou', areaList:['Tong Chuan','Xuan Han','Kai Jiang','Da Zhu','Wan Yuan']}
+    ]},
+    {name:'Gui Zhou', cityList:[		   
+    {name:'Gui Yang', areaList:['Nan Ming','Yun Yan','Hua Xi','Wu Dang','Bai Yun','Xiao He','Kai Yang','Xi Feng','Xiu Wen','Qing Zhen']},		   
+    {name:'Liu Pan Shui', areaList:['Zhong Shan','Liu Zhi Te','Shui Cheng']},		   
+    {name:'Zun Yi', areaList:['Hong Hua Gang','Hui Chuan','Zun Yi','Tong Zi','Sui Yang','Zheng An','Feng Gang','Mei Tan','Yu Qing','Xi Shui','Chi Shui','Ren Huai']},		   
+    {name:'An Shun', areaList:['Xi Xiu','Ping Ba','Pu Ding']},		   
+    {name:'Tong Ren', areaList:['Tong Ren','Jiang Kou','Si Nan','De Jiang','Wan Shan']},		   
+    {name:'Bi Jie', areaList:['Bi Jie','Da Fang','Qian Xi','Jin Sha','Zhi Jin','Na Yong','He Zhang']}		   
+    ]},
+    {name:'Jiang Su', cityList:[		   
+    {name:'Nan Jing', areaList:['Xuan Wu','Bai Xia','Qin Huai','Jian Ye','Gu Lou','Xia Guan','Pu Kou','Xi Xia','Yu Hua Tai','Jiang Ning','Liu He','Li Shui','Gao Chun']},		   
+    {name:'Wu Xi', areaList:['Cong An','Nan Chang ','Bei Tang','Xi Shan','Hui Shan','Bin Hu','Jiang Yin','Yi Xing']},		   
+    {name:'Xu Zhou', areaList:['Gu Lou','Yun Long','Jiu Li','Jia Wang','Quan Shan','Tong Shan','Xin Yi']},		   
+    {name:'Chang Zhou', areaList:['Tian Ning','Zhong Lou','Xin Bei','Wu Jin','Li Yang','Jin Tan']},		   
+    {name:'Su Zhou', areaList:['Cang Lang','Ping Jiang','Jin Chang','Hu Qiu','Wu Zhong','Xiang Cheng','Chang Shu','Zhang Jia Gang','Kun Shan','Wu Jiang','Tai Cang']},		   
+    {name:'Nan Tong', areaList:['Cong Chuan','Gang Zha','Hai An','Ru Dong','Qi Dong','Ru Gao','Tong Zhou','Hai Men']},		   
+    {name:'Lian Yun Gang', areaList:['Lian Yun','Xin Pu','Hai Zhou','Gan Yu','Dong Hai','Guan Yun','Guan Nan']},		   
+    {name:'Huai An', areaList:['Qing He','Chu Zhou','Huai Yin','Qing Pu','Lian Shui','Hong Ze','Xu Yu','Jin Hu']},		   
+    {name:'Yan Cheng', areaList:['Ting Hu','Yan Du','Xiang Shui','Bin Hai','Fu Ning','She Yang','Jian Hu','Dong Tai','Da Feng']},		   
+    {name:'Yang Zhou', areaList:['Guang Ling','Bao Ying','Yi Zheng','Gao You','Jiang Du']},		   
+    {name:'Zhen Jiang', areaList:['Jing Kou','Run Zhou','Dan Tu','Dan Yang','Yang Zhong','Ju Rong']},		   
+    {name:'Tai Zhou', areaList:['Hai Ling','Gao Gang','Xing Hua','Jing Jiang','Tai Zhou','Jiang Yan']},		   
+    {name:'Su Qian', areaList:['Su Cheng','Su Yu','Shu Yang','Si Yang','Si Hong']}
+    ]}
+    ]


### PR DESCRIPTION
Currently, there are three value 'State/Prov./Region', 'city' and 'Zip/Postal Code', now, i want to change the component to 'Select', and implement cascade relationship for the three values, i mean, first select 'Prov', then get 'city' dataOptions, after select 'city', get the 'code' dataOptions, I use onChange() event and already works fine when create action(the case in create a user), but 'city' and 'code' value cannot be display for update action(edit a existing user). I know, the reason is onChange() event is not be triggered, dataOptions for 'city' and 'code' are null when update action