### PR TITLE
STCOM-429 restore element IDs

### DIFF
--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -285,6 +285,7 @@ class UserForm extends React.Component {
       <PaneFooter>
         <Button
           data-test-user-form-cancel-button
+          id="clickable-cancel"
           buttonStyle="default mega"
           onClick={onCancel}
         >
@@ -292,6 +293,7 @@ class UserForm extends React.Component {
         </Button>
         <Button
           data-test-user-form-submit-button
+          id="clickable-save"
           buttonStyle="primary mega"
           type="submit"
           disabled={disabled}


### PR DESCRIPTION
The element ID for the save button was inadvertently removed in #925. Now
it's back!

Refs [STCOM-429](https://issues.folio.org/browse/STCOM-429)