### PR TITLE
STCOM-429: Fixed footer for Save and Cancel buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.25.0 (IN PROGRESS)
 
 * Implement exporting of only overdue loans for overdue loans report. Refs UIU-1121.
+* Implement footer with _Save & close_ and _Canclel_ buttons on the edit user form. Refs STCOM-429.
 
 ## [2.24.1](https://github.com/folio-org/ui-users/tree/v2.24.1) (2019-07-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.24.0...v2.24.1)

--- a/package.json
+++ b/package.json
@@ -657,7 +657,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.1.0",
+    "@folio/stripes": "^2.9.0",
     "react": "*"
   },
   "optionalDependencies": {

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -8,8 +8,8 @@ import {
   Paneset,
   Pane,
   PaneMenu,
-  Icon,
   PaneHeaderIconButton,
+  PaneFooter,
   Button,
   ExpandAllButton,
   expandAllFunction,
@@ -217,27 +217,6 @@ class UserForm extends React.Component {
     );
   }
 
-  getLastMenu(id, label) {
-    const {
-      pristine,
-      submitting,
-    } = this.props;
-
-    return (
-      <PaneMenu>
-        <Button
-          id={id}
-          type="submit"
-          disabled={pristine || submitting}
-          buttonStyle="primary paneHeaderNewButton"
-          marginBottom0
-        >
-          {label}
-        </Button>
-      </PaneMenu>
-    );
-  }
-
   handleExpandAll(sections) {
     this.setState({ sections });
   }
@@ -292,25 +271,36 @@ class UserForm extends React.Component {
     submitter();
   }
 
-  getActionMenu = ({ onToggle }) => {
-    const { onCancel } = this.props;
-    const handleClick = () => {
-      onCancel();
-      onToggle();
-    };
+  getPaneFooter() {
+    const {
+      pristine,
+      submitting,
+      invalid,
+      onCancel,
+    } = this.props;
+
+    const disabled = pristine || submitting || invalid;
 
     return (
-      <Button
-        data-test-cancel-user-form-action
-        buttonStyle="dropdownItem"
-        onClick={handleClick}
-      >
-        <Icon icon="times-circle">
+      <PaneFooter>
+        <Button
+          data-test-user-form-cancel-button
+          buttonStyle="default mega"
+          onClick={onCancel}
+        >
           <FormattedMessage id="ui-users.cancel" />
-        </Icon>
-      </Button>
+        </Button>
+        <Button
+          data-test-user-form-submit-button
+          buttonStyle="primary mega"
+          type="submit"
+          disabled={disabled}
+        >
+          <FormattedMessage id="ui-users.saveAndClose" />
+        </Button>
+      </PaneFooter>
     );
-  };
+  }
 
   render() {
     const {
@@ -323,11 +313,10 @@ class UserForm extends React.Component {
 
     const { sections } = this.state;
     const firstMenu = this.getAddFirstMenu();
+    const footer = this.getPaneFooter();
     const paneTitle = initialValues.id
       ? getFullName(initialValues)
       : <FormattedMessage id="ui-users.crud.createUser" />;
-
-    const lastMenu = this.getLastMenu('clickable-save', <FormattedMessage id="ui-users.save" />);
 
     return (
       <HasCommand commands={this.keyboardCommands}>
@@ -340,9 +329,8 @@ class UserForm extends React.Component {
           <Paneset isRoot>
             <Pane
               defaultWidth="100%"
-              actionMenu={this.getActionMenu}
               firstMenu={firstMenu}
-              lastMenu={lastMenu}
+              footer={footer}
               appIcon={<AppIcon app="users" appIconKey="users" />}
               paneTitle={
                 <span data-test-header-title>

--- a/test/bigtest/interactors/user-form-page.js
+++ b/test/bigtest/interactors/user-form-page.js
@@ -8,13 +8,7 @@ import {
   triggerable,
 } from '@bigtest/interactor';
 
-@interactor class HeaderDropdown {
-  click = clickable('button');
-}
-
-@interactor class HeaderDropdownMenu {
-  clickCancel = clickable('[data-test-cancel-user-form-action]');
-}
+import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor'; // eslint-disable-line
 
 @interactor class InputFieldInteractor {
   clickInput = clickable();
@@ -45,13 +39,11 @@ import {
   }
 
   title = text('[class*=paneTitleLabel---]');
-  headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
-  headerDropdownMenu = new HeaderDropdownMenu();
-
   barcodeField = new InputFieldInteractor('#adduser_barcode');
   usernameField = new InputFieldInteractor('#adduser_username');
-  clickSave = clickable('#clickable-save');
-  barcodeError = text('[class^="feedbackError---"]');
+  feedbackError = text('[class^="feedbackError---"]');
+  cancelButton = new ButtonInteractor('[data-test-user-form-cancel-button]');
+  submitButton = new ButtonInteractor('[data-test-user-form-submit-button]');
 }
 
 export default new UserFormPage('[data-test-form-page]');

--- a/test/bigtest/tests/user-create-page-test.js
+++ b/test/bigtest/tests/user-create-page-test.js
@@ -23,19 +23,13 @@ describe('ItemCreatePage', () => {
       expect(UserFormPage.title).to.equal('Create User');
     });
 
-    describe('pane header menu', () => {
+    describe('clicking on cancel button', () => {
       beforeEach(async () => {
-        await UserFormPage.headerDropdown.click();
+        await UserFormPage.cancelButton.click();
       });
 
-      describe('clicking on cancel', () => {
-        beforeEach(async () => {
-          await UserFormPage.headerDropdownMenu.clickCancel();
-        });
-
-        it('should redirect to view users page after click', () => {
-          expect(users.$root).to.exist;
-        });
+      it('should redirect to view users page after click', () => {
+        expect(users.$root).to.exist;
       });
     });
   });

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -30,19 +30,13 @@ describe('ItemEditPage', () => {
       expect(UserFormPage.title).to.equal(user1.username);
     });
 
-    describe('pane header menu', () => {
+    describe('clicking on cancel button', () => {
       beforeEach(async () => {
-        await UserFormPage.headerDropdown.click();
+        await UserFormPage.cancelButton.click();
       });
 
-      describe('clicking on cancel', () => {
-        beforeEach(async () => {
-          await UserFormPage.headerDropdownMenu.clickCancel();
-        });
-
-        it('should redirect to view users page after click', () => {
-          expect(users.$root).to.exist;
-        });
+      it('should redirect to view users page after click', () => {
+        expect(users.$root).to.exist;
       });
     });
   });
@@ -50,18 +44,18 @@ describe('ItemEditPage', () => {
   describe('validating user barcode', () => {
     beforeEach(async function () {
       await UserFormPage.barcodeField.fillAndBlur(user2.barcode);
-      await UserFormPage.clickSave();
+      await UserFormPage.submitButton.click();
     });
 
     it('should display validation error', () => {
-      expect(UserFormPage.barcodeError).to.equal('This barcode has already been taken');
+      expect(UserFormPage.feedbackError).to.equal('This barcode has already been taken');
     });
   });
 
   describe('validating empty user barcode', () => {
     beforeEach(async function () {
       await UserFormPage.barcodeField.fillAndBlur('');
-      await UserFormPage.clickSave();
+      await UserFormPage.submitButton.click();
     });
 
     it('should show user detail view', () => {
@@ -72,11 +66,11 @@ describe('ItemEditPage', () => {
   describe('validating username', () => {
     beforeEach(async function () {
       await UserFormPage.usernameField.fillAndBlur(user2.username);
-      await UserFormPage.clickSave();
+      await UserFormPage.submitButton.click();
     });
 
     it('should display validation error', () => {
-      expect(UserFormPage.barcodeError).to.equal('This username already exists');
+      expect(UserFormPage.feedbackError).to.equal('This username already exists');
     });
   });
 });


### PR DESCRIPTION
### Purpose
Implement footer with _Save & close_ and _Canclel_ buttons on the edit user form according to [story](https://issues.folio.org/browse/STCOM-429).

![Image](https://user-images.githubusercontent.com/49517355/62624220-4393c200-b92b-11e9-86f3-8842d1ab9e9c.png)
