### PR TITLE
UIU-1134 retrieve 10k permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.25.0 (IN PROGRESS)
+
+* Retrieve up to 10k permissions, up from the current limit of 1k. Fixes UIU-1134.
+
 ## [2.24.0](https://github.com/folio-org/ui-users/tree/v2.24.0) (2019-07-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.23.0...v2.24.0)
 

--- a/src/components/EditSections/EditUserPerms/EditUserPerms.js
+++ b/src/components/EditSections/EditUserPerms/EditUserPerms.js
@@ -23,7 +23,7 @@ class EditUserPerms extends React.Component {
     availablePermissions: {
       type: 'okapi',
       records: 'permissions',
-      path: 'perms/permissions?length=1000',
+      path: 'perms/permissions?length=10000',
       permissionsRequired: 'perms.permissions.get'
     },
   });

--- a/src/settings/permissions/ContainedPermissions.js
+++ b/src/settings/permissions/ContainedPermissions.js
@@ -9,7 +9,7 @@ class ContainedPermissions extends React.Component {
     availablePermissions: {
       type: 'okapi',
       records: 'permissions',
-      path: 'perms/permissions?length=1000&query=(mutable==false)',
+      path: 'perms/permissions?length=10000&query=(mutable==false)',
     },
   });
 

--- a/src/settings/permissions/PermissionSets.js
+++ b/src/settings/permissions/PermissionSets.js
@@ -34,7 +34,7 @@ class PermissionSets extends React.Component {
         path: 'perms/permissions',
       },
       GET: {
-        path: 'perms/permissions?length=1000&query=(mutable==true)&expandSubs=true',
+        path: 'perms/permissions?length=10000&query=(mutable==true)&expandSubs=true',
       },
       path: 'perms/permissions',
     },


### PR DESCRIPTION
Retrieve more permissions. 1k wasn't enough; hopefully 10k is. If not,
640k ought to be enough for everybody said nobody, ever. 

Fixes [UIU-1134](https://issues.folio.org/browse/UIU-1134)