### PR TITLE
Update loan-storage dependency to pull new mod-circulation-storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "circulation": "3.0 4.0 5.0 6.0 7.0",
       "permissions": "5.0",
       "loan-policy-storage": "1.0 2.0",
-      "loan-storage": "4.0 5.0",
+      "loan-storage": "4.0 5.0 6.0",
       "login": "4.7 5.0",
       "feesfines": "15.0",
       "request-storage": "2.5 3.0",


### PR DESCRIPTION
It was noticed that folio-snapshot build continue to use the old version of `mod-circulation-storage-8.2.0-SNAPSHOT.176` from Jun 10?. The latest mod-circulation-storage has bumped up the `loan-storage` interface to 6.0. 