### PR TITLE
UIU-1163 pass correct props to AppIcon

### DIFF
--- a/src/Users.js
+++ b/src/Users.js
@@ -283,7 +283,7 @@ class Users extends React.Component {
         <AppIcon
           app="users"
           size="small"
-          className={user.active || usersStyles.inactiveAppIcon}
+          className={user.active ? '' : usersStyles.inactiveAppIcon}
         >
           {
             user.active


### PR DESCRIPTION
AppIcon wants a string, not a boolean, for `className`.

Fixes [UIU-1163](https://issues.folio.org/browse/UIU-1163)