### PR TITLE
UIU-1297: Retrieve up to max amount of overdue loans instead of 10 for CSV report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## 2.26.0 (IN PROGRESS)
 * Prevent manual anonymization of closed loans with fees/fines. Refs UIU-1083.
 * Update sponsor and proxy labels. Refs UIU-1018.
-
 * Implement permission assigment by batch. Refs UIU-1249
 * Fix the mechanism for the accumulation of overdue loans in CSV report. Refs UIU-1286.
+* Retrieve up to max amount of overdue loans instead of 10 for CSV report. Refs UIU-1297.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/src/Users.js
+++ b/src/Users.js
@@ -25,6 +25,7 @@ import usersStyles from './Users.css';
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
+const LIMIT_MAX = 2147483647;
 
 const filterConfig = [
   {
@@ -128,7 +129,7 @@ class Users extends React.Component {
       type: 'okapi',
       records: 'loans',
       accumulate: true,
-      path: () => `circulation/loans?query=(status="Open" and dueDate < ${getLoansOverdueDate()})`,
+      path: () => `circulation/loans?limit=${LIMIT_MAX}&query=(status="Open" and dueDate < ${getLoansOverdueDate()})`,
       permissionsRequired: 'circulation.loans.collection.get,accounts.collection.get',
     }
   });


### PR DESCRIPTION
## Purposes

Retrieve up to max amount (2147483647 according to the [doc](https://s3.amazonaws.com/foliodocs/api/mod-orders-storage/location.html#orders_storage_locations_get)) of overdue loans instead of 10 to add information about all records to the CSV report. Fix [UIU-1297 ](https://issues.folio.org/browse/UIU-1297)