### PR TITLE
UIU-1314 - Problems editing a newly created user.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix the mechanism for the accumulation of overdue loans in CSV report. Refs UIU-1286.
 * Implement view loans permission. Refs UIU-1175.
 * Refactor Routing. Switch to using SearchAndSortQuery. UIU-897
+* Resolve bug updating a user just after creation. Fixes UIU-1314.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/src/components/AddServicePointModal/AddServicePointModal.js
+++ b/src/components/AddServicePointModal/AddServicePointModal.js
@@ -10,6 +10,7 @@ import {
   Checkbox,
   Layout,
   Modal,
+  Button,
   ModalFooter,
 } from '@folio/stripes/components';
 
@@ -69,17 +70,20 @@ class AddServicePointModal extends React.Component {
 
   renderModalFooter() {
     return (
-      <ModalFooter
-        primaryButton={{
-          id: 'save-service-point-btn',
-          label: <FormattedMessage id="ui-users.saveAndClose" />,
-          onClick: this.onSaveAndClose,
-        }}
-        secondaryButton={{
-          label: <FormattedMessage id="stripes-core.button.cancel" />,
-          onClick: this.onCancel,
-        }}
-      />
+      <ModalFooter>
+        <Button
+          buttonStyle="primary"
+          id="save-service-point-btn"
+          onClick={this.onSaveAndClose}
+        >
+          <FormattedMessage id="ui-users.saveAndClose" />
+        </Button>
+        <Button
+          onClick={this.onCancel}
+        >
+          <FormattedMessage id="stripes-core.button.cancel" />
+        </Button>
+      </ModalFooter>
     );
   }
 

--- a/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.js
+++ b/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.js
@@ -20,7 +20,7 @@ class CreateResetPasswordControl extends React.Component {
     userId: PropTypes.string.isRequired,
     resources: PropTypes.shape({
       isLocalPasswordSet: PropTypes.shape({
-        records: PropTypes.object,
+        records: PropTypes.arrayOf(PropTypes.object),
       }).isRequired,
     }).isRequired,
     mutator: PropTypes.shape({

--- a/src/components/EditSections/EditServicePoints/EditServicePoints.js
+++ b/src/components/EditSections/EditServicePoints/EditServicePoints.js
@@ -34,12 +34,7 @@ class EditServicePoints extends React.Component {
       servicePoints: PropTypes.array,
     }).isRequired,
     onToggle: PropTypes.func,
-    resources: PropTypes.shape({
-      servicePoints: PropTypes.shape({
-        records: PropTypes.arrayOf(PropTypes.object),
-      }).isRequired,
-    }).isRequired,
-    stripes: PropTypes.object.isRequired,
+    formData: PropTypes.object.isRequired,
     intl: intlShape.isRequired,
   };
 
@@ -177,7 +172,7 @@ class EditServicePoints extends React.Component {
   }
 
   renderAddServicePointModal() {
-    const servicePoints = get(this.props.resources, ['servicePoints', 'records'], []);
+    const servicePoints = get(this.props.formData, 'servicePoints', []);
 
     return (
       <AddServicePointModal
@@ -185,7 +180,6 @@ class EditServicePoints extends React.Component {
         onSave={this.onAddServicePoints}
         open={this.state.addingServicePoint}
         servicePoints={servicePoints}
-        stripes={this.props.stripes}
       />
     );
   }

--- a/src/components/Wrappers/withServicePoints.js
+++ b/src/components/Wrappers/withServicePoints.js
@@ -125,7 +125,7 @@ const withServicePoints = WrappedComponent => class WithServicePointsComponent e
       }
     }
 
-    getServicePoints = () => {
+    getUserServicePoints = () => {
       return this.state.userServicePoints;
     };
 
@@ -176,7 +176,7 @@ const withServicePoints = WrappedComponent => class WithServicePointsComponent e
       return (
         <Fragment>
           <WrappedComponent
-            getServicePoints={this.getServicePoints}
+            getUserServicePoints={this.getUserServicePoints}
             getPreferredServicePoint={this.getPreferredServicePoint}
             updateServicePoints={this.updateServicePoints}
             {...this.props}

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -155,7 +155,7 @@ class UserRecordContainer extends React.Component {
     updateSponsors: PropTypes.func,
     getSponsors: PropTypes.func,
     getProxies: PropTypes.func,
-    getServicePoints: PropTypes.func,
+    getUserServicePoints: PropTypes.func,
     getPreferredServicePoint: PropTypes.func,
     tagsEnabled: PropTypes.bool,
     okapi: PropTypes.object,

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -96,7 +96,7 @@ class UserDetail extends React.Component {
     history: PropTypes.object,
     getSponsors: PropTypes.func,
     getProxies: PropTypes.func,
-    getServicePoints: PropTypes.func,
+    getUserServicePoints: PropTypes.func,
     getPreferredServicePoint: PropTypes.func,
     tagsEnabled: PropTypes.bool,
     paneWidth: PropTypes.string,
@@ -355,7 +355,7 @@ class UserDetail extends React.Component {
     const settings = (resources.settings || {}).records || [];
     const sponsors = this.props.getSponsors();
     const proxies = this.props.getProxies();
-    const servicePoints = this.props.getServicePoints();
+    const servicePoints = this.props.getUserServicePoints();
     const preferredServicePoint = this.props.getPreferredServicePoint();
     const hasPatronBlocks = (get(resources, ['hasPatronBlocks', 'isPending'], true)) ? -1 : 1;
     const totalPatronBlocks = get(resources, ['hasPatronBlocks', 'other', 'totalRecords'], 0);

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -40,6 +40,7 @@ class UserEdit extends React.Component {
     updateProxies: PropTypes.func,
     updateSponsors: PropTypes.func,
     updateServicePoints: PropTypes.func,
+    getUserServicePoints: PropTypes.func,
     getPreferredServicePoint: PropTypes.func,
     mutator: PropTypes.object,
   }
@@ -57,6 +58,7 @@ class UserEdit extends React.Component {
   getUserFormValues() {
     const {
       getPreferredServicePoint,
+      getUserServicePoints,
       resources
     } = this.props;
 
@@ -67,16 +69,17 @@ class UserEdit extends React.Component {
       'sponsors',
       'proxies',
       'permissions',
-      'servicePoints'
     );
 
+    const servicePoints = getUserServicePoints();
     const addressTypes = resources.addressTypes.records;
     const addresses = toListAddresses(get(user, ['personal', 'addresses'], []), addressTypes);
 
     const preferredServicePoint = getPreferredServicePoint();
     userFormValues.personal.addresses = addresses;
     Object.assign(userFormValues, formRecordValues, {
-      preferredServicePoint
+      preferredServicePoint,
+      servicePoints
     });
 
     return userFormValues;
@@ -84,13 +87,15 @@ class UserEdit extends React.Component {
 
   getUserFormData() {
     const {
-      resources
+      resources,
     } = this.props;
     const formData = getRecordObject(
       resources,
       'patronGroups',
       'addressTypes',
+      'servicePoints'
     );
+
     return formData;
   }
 

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -97,7 +97,9 @@ function asyncValidateField(field, value, validator) {
 function asyncValidate(values, dispatch, props, blurredField) {
   const { uniquenessValidator, initialValues } = props;
   const { username, barcode } = values;
-  values.username = username.trim();
+  if (username) {
+    values.username = username.trim();
+  }
   const curValue = values[blurredField];
   const prevValue = initialValues[blurredField];
 


### PR DESCRIPTION
# Problem
Save button is not enabling when editing a newly created user, despite changes in values.

# Approach
It turns out that `props.resources.servicePoints.records` and `getServicePoints()` are two very different things...
I passed those to UserForm in the proper places, and renamed `getServicePoints()` to `getUserSevicePoints` so that it's slightly clearer.

Additionally, I cleaned up a couple of console gripes for invalid prop types and resolved an error attempting to `trim()` an undefined value.
