### PR TITLE
UIU-1223 - Do not display user generated permission sets in list

### DIFF
--- a/src/components/PermissionsAccordion/PermissionsAccordion.js
+++ b/src/components/PermissionsAccordion/PermissionsAccordion.js
@@ -67,10 +67,12 @@ class PermissionsAccordion extends React.Component {
     headlineContent: PropTypes.element.isRequired,
     unassignPermission: PropTypes.func.isRequired,
     addPermissions: PropTypes.func.isRequired,
+    excludePermissionSets: PropTypes.bool,
   };
 
   static defaultProps = {
     initialValues: {},
+    excludePermissionSets: false,
   };
 
   constructor(props) {
@@ -156,6 +158,7 @@ class PermissionsAccordion extends React.Component {
       headlineContent,
       assignedPermissions,
       addPermissions,
+      excludePermissionSets,
     } = this.props;
 
     const { permissionModalOpen } = this.state;
@@ -197,6 +200,7 @@ class PermissionsAccordion extends React.Component {
               assignedPermissions={assignedPermissions}
               addPermissions={addPermissions}
               open={permissionModalOpen}
+              excludePermissionSets={excludePermissionSets}
               visibleColumns={visibleColumns}
               filtersConfig={filtersConfig}
               onClose={this.closePermissionModal}

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -30,7 +30,13 @@ class PermissionsModal extends React.Component {
     availablePermissions: {
       type: 'okapi',
       records: 'permissions',
-      path: 'perms/permissions?length=10000&query=(visible==true)',
+      path: (queryParams, pathComponents, resourceData, config, props) => {
+        const excludePermissionSets = props.excludePermissionSets;
+
+        return excludePermissionSets
+          ? 'perms/permissions?length=10000&query=(visible==true and mutable==false)'
+          : 'perms/permissions?length=10000&query=(visible==true)';
+      },
       fetch: false,
       accumulate: true,
     },
@@ -78,10 +84,12 @@ class PermissionsModal extends React.Component {
     onClose: PropTypes.func.isRequired,
     addPermissions: PropTypes.func.isRequired,
     visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
+    excludePermissionSets: PropTypes.bool,
   };
 
   static defaultProps = {
     resources: { availablePermissions: { records: [] } },
+    excludePermissionSets: false,
   };
 
   constructor(props) {

--- a/src/settings/permissions/PermissionSetForm.js
+++ b/src/settings/permissions/PermissionSetForm.js
@@ -289,6 +289,7 @@ class PermissionSetForm extends React.Component {
               permToModify="perms.permissions.item.put"
               formName="permissionSetForm"
               permissionsField="subPermissions"
+              excludePermissionSets
             />
           </Pane>
         </Paneset>


### PR DESCRIPTION
# Purpose
To allow to exclude custom permissions sets from the list of permissions

# Link
https://issues.folio.org/browse/UIU-1223

# Screenshot
![Screenshot_6](https://user-images.githubusercontent.com/43472449/65613593-fba22a80-dfbe-11e9-9dc3-82442598d2a0.png)
![Screenshot_7](https://user-images.githubusercontent.com/43472449/65613594-fba22a80-dfbe-11e9-9e74-370948adaa2c.png)
