### PR TITLE
UIU-1083: Prevent manual anonymization of closed loans with fees/fines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-users
 
 ## 2.26.0 (IN PROGRESS)
+* Prevent manual anonymization of closed loans with fees/fines. Refs UIU-1083.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/test/bigtest/interactors/closed-loans.js
+++ b/test/bigtest/interactors/closed-loans.js
@@ -1,0 +1,22 @@
+import {
+  interactor,
+  scoped,
+  Interactor,
+} from '@bigtest/interactor';
+
+import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor'; // eslint-disable-line
+
+@interactor class ClosedLoans {
+  static defaultScope = '[data-test-closed-loans]';
+
+  anonymizeButton = new ButtonInteractor('#anonymize-all');
+  anonymizationFeesFinesErrorModal = new Interactor('#anonymization-fees-fines-modal');
+  anonymizationConfirmButton = new ButtonInteractor('#anonymization-fees-fines-modal-footer button');
+  list = scoped('#list-loanshistory');
+
+  whenLoaded() {
+    return this.when(() => this.list.isVisible);
+  }
+}
+
+export default new ClosedLoans();

--- a/test/bigtest/tests/closed-loans-test.js
+++ b/test/bigtest/tests/closed-loans-test.js
@@ -1,0 +1,83 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import ClosedLoansInteractor from '../interactors/closed-loans';
+
+function setupAnonymizationAPIResponse(server, errors) {
+  server.post('/loan-anonymization/by-user/:id', { errors });
+}
+
+describe('Closed Loans', () => {
+  setupApplication({
+    permissions: {
+      'manualblocks.collection.get': true,
+      'circulation.loans.collection.get': true,
+    },
+  });
+
+  beforeEach(async function () {
+    const user = this.server.create('user');
+    const loan = this.server.create('loan', {
+      status: { name: 'Closed' },
+      feesAndFines : { amountRemainingToPay: 200 }
+    });
+
+    setupAnonymizationAPIResponse(this.server, [{
+      message: 'haveAssociatedFeesAndFines',
+      parameters: [{
+        key: 'loanIds',
+        value: JSON.stringify([loan]),
+      }]
+    }]);
+
+    this.visit(`/users/view/${user.id}?layer=closed-loans`);
+
+    await ClosedLoansInteractor.whenLoaded();
+  });
+
+  it('should be presented', () => {
+    expect(ClosedLoansInteractor.isPresent).to.be.true;
+  });
+
+  describe('loan list', () => {
+    it('should be presented', () => {
+      expect(ClosedLoansInteractor.list.isPresent).to.be.true;
+    });
+  });
+
+  describe('anonymizing loans without fee/fines', () => {
+    beforeEach(async function () {
+      setupAnonymizationAPIResponse(this.server, []);
+      await ClosedLoansInteractor.anonymizeButton.click();
+    });
+
+    it('should not be prevented and error modal should not be shown', () => {
+      expect(ClosedLoansInteractor.anonymizationFeesFinesErrorModal.isPresent).to.be.false;
+    });
+  });
+
+  describe('anonymizing loans with fee/fines', () => {
+    beforeEach(async () => {
+      await ClosedLoansInteractor.anonymizeButton.click();
+    });
+
+    it('should be prevented and error modal should be shown', () => {
+      expect(ClosedLoansInteractor.anonymizationFeesFinesErrorModal.isPresent).to.be.true;
+    });
+
+    describe('clicking on the confirmation button in the error modal', () => {
+      beforeEach(async () => {
+        await ClosedLoansInteractor.anonymizationConfirmButton.click();
+      });
+
+      it('should close the error modal', () => {
+        expect(ClosedLoansInteractor.anonymizationFeesFinesErrorModal.isPresent).to.be.false;
+      });
+    });
+  });
+});

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -897,5 +897,8 @@
   "permissions.modal.total": "Total selected: {count}",
   "permissions.modal.hideSearchPane": "Hide search and filters pane.",
   "permissions.modal.showSearchPane": "Show search and filters pane.",
-  "permissions.modal.numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}"
+  "permissions.modal.numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",
+
+  "anonymization.confirmation.header": "Anonymization prevented",
+  "anonymization.confirmation.message": "{amount} loan(s) had associated fees/fines and could not be anonymized."
 }


### PR DESCRIPTION
## Purpose

Prevent manual anonymization of closed loans with fees/fines in the scope of the [UIU-1083](https://issues.folio.org/browse/UIU-1083).

## Screenshot
<img width="763" alt="Screen Shot 2019-10-02 at 13 58 03" src="https://user-images.githubusercontent.com/40821852/66039674-2d1a7900-e51e-11e9-8351-c62fc21bf7e0.png">

