### PR TITLE
CHAL-30 dedupe loan policy list before retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.26.0 (IN PROGRESS)
+
+* Dedupe loan policy list before retrieving it. Refs CHAL-30.
+
 ## [2.25.1](https://github.com/folio-org/ui-users/tree/v2.25.1) (2019-09-11)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.0...v2.25.1)
 

--- a/src/withRenew.js
+++ b/src/withRenew.js
@@ -269,7 +269,9 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
 
 
   fetchLoanPolicyNames = () => {
-    const query = this.state.loans.map(loan => `id==${loan.loanPolicyId}`).join(' or ');
+    // get a list of unique policy IDs to retrieve. multiple loans may share
+    // the same policy; we only need to retrieve that policy once.
+    const query = `id==(${[...new Set(this.state.loans.map(loan => loan.loanPolicyId))].join(' or ')})`;
     const {
       mutator: {
         loanPolicies: {


### PR DESCRIPTION
Dedupe the list of loan policies before retrieving it. Previously, a
long list of loans, even if they all shared the same policy, would
generate a long query with one entry per loan. The query now contains
one entry per unique policy.

Refs [CHAL-30](https://issues.folio.org/browse/CHAL-30)