### PR TITLE
UIU-1320 Updating fee/fine column/display after charge

### DIFF
--- a/src/components/Accounts/Actions/ActionModal.js
+++ b/src/components/Accounts/Actions/ActionModal.js
@@ -60,7 +60,7 @@ class ActionModal extends React.Component {
     open: PropTypes.bool,
     accounts: PropTypes.arrayOf(PropTypes.object),
     data: PropTypes.arrayOf(PropTypes.object),
-    balance: PropTypes.number,
+    balance: PropTypes.string,
     submitting: PropTypes.bool,
     invalid: PropTypes.bool,
     pristine: PropTypes.bool,

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -178,8 +178,7 @@ class ChargeFeeFine extends React.Component {
     return new Promise((resolve, reject) => {
       this.payResolve = resolve;
       this.payReject = reject;
-    })
-      .then(() => { this.props.history.goBack(); });
+    });
   }
 
   onClosePayModal() {

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -178,7 +178,8 @@ class ChargeFeeFine extends React.Component {
     return new Promise((resolve, reject) => {
       this.payResolve = resolve;
       this.payReject = reject;
-    });
+    })
+      .then(() => { this.props.history.goBack(); });
   }
 
   onClosePayModal() {

--- a/src/components/Loans/ClosedLoans/ClosedLoans.js
+++ b/src/components/Loans/ClosedLoans/ClosedLoans.js
@@ -241,7 +241,7 @@ class ClosedLoans extends React.Component {
 
   feefine = (loan) => {
     const { history, match: { params } } = this.props;
-    history.push(`/users/${params.id}/charge?loan=${loan.id}`);
+    history.push(`/users/${params.id}/charge/${loan.id}`);
   }
 
   feefineDetails = (loan, e) => {

--- a/src/components/util/navigationHandlers.js
+++ b/src/components/util/navigationHandlers.js
@@ -23,5 +23,5 @@ export function onClickViewChargeFeeFine(e, history, params) {
 }
 
 export function onClickChargeFineToLoan(e, loan, history, params) {
-  history.push(`/users/${params.id}/charge?loan=${loan.id}`);
+  history.push(`/users/${params.id}/charge/${loan.id}`);
 }

--- a/src/routes/ChargeFeesFinesContainer.js
+++ b/src/routes/ChargeFeesFinesContainer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
+import queryString from 'query-string';
 
 import {
   stripesConnect,
@@ -24,7 +25,7 @@ class ChargeFeesFinesContainer extends React.Component {
       type: 'okapi',
       path: (_q, _p, _r, _l, props) => {
         const { match: { params } } = props;
-        const loanId = _q.loan || params.loanid;
+        const loanId = params.loanid;
         return loanId ? `loan-storage/loans/${loanId}` : null;
       },
       clear: false,


### PR DESCRIPTION
## Problem
See [UIU-1320](https://issues.folio.org/browse/UIU-1320)

## Approach
Logic for fetching loans/choosing the selected loan was checking the URL for a loan id in 2 different ways: the query string AND dynamic params picked up via react-router. I opted for the params route and removed the extra query string logic.
The charge fee/fine form should now have what it needs to apply the fine to the loan correctly.
The amounts in the Loans listing/detail will be updated, no refresh/navigation necessary.