### PR TITLE
UIU-897 props cleanup

### DIFF
--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 
 import { ViewMetaData } from '@folio/stripes/smart-components';
 import {
@@ -18,11 +18,12 @@ import css from './EditUserInfo.css';
 
 class EditUserInfo extends React.Component {
   static propTypes = {
-    patronGroups: PropTypes.arrayOf(PropTypes.object),
-    initialValues: PropTypes.object,
-    expanded: PropTypes.bool,
-    onToggle: PropTypes.func,
     accordionId: PropTypes.string.isRequired,
+    expanded: PropTypes.bool,
+    initialValues: PropTypes.object,
+    intl: PropTypes.object.isRequired,
+    onToggle: PropTypes.func,
+    patronGroups: PropTypes.arrayOf(PropTypes.object),
   };
 
   render() {
@@ -32,11 +33,10 @@ class EditUserInfo extends React.Component {
       expanded,
       onToggle,
       accordionId,
+      intl,
     } = this.props;
 
-    const patronGroupOptions = patronGroups.map(g => (
-      <option key={g.id} value={g.id}>{g.group.concat(g.desc ? ` (${g.desc})` : '')}</option>
-    ));
+
     const isUserExpired = () => {
       const expirationDate = new Date(initialValues.expirationDate);
       const now = Date.now();
@@ -48,6 +48,29 @@ class EditUserInfo extends React.Component {
       statusFieldDisabled = isUserExpired();
       return statusFieldDisabled;
     };
+
+    const patronGroupOptions = [
+      {
+        value: '',
+        label: intl.formatMessage({ id: 'ui-users.information.selectPatronGroup' }),
+      },
+      ...patronGroups.map(g => ({
+        key: g.id,
+        value: g.id,
+        label: g.group.concat(g.desc ? ` (${g.desc})` : ''),
+      }))
+    ];
+
+    const statusOptions = [
+      {
+        value: 'true',
+        label: intl.formatMessage({ id: 'ui-users.active' })
+      },
+      {
+        value: 'false',
+        label: intl.formatMessage({ id: 'ui-users.inactive' })
+      }
+    ];
 
     return (
       <Accordion
@@ -112,13 +135,9 @@ class EditUserInfo extends React.Component {
               component={Select}
               selectClass={css.patronGroup}
               fullWidth
+              dataOptions={patronGroupOptions}
               defaultValue={initialValues.patronGroup}
-            >
-              <FormattedMessage id="ui-users.information.selectPatronGroup">
-                {(message) => <option value="">{message}</option>}
-              </FormattedMessage>
-              {patronGroupOptions}
-            </Field>
+            />
           </Col>
           <Col xs={12} md={3}>
             <Field
@@ -132,15 +151,10 @@ class EditUserInfo extends React.Component {
               component={Select}
               fullWidth
               disabled={isStatusFieldDisabled()}
+              dataOptions={statusOptions}
+              format={(value) => (value ? 'true' : 'false')}
               defaultValue={initialValues.active}
-            >
-              <FormattedMessage id="ui-users.active">
-                {(message) => <option value="true">{message}</option>}
-              </FormattedMessage>
-              <FormattedMessage id="ui-users.inactive">
-                {(message) => <option value="false">{message}</option>}
-              </FormattedMessage>
-            </Field>
+            />
             {isUserExpired() && (
               <span style={{ 'color': '#900', 'position': 'relative', 'top': '-10px', 'fontSize': '0.9em' }}>
                 <FormattedMessage id="ui-users.errors.userExpired" />
@@ -162,4 +176,4 @@ class EditUserInfo extends React.Component {
   }
 }
 
-export default EditUserInfo;
+export default injectIntl(EditUserInfo);

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -183,7 +183,7 @@ class UserEdit extends React.Component {
     } = this.props;
 
     if (!resourcesLoaded(resources, ['uniquenessValidator'])) {
-      return <ViewLoading data-test-form-page paneTitle={params.id ? 'Edit User' : 'Create User'} />;
+      return <ViewLoading data-test-form-page paneTitle={params.id ? 'Edit User' : 'Create User'} defaultWidth="100%" />;
     }
 
     // values are strictly values...if we're editing (id param present) pull in existing values.

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -126,9 +126,6 @@ function asyncValidate(values, dispatch, props, blurredField) {
 class UserForm extends React.Component {
   static propTypes = {
     change: PropTypes.func,
-    stripes: PropTypes.shape({
-      store: PropTypes.object,
-    }).isRequired,
     formData: PropTypes.object,
     handleSubmit: PropTypes.func.isRequired,
     location: PropTypes.object,
@@ -329,7 +326,6 @@ class UserForm extends React.Component {
       initialValues,
       handleSubmit,
       formData,
-      stripes,
       change, // from redux-form...
     } = this.props;
 
@@ -409,7 +405,6 @@ class UserForm extends React.Component {
                         sponsors={initialValues.sponsors}
                         proxies={initialValues.proxies}
                         fullName={fullName}
-                        stripes={stripes}
                         change={change}
                         initialValues={initialValues}
                       />


### PR DESCRIPTION
It's not really fair to pin this on UIU-897 since many of these errors
were present previously. All that's going on here is some cleanup of
incorrect and/or missing and/or extraneous props.

* `EditUserInfo` needed a formatter for its boolean status value
* `UserEdit` omitted `defaultWidth`
* `UserForm` included `stripes` but that's handled by `withStripes`

I found this stuff while pursuing something else that was blowing up in
the console, and the console pollution from this stuff was just killing
me, so I fixed it.