### PR TITLE
UIU-897 test cleanup

### DIFF
--- a/test/ui-testing/patron-group.js
+++ b/test/ui-testing/patron-group.js
@@ -79,6 +79,7 @@ module.exports.test = function foo(uiTestCtx) {
           .type('#input-user-search', '0')
           .wait('#clickable-reset-all')
           .click('#clickable-reset-all')
+          .wait('[class^="noResultsMessageLabel"]')
           .type('#input-user-search', userBarcode)
           .wait('button[type=submit]')
           .click('button[type=submit]')


### PR DESCRIPTION
It seems the search form may re-render in the middle of collecting input
from Nightmare, which sucks. Waiting for the "no results" message seems
like a good element to wait for that satisfies "all done rendering".

Refs [UIU-897](https://issues.folio.org/browse/UIU-897)