### PR TITLE
adjust amount with normalize instead of onBlur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Implement footer with _Save & close_ and _Canclel_ buttons on the edit user form. Refs STCOM-429.
 * Finish implementing patron notices. Refs UIU-1113, UIU-1114, UIU-1115.
 * Clean up duplicate code. Refs UIU-932.
+* Adjust amount with `normalize` instead of `onBlur`.
 
 ## [2.24.1](https://github.com/folio-org/ui-users/tree/v2.24.1) (2019-07-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.24.0...v2.24.1)

--- a/src/components/Accounts/Actions/ActionModal.js
+++ b/src/components/Accounts/Actions/ActionModal.js
@@ -167,10 +167,7 @@ class ActionModal extends React.Component {
     return action === 'payment';
   }
 
-  onBlurAmount = (e) => {
-    const amount = parseFloat(e.target.value || 0).toFixed(2);
-    e.target.value = amount;
-  }
+  normalizeAmount = (value) => parseFloat(value || 0).toFixed(2);
 
   onChangeOwner = () => {
     const { dispatch } = this.props;
@@ -272,7 +269,7 @@ class ActionModal extends React.Component {
                       name="amount"
                       component={TextField}
                       hasClearIcon={false}
-                      onBlur={this.onBlurAmount}
+                      normalize={this.normalizeAmount}
                       fullWidth
                       marginBottom0
                       autoFocus

--- a/src/components/Accounts/ChargeFeeFine/FeeFineInfo.js
+++ b/src/components/Accounts/ChargeFeeFine/FeeFineInfo.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Field, change } from 'redux-form';
+import { Field } from 'redux-form';
 import {
   Row,
   Col,
@@ -18,7 +18,6 @@ class FeeFineInfo extends React.Component {
     feefines: PropTypes.arrayOf(PropTypes.object),
     isPending: PropTypes.object,
     initialValues: PropTypes.object,
-    dispatch: PropTypes.func,
   };
 
   constructor(props) {
@@ -41,12 +40,7 @@ class FeeFineInfo extends React.Component {
     this.props.onChangeFeeFine(parseFloat(feefine.defaultAmount || 0).toFixed(2), feeFineId);
   }
 
-  onBlurAmount = (e) => {
-    const { dispatch } = this.props;
-    const amount = parseFloat(e.target.value || 0).toFixed(2);
-    e.preventDefault();
-    dispatch(change('chargefeefine', 'amount', amount));
-  }
+  normalizeAmount = (value) => parseFloat(value || 0).toFixed(2);
 
   render() {
     const {
@@ -125,7 +119,7 @@ class FeeFineInfo extends React.Component {
                       fullWidth
                       required
                       onChange={this.onChangeAmount}
-                      onBlur={this.onBlurAmount}
+                      normalize={this.normalizeAmount}
                     />
                   </Col>
                 </Row>


### PR DESCRIPTION
Comments in PR #923 indicated that `onBlur` handlers may not be
reliable. `normalize` provides an alternative. ([normalize documentation](https://redux-form.com/7.0.1/examples/normalizing/))