### PR TITLE
UIU-897 restore former form element id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ class UsersRouting extends React.Component {
 
   focusSearchField = () => {
     const { history } = this.props;
-    const el = document.getElementById('userSearchField');
+    const el = document.getElementById('input-user-search');
     if (el) {
       el.focus();
     } else {

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -311,7 +311,7 @@ class UserSearch extends React.Component {
                                 <SearchField
                                   aria-label="user search"
                                   name="query"
-                                  id="userSearchField"
+                                  id="input-user-search"
                                   className={css.searchField}
                                   onChange={getSearchHandlers().query}
                                   value={searchValue.query}
@@ -362,6 +362,7 @@ class UserSearch extends React.Component {
                           noOverflow
                         >
                           <MultiColumnList
+                            id="list-users"
                             visibleColumns={visibleColumns}
                             rowUpdater={this.rowUpdater}
                             contentData={users}


### PR DESCRIPTION
Restore the former search-input DOM id. It's simpler than changing all
the integration tests.

Refs [UIU-897](https://issues.folio.org/browse/UIU-897) / PR #839.