### PR TITLE
Raising the interface version related to mod-login API breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       "permissions": "5.0",
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0",
-      "login": "4.7 5.0",
+      "login": "6.0",
       "feesfines": "15.0",
       "request-storage": "2.5 3.0",
       "users-bl": "5.0"


### PR DESCRIPTION
[Changes](https://github.com/folio-org/mod-login/pull/64) in the version of the mod-login affect changes in the modules: 

-  'edge-oai-pmh',
-  'edge-orders',
-  'edge-patron',
-  'edge-rtac',
-  'ui-users',
-  'mod-users-bl'
-  'edge-sip2'
-  'mod-login'