### PR TITLE
Revert "UIU-1243: Update the circulation API to support changes in the rule editor"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "okapiInterfaces": {
       "users": "15.0",
       "configuration": "2.0",
-      "circulation": "3.0 4.0 5.0 6.0 7.0 8.0",
+      "circulation": "3.0 4.0 5.0 6.0 7.0",
       "permissions": "5.0",
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0",


### PR DESCRIPTION
Reverts folio-org/ui-users#969

Reverting only so we can tag a patch release at tip-of-master; this is the only feature-commit since `v2.25.2` was released and reverting (and then reapplying) a single PR will be easier than cherry-picking everything since this PR onto a release branch. Yes, yes, we may want to investigate a different branching strategy like GitFlow in the long term to mitigate this process. Today, I just need to publish a release. 