### PR TITLE
STCOM-571 include latest stripes-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -628,7 +628,7 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^2.10.0",
+    "@folio/stripes": "^2.10.1",
     "@folio/stripes-cli": "^1.11.0",
     "@folio/stripes-core": "^3.0.1",
     "babel-eslint": "^9.0.0",
@@ -658,7 +658,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.10.0",
+    "@folio/stripes": "^2.10.1",
     "react": "*"
   },
   "optionalDependencies": {


### PR DESCRIPTION
PR #950 included changes to the add/edit user form's footer that relied
on a change to stripes-components that was not present in stripes
v2.10.0. That change was added in a patch release, v2.10.1, so this PR
updates the minimum stripes version to v2.10.1.

Yarn will do The Right Thing with the `~` dependencies here and pull in
that patch release automatically, but if any platform build processes
remove that `~` and use straight version, then this will protect them
and cause the correct version to be pulled in.

Refs [STCOM-571](https://issues.folio.org/browse/STCOM-571)