### PR TITLE
STCOM-571: Make PaneFooter flexible enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Show all reasons when a loan renewal fails. Refs UIU-1129.
 * Pass correct props to `<AppIcon>`.
 * Add new permissions modal component. Refs UIU-629, UIU-631.
+* Update `<PaneFooter>`: support arbitrary rendering of the content on two sides. Refs STCOM-521.
 
 ## [2.24.1](https://github.com/folio-org/ui-users/tree/v2.24.1) (2019-07-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.24.0...v2.24.1)

--- a/src/UserForm.js
+++ b/src/UserForm.js
@@ -133,6 +133,7 @@ class UserForm extends React.Component {
     parentResources: PropTypes.object.isRequired,
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
+    invalid: PropTypes.bool,
     onCancel: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     initialValues: PropTypes.object.isRequired,
@@ -141,6 +142,7 @@ class UserForm extends React.Component {
   static defaultProps = {
     pristine: false,
     submitting: false,
+    invalid: false,
   };
 
   constructor(props) {
@@ -279,26 +281,38 @@ class UserForm extends React.Component {
 
     const disabled = pristine || submitting || invalid;
 
+    const startButton = (
+      <Button
+        data-test-user-form-cancel-button
+        marginBottom0
+        id="clickable-cancel"
+        buttonStyle="default mega"
+        onClick={onCancel}
+      >
+        <FormattedMessage id="ui-users.cancel" />
+      </Button>
+    );
+
+    const endButton = (
+      <Button
+        data-test-user-form-submit-button
+        marginBottom0
+        id="clickable-save"
+        buttonStyle="primary mega"
+        type="submit"
+        disabled={disabled}
+      >
+        <FormattedMessage id="ui-users.saveAndClose" />
+      </Button>
+    );
+
     return (
-      <PaneFooter>
-        <Button
-          data-test-user-form-cancel-button
-          id="clickable-cancel"
-          buttonStyle="default mega"
-          onClick={onCancel}
-        >
-          <FormattedMessage id="ui-users.cancel" />
-        </Button>
-        <Button
-          data-test-user-form-submit-button
-          id="clickable-save"
-          buttonStyle="primary mega"
-          type="submit"
-          disabled={disabled}
-        >
-          <FormattedMessage id="ui-users.saveAndClose" />
-        </Button>
-      </PaneFooter>
+      <PaneFooter
+        renderStart={startButton}
+        renderEnd={endButton}
+        className={css.paneFooterClass}
+        innerClassName={css.paneFooterContentClass}
+      />
     );
   }
 

--- a/test/bigtest/tests/user-create-page-test.js
+++ b/test/bigtest/tests/user-create-page-test.js
@@ -19,8 +19,16 @@ describe('ItemCreatePage', () => {
   });
 
   describe('visiting the create user page', () => {
-    it('displays the title in the pane header', () => {
+    it('should display the title in the pane header', () => {
       expect(UserFormPage.title).to.equal('Create User');
+    });
+
+    it('should render a primary button', () => {
+      expect(UserFormPage.submitButton.rendersPrimary).to.be.true;
+    });
+
+    it('should render a default button', () => {
+      expect(UserFormPage.cancelButton.rendersDefault).to.be.true;
     });
 
     describe('clicking on cancel button', () => {


### PR DESCRIPTION
### Purpose
Update footer with _Save & close_ and _Cancel_ buttons on the edit user form.
Support arbitrary rendering of the content on two sides according the [story](https://issues.folio.org/browse/STCOM-571).

**Screenshots**
![View_1](https://user-images.githubusercontent.com/49517355/64124100-ca16b480-cdae-11e9-984b-15bd073ed971.png)
![View_2](https://user-images.githubusercontent.com/49517355/64124105-cc790e80-cdae-11e9-8c53-c5a1b54e68d2.png)
![View_3](https://user-images.githubusercontent.com/49517355/64124107-cedb6880-cdae-11e9-9c14-2c3b36ba12ee.png)
![View_4](https://user-images.githubusercontent.com/49517355/64124111-d00c9580-cdae-11e9-83db-c965a175fbb2.png)
![View_5](https://user-images.githubusercontent.com/49517355/64124115-d1d65900-cdae-11e9-8eda-1f419039c465.png)
