### PR TITLE
Revert "STCOM-429: Prevent disabling user form submit button when form is `inva…"

### DIFF
--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -275,10 +275,11 @@ class UserForm extends React.Component {
     const {
       pristine,
       submitting,
+      invalid,
       onCancel,
     } = this.props;
 
-    const disabled = pristine || submitting;
+    const disabled = pristine || submitting || invalid;
 
     return (
       <PaneFooter>


### PR DESCRIPTION
Reverts folio-org/ui-users#928

@zburke, @SergiyVSergiyenko, I was not right. We had this in requirements. 
> Save would only be clickable if the form is dirty, valid, and not submitting. 