### PR TITLE
UIU-1155: implement request preferences on view and edit pages

### DIFF
--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -13,11 +13,15 @@ import {
   Headline
 } from '@folio/stripes/components';
 
+import { addressTypesShape } from '../../../shapes';
+
 import PasswordControl from './PasswordControl';
 import CreateResetPasswordControl from './CreateResetPasswordControl';
+import RequestPreferencesEdit from './RequestPreferencesEdit';
 
 class EditExtendedInfo extends Component {
   static propTypes = {
+    addressTypes: addressTypesShape,
     expanded: PropTypes.bool.isRequired,
     userId: PropTypes.string.isRequired,
     userEmail: PropTypes.string.isRequired,
@@ -45,9 +49,11 @@ class EditExtendedInfo extends Component {
       userId,
       userFirstName,
       userEmail,
+      addressTypes,
     } = this.props;
 
     const accordionHeader = this.buildAccordionHeader();
+    const isEditForm = !!userId;
 
     return (
       <Accordion
@@ -119,7 +125,7 @@ class EditExtendedInfo extends Component {
             />
           </Col>
           {
-            userId
+            isEditForm
               ? (
                 <CreateResetPasswordControl
                   userId={userId}
@@ -129,6 +135,7 @@ class EditExtendedInfo extends Component {
               )
               : <PasswordControl />
           }
+          <RequestPreferencesEdit addressTypes={addressTypes} />
         </Row>
         <br />
       </Accordion>

--- a/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/RequestPreferencesEdit.css
+++ b/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/RequestPreferencesEdit.css
@@ -1,0 +1,3 @@
+.heading {
+  margin-bottom: 0.5em;
+}

--- a/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/RequestPreferencesEdit.js
+++ b/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/RequestPreferencesEdit.js
@@ -1,0 +1,238 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import {
+  Field,
+  formValueSelector,
+  change,
+} from 'redux-form';
+import {
+  get,
+  isEmpty,
+  difference,
+} from 'lodash';
+
+import {
+  Row,
+  Col,
+  Select,
+  Checkbox,
+} from '@folio/stripes/components';
+import { deliveryFulfillmentValues } from '../../../../constants';
+import { addressTypesShape } from '../../../../shapes';
+import styles from './RequestPreferencesEdit.css';
+
+class RequestPreferencesEdit extends Component {
+  static propTypes = {
+    deliveryAvailable: PropTypes.bool,
+    servicePoints: PropTypes.arrayOf(PropTypes.object),
+    addresses: PropTypes.arrayOf(PropTypes.shape({
+      addressType: PropTypes.string.isRequired,
+    })),
+    addressTypes: addressTypesShape,
+    setFieldValue: PropTypes.func.isRequired,
+    intl: intlShape,
+    defaultDeliveryAddressTypeId: PropTypes.oneOfType(
+      PropTypes.string,
+      PropTypes.oneOf([null]),
+    ),
+  };
+
+  componentDidUpdate(prevProps) {
+    const {
+      addresses,
+    } = this.props;
+
+    if (this.areAddressTypesChanged(addresses, prevProps.addresses) && !this.isDefaultAddressTypeExists()) {
+      this.resetDefaultDeliveryAddress();
+    }
+  }
+
+  isDefaultAddressTypeExists(currentAddressTypeIds) {
+    return currentAddressTypeIds.some(addressTypeId => addressTypeId === this.props.defaultDeliveryAddressTypeId);
+  }
+
+  areAddressTypesChanged(currentAddresses, prevAddresses) {
+    const currentAddressTypeIds = currentAddresses.map(address => get(address, 'addressType'));
+    const prevAddressTypeIds = prevAddresses.map(address => get(address, 'addressType'));
+
+    if (currentAddresses === 0 && prevAddresses.length === 0) return false;
+
+    return difference(prevAddressTypeIds, currentAddressTypeIds).length !== 0;
+  }
+
+  renderDefaultDeliveryAddressSelect() {
+    return (
+      <Field
+        name="requestPreferences.defaultDeliveryAddressTypeId"
+        label={<FormattedMessage id="ui-users.requests.defaultDeliveryAddress" />}
+        dataOptions={this.getAddressOptions()}
+        component={Select}
+        validate={this.defaultDeliveryAddressValidator}
+        placeholder={this.props.intl.formatMessage({ id: 'ui-users.requests.selectDeliveryAddress' })}
+        required
+      />
+    );
+  }
+
+  renderServicePointSelect() {
+    const { servicePoints, intl } = this.props;
+
+    const options = servicePoints.map(servicePoint => ({
+      value: servicePoint.id,
+      label: servicePoint.name,
+    }));
+
+    const defaultOption = { value: '', label: intl.formatMessage({ id: 'ui-users.sp.selectServicePoint' }) };
+    const resultOptions = [defaultOption, ...options];
+
+    return (
+      <Field
+        name="requestPreferences.defaultServicePointId"
+        label={<FormattedMessage id="ui-users.requests.defaultServicePoint" />}
+        dataOptions={resultOptions}
+        component={Select}
+        parse={this.defaultServicePointFieldParser}
+      />
+    );
+  }
+
+  defaultServicePointFieldParser(value) {
+    return value === '' ? null : value;
+  }
+
+  renderFulfilmentPreferenceSelect() {
+    const { intl } = this.props;
+    const options = [
+      {
+        value: deliveryFulfillmentValues.HOLD_SHELF,
+        label: intl.formatMessage({ id: 'ui-users.requests.holdShelf' })
+      },
+      {
+        value: deliveryFulfillmentValues.DELIVERY,
+        label: intl.formatMessage({ id: 'ui-users.requests.delivery' })
+      },
+    ];
+
+    return (
+      <Field
+        name="requestPreferences.fulfillment"
+        label={<FormattedMessage id="ui-users.requests.fulfillmentPreference" />}
+        dataOptions={options}
+        component={Select}
+      />
+    );
+  }
+
+  getAddressOptions() {
+    const {
+      addresses,
+      addressTypes,
+    } = this.props;
+
+    return addresses.reduce((options, address) => {
+      const { addressType: addressTypeId } = address;
+      const relatedAddressType = addressTypes
+        .find((currentAddressType) => currentAddressType.id === addressTypeId);
+
+      return [
+        ...options,
+        {
+          value: get(relatedAddressType, 'id'),
+          label: get(relatedAddressType, 'addressType'),
+        }
+      ];
+    }, []);
+  }
+
+  defaultDeliveryAddressValidator = () => {
+    return this.props.addresses.length === 0 ? <FormattedMessage id="ui-users.addAddressError" /> : null;
+  }
+
+  resetDefaultDeliveryAddress() {
+    this.props.setFieldValue('requestPreferences.defaultDeliveryAddressTypeId', null);
+  }
+
+  onDeliveryCheckboxChange = (event) => {
+    const { setFieldValue } = this.props;
+    const fulfilmentValue = event.target.checked ? deliveryFulfillmentValues.HOLD_SHELF : null;
+
+    setFieldValue('requestPreferences.fulfillment', fulfilmentValue);
+    this.resetDefaultDeliveryAddress();
+  }
+
+  render() {
+    const {
+      deliveryAvailable,
+    } = this.props;
+
+    return (
+      <Col xs={12} md={6}>
+        <Row>
+          <Col
+            xs={12}
+            md={6}
+            className={styles.heading}
+          >
+            <FormattedMessage id="ui-users.requests.preferences" />
+          </Col>
+        </Row>
+        <Row className={styles.heading}>
+          <Col xs={12} md={6}>
+            <Field
+              name="requestPreferences.holdShelf"
+              label={<FormattedMessage id="ui-users.requests.holdShelf" />}
+              checked
+              disabled
+              component={Checkbox}
+            />
+          </Col>
+          <Col xs={12} md={6}>
+            <Field
+              name="requestPreferences.delivery"
+              label={<FormattedMessage id="ui-users.requests.delivery" />}
+              checked={deliveryAvailable}
+              component={Checkbox}
+              onChange={this.onDeliveryCheckboxChange}
+            />
+          </Col>
+        </Row>
+        <Row className={styles.heading}>
+          <Col xs={12} md={6}>
+            {this.renderServicePointSelect()}
+          </Col>
+          <Col xs={12} md={6}>
+            { deliveryAvailable && this.renderFulfilmentPreferenceSelect() }
+          </Col>
+        </Row>
+        <Row className={styles.heading}>
+          <Col mdOffset={6} xs={12} md={6}>
+            { deliveryAvailable && this.renderDefaultDeliveryAddressSelect() }
+          </Col>
+        </Row>
+      </Col>
+    );
+  }
+}
+
+const selectFormValue = formValueSelector('userForm');
+const selectAddresses = (store) => {
+  const addresses = selectFormValue(store, 'personal.addresses') || [];
+  return addresses.filter(address => !isEmpty(address));
+};
+const selectServicePointsWithPickupLocation = store => get(store, 'okapi.currentUser.servicePoints', [])
+  .filter(servicePoint => servicePoint.pickupLocation)
+  .sort();
+
+export default connect(
+  store => ({
+    addresses: selectAddresses(store),
+    defaultDeliveryAddressTypeId: selectFormValue(store, 'requestPreferences.defaultDeliveryAddressTypeId'),
+    deliveryAvailable: selectFormValue(store, 'requestPreferences.delivery'),
+    servicePoints: selectServicePointsWithPickupLocation(store)
+  }),
+  dispatch => ({
+    setFieldValue(fieldName, fieldValue) { dispatch(change('userForm', fieldName, fieldValue)); }
+  }),
+)(injectIntl(RequestPreferencesEdit));

--- a/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/index.js
+++ b/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/index.js
@@ -1,0 +1,1 @@
+export { default } from './RequestPreferencesEdit';

--- a/src/components/UserDetailSections/ExtendedInfo/ExtendedInfo.js
+++ b/src/components/UserDetailSections/ExtendedInfo/ExtendedInfo.js
@@ -13,52 +13,78 @@ import {
   Row
 } from '@folio/stripes/components';
 
-const ExtendedInfo = ({ accordionId, expanded, onToggle, user }) => (
-  <Accordion
-    id={accordionId}
-    label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.extended.extendedInformation" /></Headline>}
-    onToggle={onToggle}
-    open={expanded}
-  >
-    <Row>
-      <Col xs={12} md={3}>
-        <KeyValue label={<FormattedMessage id="ui-users.extended.dateEnrolled" />}>
-          {user.enrollmentDate ? <FormattedDate value={user.enrollmentDate} /> : '-'}
-        </KeyValue>
-      </Col>
-      <Col xs={12} md={3}>
-        <KeyValue label={<FormattedMessage id="ui-users.extended.birthDate" />}>
-          {user.personal.dateOfBirth ? <FormattedDate value={user.personal.dateOfBirth} timeZone="UTC" /> : '-'}
-        </KeyValue>
-      </Col>
-    </Row>
-    <Row>
-      <Col xs={12} md={6}>
-        <KeyValue label={<FormattedMessage id="ui-users.extended.folioNumber" />}>
-          {get(user, ['id'], '-')}
-        </KeyValue>
-      </Col>
-      <Col xs={12} md={6}>
-        <KeyValue label={<FormattedMessage id="ui-users.extended.externalSystemId" />}>
-          {get(user, ['externalSystemId'], '-')}
-        </KeyValue>
-      </Col>
-    </Row>
-    <Row>
-      <Col xs={12}>
-        <KeyValue label={<FormattedMessage id="ui-users.information.username" />}>
-          {get(user, ['username'], '')}
-        </KeyValue>
-      </Col>
-    </Row>
-  </Accordion>
-);
+import { requestPreferencesShape } from '../../../shapes';
+
+import RequestPreferencesView from './components/RequestPreferencesView';
+
+const ExtendedInfo = (props) => {
+  const {
+    accordionId,
+    expanded,
+    onToggle,
+    user,
+    requestPreferences,
+    defaultServicePointName,
+    defaultDeliveryAddressTypeName,
+  } = props;
+
+  return (
+    <Accordion
+      id={accordionId}
+      label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.extended.extendedInformation" /></Headline>}
+      onToggle={onToggle}
+      open={expanded}
+    >
+      <Row>
+        <Col xs={12} md={3}>
+          <KeyValue label={<FormattedMessage id="ui-users.extended.dateEnrolled" />}>
+            {user.enrollmentDate ? <FormattedDate value={user.enrollmentDate} /> : '-'}
+          </KeyValue>
+        </Col>
+        <Col xs={12} md={3}>
+          <KeyValue label={<FormattedMessage id="ui-users.extended.birthDate" />}>
+            {user.personal.dateOfBirth ? <FormattedDate value={user.personal.dateOfBirth} timeZone="UTC" /> : '-'}
+          </KeyValue>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={12} md={6}>
+          <KeyValue label={<FormattedMessage id="ui-users.extended.folioNumber" />}>
+            {get(user, ['id'], '-')}
+          </KeyValue>
+        </Col>
+        <Col xs={12} md={6}>
+          <KeyValue label={<FormattedMessage id="ui-users.extended.externalSystemId" />}>
+            {get(user, ['externalSystemId'], '-')}
+          </KeyValue>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={3}>
+          <KeyValue label={<FormattedMessage id="ui-users.information.username" />}>
+            {get(user, ['username'], '')}
+          </KeyValue>
+        </Col>
+        <Col xs={9}>
+          <RequestPreferencesView
+            requestPreferences={requestPreferences}
+            defaultServicePointName={defaultServicePointName}
+            defaultDeliveryAddressTypeName={defaultDeliveryAddressTypeName}
+          />
+        </Col>
+      </Row>
+    </Accordion>
+  );
+};
 
 ExtendedInfo.propTypes = {
   accordionId: PropTypes.string.isRequired,
   expanded: PropTypes.bool,
   onToggle: PropTypes.func,
-  user: PropTypes.object
+  user: PropTypes.object,
+  defaultServicePointName: PropTypes.string,
+  requestPreferences: requestPreferencesShape,
+  defaultDeliveryAddressTypeName: PropTypes.string.isRequired,
 };
 
 export default ExtendedInfo;

--- a/src/components/UserDetailSections/ExtendedInfo/components/RequestPreferencesView/RequestPreferencesView.css
+++ b/src/components/UserDetailSections/ExtendedInfo/components/RequestPreferencesView/RequestPreferencesView.css
@@ -1,0 +1,11 @@
+.heading {
+  margin-bottom: 3.5px;
+  display: block;
+  font-size: 14.7px;
+  line-height: 22.05px;
+  font-weight: bold;
+}
+
+.request-preferences-row {
+  margin-bottom: 11px;
+}

--- a/src/components/UserDetailSections/ExtendedInfo/components/RequestPreferencesView/RequestPreferencesView.js
+++ b/src/components/UserDetailSections/ExtendedInfo/components/RequestPreferencesView/RequestPreferencesView.js
@@ -1,0 +1,87 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import {
+  Col,
+  KeyValue,
+  Row,
+} from '@folio/stripes/components';
+
+import { requestPreferencesShape } from '../../../../../shapes';
+
+import styles from './RequestPreferencesView.css';
+
+class RequestPreferencesView extends Component {
+  static propTypes = {
+    requestPreferences: requestPreferencesShape,
+    defaultServicePointName: PropTypes.string,
+    defaultDeliveryAddressTypeName: PropTypes.string.isRequired,
+  };
+
+  getHoldShelfStateTranslationKey() {
+    return this.props.requestPreferences.holdShelf
+      ? 'ui-users.requests.holdShelfYes'
+      : 'ui-users.requests.holdShelfNo';
+  }
+
+  getDeliveryStateTranslationKey() {
+    return this.props.requestPreferences.delivery
+      ? 'ui-users.requests.deliveryYes'
+      : 'ui-users.requests.deliveryNo';
+  }
+
+  render() {
+    const {
+      requestPreferences,
+      defaultServicePointName,
+      defaultDeliveryAddressTypeName,
+    } = this.props;
+
+    return (
+      <Fragment>
+        <Row>
+          <Col xs={4}>
+            <span className={styles.heading}>
+              <FormattedMessage id="ui-users.requests.preferences" />
+            </span>
+          </Col>
+        </Row>
+        <Row className={styles['request-preferences-row']}>
+          <Col xs={4}>
+            <FormattedMessage id={this.getHoldShelfStateTranslationKey()} />
+          </Col>
+          <Col xs={4}>
+            <FormattedMessage id={this.getDeliveryStateTranslationKey()} />
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={4}>
+            {requestPreferences.holdShelf && (
+              <KeyValue label={<FormattedMessage id="ui-users.requests.defaultServicePoint" />}>
+                { defaultServicePointName || '-' }
+              </KeyValue>
+            )}
+          </Col>
+          <Col xs={4}>
+            {requestPreferences.delivery && (
+              <KeyValue label={<FormattedMessage id="ui-users.requests.fulfillmentPreference" />}>
+                { requestPreferences.fulfillment }
+              </KeyValue>
+            )}
+          </Col>
+        </Row>
+        <Row>
+          <Col xsOffset={4} xs={8}>
+            {requestPreferences.delivery && (
+              <KeyValue label={<FormattedMessage id="ui-users.requests.defaultDeliveryAddress" />}>
+                { defaultDeliveryAddressTypeName || '-'}
+              </KeyValue>
+            )}
+          </Col>
+        </Row>
+      </Fragment>
+    );
+  }
+}
+
+export default RequestPreferencesView;

--- a/src/components/UserDetailSections/ExtendedInfo/components/RequestPreferencesView/index.js
+++ b/src/components/UserDetailSections/ExtendedInfo/components/RequestPreferencesView/index.js
@@ -1,0 +1,1 @@
+export { default } from './RequestPreferencesView';

--- a/src/components/UserDetailSections/ExtendedInfo/components/index.js
+++ b/src/components/UserDetailSections/ExtendedInfo/components/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as RequestPreferencesView } from './RequestPreferencesView';

--- a/src/components/UserDetailSections/index.js
+++ b/src/components/UserDetailSections/index.js
@@ -8,3 +8,4 @@ export { default as UserRequests } from './UserRequests';
 export { default as UserAccounts } from './UserAccounts';
 export { default as UserPermissions } from './UserPermissions';
 export { default as UserServicePoints } from './UserServicePoints';
+export { default as RequestPreferencesView } from './ExtendedInfo/components/RequestPreferencesView';

--- a/src/components/data/converters/address.js
+++ b/src/components/data/converters/address.js
@@ -1,12 +1,10 @@
 import _ from 'lodash';
 import { hashCode } from 'hashcode';
-import { getAddressTypesByName, getAddressTypesById } from './address_type';
 
-function toListAddress(addr, addrType) {
+function toListAddress(addr) {
   if (addr.id) return { ...addr };
 
   const country = (addr.countryId) ? addr.countryId : '';
-  const addressType = _.get(addrType, ['addressType'], '');
   const id = hashCode().value(addr).toString();
 
   return {
@@ -19,36 +17,31 @@ function toListAddress(addr, addrType) {
     stateRegion: addr.region,
     zipCode: addr.postalCode,
     country,
-    addressType,
+    addressType: addr.addressTypeId,
   };
 }
 
-function toUserAddress(addr, addrType) {
-  // console.log('toUserAddress for', addr, '-- countriesByName[addr.country] =', countriesByName[addr.country]);
-  const countryId = (addr.country) ? addr.country : '';
-  const addressTypeId = _.get(addrType, ['id'], '');
-  return {
-    addressLine1: addr.addressLine1,
-    addressLine2: addr.addressLine2,
-    city: addr.city,
-    primaryAddress: addr.primaryAddress,
-    region: addr.stateRegion,
-    postalCode: addr.zipCode,
-    addressTypeId,
-    countryId,
-  };
-}
-
-export function toListAddresses(addresses, addressTypes) {
+export function getFormAddressList(addresses) {
   if (!addresses || !addresses.length) return addresses;
 
-  const addressTypesById = getAddressTypesById(addressTypes);
-  return _.sortBy(addresses, a => -a.primaryAddress).map(addr => toListAddress(addr, addressTypesById[addr.addressTypeId]));
+  return _.sortBy(addresses, a => -a.primaryAddress)
+    .map(addr => toListAddress(addr));
 }
 
-export function toUserAddresses(addresses, addressTypes) {
-  if (!addresses || !addresses.length) return addresses;
+export function toUserAddresses(addresses) {
+  if (_.isEmpty(addresses)) return;
 
-  const addressTypesByName = getAddressTypesByName(addressTypes);
-  return addresses.map(addr => toUserAddress(addr, addressTypesByName[addr.addressType]));
+  // eslint-disable-next-line consistent-return
+  return addresses.map(address => {
+    return {
+      addressLine1: address.addressLine1,
+      addressLine2: address.addressLine2,
+      city: address.city,
+      primaryAddress: address.primaryAddress,
+      region: address.stateRegion,
+      postalCode: address.zipCode,
+      addressTypeId: address.addressType,
+      countryId: address.country,
+    };
+  });
 }

--- a/src/components/data/converters/address_type.js
+++ b/src/components/data/converters/address_type.js
@@ -1,17 +1,8 @@
+// eslint-disable-next-line import/prefer-default-export
 export function toAddressTypeOptions(addressTypes) {
   if (!addressTypes) return [];
   return addressTypes.map(at => ({
     label: at.addressType,
-    value: at.addressType,
+    value: at.id,
   }));
-}
-
-export function getAddressTypesById(addressTypes) {
-  if (!addressTypes) return {};
-  return addressTypes.reduce((map, addrType) => (Object.assign(map, { [addrType.id]: addrType })), {});
-}
-
-export function getAddressTypesByName(addressTypes) {
-  if (!addressTypes) return {};
-  return addressTypes.reduce((map, addrType) => (Object.assign(map, { [addrType.addressType]: addrType })), {});
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export const deliveryFulfillmentValues = {
+  HOLD_SHELF: 'Hold Shelf',
+  DELIVERY: 'Delivery',
+};

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -97,6 +97,23 @@ class UserRecordContainer extends React.Component {
       records: 'configs',
       path: 'configurations/entries?query=(module==USERS and configName==profile_pictures)',
     },
+    requestPreferences: {
+      type: 'okapi',
+      GET: {
+        path: 'request-preference-storage/request-preference',
+        params: {
+          query: 'userId==:{id}'
+        }
+      },
+      POST: {
+        path: 'request-preference-storage/request-preference',
+      },
+      PUT: {
+        path: (queryParams, pathComponents, resourceData) => {
+          return `request-preference-storage/request-preference/${resourceData.request_preferences.records[0].requestPreferences[0].id}`;
+        },
+      }
+    },
   });
 
   static propTypes = {

--- a/src/shapes.js
+++ b/src/shapes.js
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+
+import { deliveryFulfillmentValues } from './constants';
+
+const {
+  HOLD_SHELF,
+  DELIVERY,
+} = deliveryFulfillmentValues;
+
+export const addressTypesShape = PropTypes.arrayOf(PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  addressType: PropTypes.string.isRequired,
+}));
+
+export const requestPreferencesShape = PropTypes.shape({
+  holdShelf: PropTypes.bool.isRequired,
+  delivery: PropTypes.bool.isRequired,
+  defaultDeliveryAddressTypeId: PropTypes.string,
+  defaultServicePointId: PropTypes.string,
+  fulfillment: PropTypes.oneOf([HOLD_SHELF, DELIVERY])
+});

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -48,7 +48,7 @@ import {
   PatronBlockMessage
 } from '../../components/PatronBlock';
 import {
-  toListAddresses,
+  getFormAddressList,
   // toUserAddresses
 } from '../../components/data/converters/address';
 import {
@@ -350,7 +350,7 @@ class UserDetail extends React.Component {
     const user = this.getUser();
 
     const addressTypes = (resources.addressTypes || {}).records || [];
-    const addresses = toListAddresses(get(user, ['personal', 'addresses'], []), addressTypes);
+    const addresses = getFormAddressList(get(user, 'personal.addresses', []));
     const permissions = (resources.permissions || {}).records || [];
     const settings = (resources.settings || {}).records || [];
     const sponsors = this.props.getSponsors();
@@ -362,6 +362,18 @@ class UserDetail extends React.Component {
     const patronBlocks = get(resources, ['hasPatronBlocks', 'records'], []);
     const patronGroup = this.getPatronGroup(user);
     // const detailMenu = this.renderDetailMenu(user);
+    const requestPreferences = get(resources, 'requestPreferences.records.[0].requestPreferences[0]', {});
+    const allServicePoints = get(resources, 'servicePoints.records', [{}]);
+    const defaultServicePointName = get(
+      allServicePoints.find(servicePoint => servicePoint.id === requestPreferences.defaultServicePointId),
+      'name',
+      '',
+    );
+    const defaultDeliveryAddressTypeName = get(
+      addressTypes.find(addressType => addressType.id === requestPreferences.defaultDeliveryAddressTypeId),
+      'addressType',
+      '',
+    );
 
     if (!user) {
       return (
@@ -443,6 +455,9 @@ class UserDetail extends React.Component {
                   accordionId="extendedInfoSection"
                   user={user}
                   expanded={sections.extendedInfoSection}
+                  requestPreferences={requestPreferences}
+                  defaultServicePointName={defaultServicePointName}
+                  defaultDeliveryAddressTypeName={defaultDeliveryAddressTypeName}
                   onToggle={this.handleSectionToggle}
                 />
                 <ContactInfo

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
-
 import { AppIcon } from '@folio/stripes/core';
 import {
   Paneset,
@@ -35,6 +34,7 @@ import {
   statusFilterConfig,
   permissionTypeFilterConfig,
 } from '../../components/PermissionsAccordion/helpers/filtersConfig';
+import { addressTypesShape } from '../../shapes';
 
 import css from './UserForm.css';
 
@@ -126,6 +126,10 @@ function asyncValidate(values, dispatch, props, blurredField) {
 class UserForm extends React.Component {
   static propTypes = {
     change: PropTypes.func,
+    addressTypes: addressTypesShape,
+    stripes: PropTypes.shape({
+      store: PropTypes.object,
+    }).isRequired,
     formData: PropTypes.object,
     handleSubmit: PropTypes.func.isRequired,
     location: PropTypes.object,
@@ -327,6 +331,7 @@ class UserForm extends React.Component {
       handleSubmit,
       formData,
       change, // from redux-form...
+      servicePoints,
     } = this.props;
 
     const { sections } = this.state;
@@ -388,6 +393,8 @@ class UserForm extends React.Component {
                     userId={initialValues.id}
                     userFirstName={initialValues.personal.firstName}
                     userEmail={initialValues.personal.email}
+                    servicePoints={servicePoints}
+                    addressTypes={formData.addressTypes}
                   />
                   <EditContactInfo
                     accordionId="contactInfo"

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -366,6 +366,17 @@
   "requests.createRequest": "Create request",
   "requests.numOpenRequests": "{count, number} {count, plural, one {open request} other {open requests}}",
   "requests.numClosedRequests": "{count, number} {count, plural, one {closed request} other {closed requests}}",
+  "requests.preferences": "Request preferences",
+  "requests.defaultServicePoint": "Default service point",
+  "requests.fulfillmentPreference": "Fulfillment preference",
+  "requests.defaultDeliveryAddress": "Default delivery address",
+  "requests.deliveryYes": "Delivery - Yes",
+  "requests.deliveryNo": "Delivery - No",
+  "requests.holdShelf": "Hold Shelf",
+  "requests.delivery": "Delivery",
+  "requests.holdShelfYes": "Hold shelf - Yes",
+  "requests.holdShelfNo": "Hold shelf - No",
+  "requests.selectDeliveryAddress": "Select delivery address",
 
   "permissions.emptyField": "Please fill this in to continue",
   "permissions.noSponsorsFound": "No sponsors found",
@@ -900,5 +911,6 @@
   "permissions.modal.numberOfFilters": "{count, number} {count, plural, one {applied filter} other {applied filters}}",
 
   "anonymization.confirmation.header": "Anonymization prevented",
-  "anonymization.confirmation.message": "{amount} loan(s) had associated fees/fines and could not be anonymized."
+  "anonymization.confirmation.message": "{amount} loan(s) had associated fees/fines and could not be anonymized.",
+  "addAddressError": "Please, add at least one address inside \"Addresses\" section"
 }


### PR DESCRIPTION
`RequestPreferencesEdit` and `RequestPreferencesView` components were created to display and edit request preferences of users. `ViewUser` handles a lot of things, including displaying the edit user form, so the logic of GETting, PUTting, and POSTting the request preferences was placed in the `ViewUser` component.

Tests part is out of scope and extracted to this task https://issues.folio.org/browse/UIU-1328