### PR TITLE
CHAL-30 more efficient request retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Dedupe loan policy list before retrieving it. Refs CHAL-30.
 * Retrieve up to 1000 loans instead of 100. LIBRARIANS LOVE BOOKS! Refs CHAL-29.
 * Correctly display checkboxes in the add-servicepoint modal. Refs UIU-1240.
+* Slightly more efficient request retrieval. Refs CHAL-30.
 
 ## [2.25.1](https://github.com/folio-org/ui-users/tree/v2.25.1) (2019-09-11)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.0...v2.25.1)

--- a/src/withRenew.js
+++ b/src/withRenew.js
@@ -44,20 +44,23 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
   );
 
   static propTypes = {
+    loans: PropTypes.object,
     mutator: PropTypes.shape({
-      renew: PropTypes.shape({
-        POST: PropTypes.func.isRequired,
-      }),
       loanPolicies: PropTypes.shape({
         GET: PropTypes.func.isRequired,
         reset: PropTypes.func.isRequired,
+      }),
+      renew: PropTypes.shape({
+        POST: PropTypes.func.isRequired,
       }),
       requests: PropTypes.shape({
         GET: PropTypes.func.isRequired,
         reset: PropTypes.func.isRequired,
       }),
     }),
-    loans: PropTypes.object,
+    stripes: PropTypes.shape({
+      connect: PropTypes.func.isRequired,
+    }),
   };
 
   static defaultProps = {
@@ -235,6 +238,14 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
 
   hideBulkRenewalDialog = () => this.setState({ bulkRenewalDialogOpen: false });
 
+  /**
+   * retrieve count of open requests against this patron's open loans and
+   * store a map of itemId => open-request count in state.
+   *
+   * It sure would be nice if there were a more efficient way to construct
+   * this query than joining the entire list of item-ids, but there ain't.
+   * See CHAL-30 for details of the pain this causes.
+   */
   getOpenRequestsCount = () => {
     const {
       stripes,
@@ -252,8 +263,8 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
       return;
     }
 
-    const q = loans.map(loan => `itemId==${loan.itemId}`).join(' or ');
-    const query = `(${q}) and status==("Open - Awaiting pickup" or "Open - Not yet filled") sortby requestDate desc`;
+    const q = loans.map(loan => loan.itemId).join(' or ');
+    const query = `(itemId==(${q})) and status==("Open - Awaiting pickup" or "Open - Not yet filled") sortby requestDate desc`;
 
     reset();
 
@@ -271,6 +282,10 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
   };
 
 
+  /**
+   * retrieve loan policies related to current loans and store a map of
+   * loan-policy.id => loan-policy.name in state.
+   */
   fetchLoanPolicyNames = () => {
     // get a list of unique policy IDs to retrieve. multiple loans may share
     // the same policy; we only need to retrieve that policy once.


### PR DESCRIPTION
Tweak the query that retrieves open requests related to a patron's loans
to be slightly more efficient. This is not a huge improvement, though
it's a little bit that can add up over many loans. The real problem is
that the requests API does not allow for the retrieval of requests keyed
by the borrower's ID, only the item ID, so the only way to find requests
for a patron's loans is to pass in the item ID for every loan.

Refs [CHAL-30](https://issues.folio.org/browse/CHAL-30)