### PR TITLE
Add proxy behavior

### DIFF
--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/Popdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/Popdown.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -8,75 +8,64 @@ import Popper from '@folio/stripes-components/lib/Popper/Popper';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 /* eslint-enable */
 
-class Popdown extends React.Component {
-  static propTypes = {
-    children: PropTypes.node,
-    buttonProps: PropTypes.object,
-    label: PropTypes.node,
-    renderTrigger: PropTypes.func,
-    portal: PropTypes.bool,
-  }
+const Popdown = ({ label, buttonProps, children, renderTrigger, portal }) => {
+  const [open, setOpen] = useState(false);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      open: false
-    };
+  const triggerRef = React.createRef();
 
-    this.triggerRef = React.createRef();
-  }
-
-  toggleMenu = (e) => {
+  const toggleMenu = (e) => {
     e.stopPropagation();
-    this.setState((curState) => {
-      return {
-        open: !curState.open
-      };
-    });
+    setOpen(prevOpen => !prevOpen);
   };
 
-  renderTrigger = () => {
-    const { renderTrigger: renderTriggerProp, buttonProps, label } = this.props;
-    const ariaProps = {
-      'aria-expanded': this.state.open,
-      'aria-haspopup': true
-    };
+  const ariaProps = {
+    'aria-expanded': open,
+    'aria-haspopup': true
+  };
 
-    if (renderTriggerProp) {
-      return renderTriggerProp(this.triggerRef, this.toggleMenu, ariaProps);
-    }
-
-    return (
+  const trigger = renderTrigger ?
+    renderTrigger(triggerRef, toggleMenu, ariaProps) :
+    (
       <Button
-        buttonRef={this.triggerRef}
+        buttonRef={triggerRef}
         buttonStyle="none"
-        onClick={this.toggleMenu}
+        onClick={toggleMenu}
         {...buttonProps}
         {...ariaProps}
       >
         {label}
       </Button>
     );
-  }
 
-  render() {
-    const { children, portal } = this.props;
-    const portalEl = document.getElementById('OverlayContainer');
-    return (
-      <React.Fragment>
-        {this.renderTrigger()}
-        <Popper
-          isOpen={this.state.open}
-          anchorRef={this.triggerRef}
-          portal={portal ? portalEl : null}
-        >
-          <RootCloseWrapper onRootClose={this.toggleMenu}>
-            {children}
-          </RootCloseWrapper>
-        </Popper>
-      </React.Fragment>
-    );
-  }
-}
+  const portalEl = document.getElementById('OverlayContainer');
+
+  return (
+    <React.Fragment>
+      {trigger}
+      <Popper
+        modifiers={{
+          flip: { boundariesElement: 'scrollParent', padding: 10 },
+          preventOverflow: { boundariesElement: 'scrollParent', padding: 10 }
+        }}
+        placement="bottom-start"
+        isOpen={open}
+        anchorRef={triggerRef}
+        portal={portal ? portalEl : null}
+      >
+        <RootCloseWrapper onRootClose={toggleMenu}>
+          {children}
+        </RootCloseWrapper>
+      </Popper>
+    </React.Fragment>
+  );
+};
+
+Popdown.propTypes = {
+  children: PropTypes.node,
+  buttonProps: PropTypes.object,
+  label: PropTypes.node,
+  renderTrigger: PropTypes.func,
+  portal: PropTypes.bool,
+};
 
 export default Popdown;

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/Popdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/Popdown.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,

--- a/src/components/ProxyGroup/ProxyEditList/ProxyEditList.js
+++ b/src/components/ProxyGroup/ProxyEditList/ProxyEditList.js
@@ -177,15 +177,17 @@ class ProxyEditList extends React.Component {
             <h3 className={css.label}>{label}</h3>
           </Col>
         </Row>
-        {items.length ?
-          items :
-          <p className={css.isEmptyMessage}>
-            <FormattedMessage
-              id="ui-users.noItemFound"
-              values={{ item: name }}
-            />
-          </p>
-        }
+        <Layout className="fullWidth" data-test={name}>
+          {items.length ?
+            items :
+            <p className={css.isEmptyMessage}>
+              <FormattedMessage
+                id="ui-users.noItemFound"
+                values={{ item: name }}
+              />
+            </p>
+          }
+        </Layout>
         <Row>
           <Col xs={4}>
             <Layout>

--- a/src/components/ProxyGroup/ProxyViewList/ProxyViewList.js
+++ b/src/components/ProxyGroup/ProxyViewList/ProxyViewList.js
@@ -14,7 +14,7 @@ const ProxyViewList = ({ records, name, label, itemComponent, stripes }) => {
   const noneFoundMsg = name === 'sponsors' ? noSponsorsFound : noProxiesFound;
 
   return (
-    <div className={css.list}>
+    <div className={css.list} data-test={name}>
       <Headline tag="h4" size="small" margin="small">{label}</Headline>
       {items.length ? items : <p className={css.isEmptyMessage}>{noneFoundMsg}</p>}
     </div>

--- a/src/components/Wrappers/withProxy.js
+++ b/src/components/Wrappers/withProxy.js
@@ -186,14 +186,12 @@ const withProxy = WrappedComponent => class WithProxyComponent extends React.Com
     }
 
     updateProxies(proxies) {
-      const userId = this.props.match.params.id;
       const curProxies = this.getProxies();
 
       this.update('proxies', proxies, curProxies);
     }
 
     updateSponsors(sponsors) {
-      const userId = this.props.match.params.id;
       const curSponsors = this.getSponsors();
 
       this.update('sponsors', sponsors, curSponsors);

--- a/src/components/Wrappers/withProxy.js
+++ b/src/components/Wrappers/withProxy.js
@@ -115,7 +115,6 @@ const withProxy = WrappedComponent => class WithProxyComponent extends React.Com
         return;
       }
 
-      console.log('proxy load called');
       this.loadSponsors(userId);
       this.loadProxies(userId);
     }

--- a/src/components/Wrappers/withProxy.js
+++ b/src/components/Wrappers/withProxy.js
@@ -95,14 +95,9 @@ const withProxy = WrappedComponent => class WithProxyComponent extends React.Com
       return null;
     }
 
-    componentDidMount() {
-      const { match: { params: { id } } } = this.props;
-      this.load(id);
-    }
-
     componentDidUpdate(prevProps, prevState) {
       const { userId } = this.state;
-      if (userId && userId !== prevState.userId) {
+      if (prevState.userId && userId && userId !== prevState.userId) {
         this.load(userId);
       }
     }
@@ -120,6 +115,7 @@ const withProxy = WrappedComponent => class WithProxyComponent extends React.Com
         return;
       }
 
+      console.log('proxy load called');
       this.loadSponsors(userId);
       this.loadProxies(userId);
     }

--- a/src/routes/ChargeFeesFinesContainer.js
+++ b/src/routes/ChargeFeesFinesContainer.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
-import queryString from 'query-string';
 
 import {
   stripesConnect,

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -399,7 +399,7 @@ class UserForm extends React.Component {
                   {initialValues.id &&
                     <div>
                       <EditProxy
-                        accordionId="proxy"
+                        accordionId="proxyAccordion"
                         expanded={sections.proxy}
                         onToggle={this.handleSectionToggle}
                         sponsors={initialValues.sponsors}

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -71,7 +71,7 @@ function validate(values, props) {
     });
   }
 
-  if (values.servicePoints && values.preferredServicePoint === undefined) {
+  if (values.servicePoints && values.servicePoints.length > 0 && values.preferredServicePoint === undefined) {
     errors.preferredServicePoint = <FormattedMessage id="ui-users.errors.missingRequiredPreferredServicePoint" />;
   }
 
@@ -147,15 +147,15 @@ class UserForm extends React.Component {
     invalid: false,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       sections: {
         editUserInfo: true,
         extendedInfo: true,
         contactInfo: true,
-        proxy: false,
+        proxyAccordion: false,
         permissions: false,
         servicePoints: false,
       },

--- a/test/bigtest/interactors/user-form-page.js
+++ b/test/bigtest/interactors/user-form-page.js
@@ -1,6 +1,7 @@
 import {
   interactor,
   clickable,
+  count,
   text,
   fillable,
   blurrable,
@@ -11,6 +12,7 @@ import {
 
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor'; // eslint-disable-line
 import PermissionsModal from './permissions-modal';
+import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.css';
 
 @interactor class InputFieldInteractor {
   clickInput = clickable();
@@ -33,6 +35,13 @@ import PermissionsModal from './permissions-modal';
   }
 }
 
+@interactor class ProxyEditInteractor {
+  findProxyButton = clickable('#clickable-plugin-find-proxy');
+  findSponsorButton = clickable('#clickable-plugin-find-sponsor');
+  proxyCount = count(`[data-test="proxies"] .${proxyEditItemCSS.item}`);
+  sponsorCount = count(`[data-test="sponsors"] .${proxyEditItemCSS.item}`);
+}
+
 @interactor class UserFormPage {
   // isLoaded = isPresent('[class*=paneTitleLabel---]');
 
@@ -50,6 +59,7 @@ import PermissionsModal from './permissions-modal';
   addPermissionButton = scoped('#clickable-add-permission');
   permissionsModal = new PermissionsModal();
   permissions = collection('[data-permission-name]');
+  proxySection = scoped('#proxyAccordion', ProxyEditInteractor);
 }
 
 export default new UserFormPage('[data-test-form-page]');

--- a/test/bigtest/interactors/user-view-page.js
+++ b/test/bigtest/interactors/user-view-page.js
@@ -3,7 +3,11 @@ import {
   clickable,
   text,
   isPresent,
+  scoped,
+  count,
 } from '@bigtest/interactor';
+
+import proxyItemCSS from '../../../src/components/ProxyGroup/ProxyItem/ProxyItem.css';
 
 @interactor class HeaderDropdown {
   click = clickable('button');
@@ -13,15 +17,20 @@ import {
   clickEdit = clickable('[data-test-user-instance-edit-action]');
 }
 
+@interactor class ProxySectionInteractor {
+  proxyCount = count(`[data-test="proxies"] .${proxyItemCSS.item}`);
+  sponsorCount = count(`[data-test="sponsors"] .${proxyItemCSS.item}`);
+}
+
 @interactor class InstanceViewPage {
   title = text('[data-test-header-title]');
   headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   headerDropdownMenu = new HeaderDropdownMenu();
   editButtonPresent = isPresent('#clickable-edituser');
   clickEditButton = clickable('#clickable-edituser');
-
+  proxySection = scoped('#proxySection', ProxySectionInteractor);
   whenLoaded() {
-    return this.when(() => this.isPresent).timeout(4000);
+    return this.when(() => this.isPresent).timeout(5000);
   }
 }
 

--- a/test/bigtest/network/factories/loan.js
+++ b/test/bigtest/network/factories/loan.js
@@ -30,9 +30,9 @@ export default Factory.extend({
   }),
 
   metadata: {
-    createdDate: faker.date.past(0.1, faker.date.past(0.1)).toString(),
-    createdByUserId: faker.random.uuid(),
-    updatedDate: faker.date.past(0.1).toString(),
+    createdDate: () => faker.date.past(0.1, faker.date.past(0.1)).toString(),
+    createdByUserId: () => faker.random.uuid(),
+    updatedDate: () => faker.date.past(0.1).toString(),
     // updatedByUserId: faker.random.uuid(),
   },
   afterCreate(loan, server) {

--- a/test/bigtest/network/factories/proxiesfor.js
+++ b/test/bigtest/network/factories/proxiesfor.js
@@ -1,0 +1,22 @@
+import {
+  Factory,
+  faker,
+} from '@bigtest/mirage';
+
+export default Factory.extend({
+  id: () => faker.random.uuid(),
+  userId: () => faker.random.uuid(),
+  proxyUserId: () => faker.random.uuid(),
+  createdDate: () => faker.date.past(0.1).toString(), // deprecated
+  requestForSponsor: faker.random.arrayElement(['yes', 'no']),
+  notificationsTo: () => faker.random.uuid(),
+  accrueTo: () => faker.random.uuid(),
+  status: () => faker.random.arrayElement(['Active', 'Inactive']),
+  expirationDate: () => faker.date.future(0.1).toString(),
+  metadata: {
+    createdDate: () => faker.date.past(0.1, faker.date.past(0.1)).toString(),
+    createdByUserId: () => faker.random.uuid(),
+    updatedDate: () => faker.date.past(0.1).toString(),
+    updatedByUserId: () => faker.random.uuid(),
+  }
+});

--- a/test/bigtest/network/models/proxiesfor.js
+++ b/test/bigtest/network/models/proxiesfor.js
@@ -1,0 +1,3 @@
+import { Model } from '@bigtest/mirage';
+
+export default Model.extend({});

--- a/test/bigtest/network/scenarios/user-proxy-edit.js
+++ b/test/bigtest/network/scenarios/user-proxy-edit.js
@@ -1,0 +1,72 @@
+import CQLParser from '../cql';
+/* istanbul ignore file */
+
+export default (server) => {
+  server.logging = true;
+  server.create('user', { active: true, id: 'test-user-proxy-unique-id' });
+  server.create('user', { active: true, barcode: 'sponsor' });
+  server.create('user', { active: true, barcode: 'proxy' });
+
+  server.get('/users', ({ users }, request) => {
+    if (request.queryParams.query) {
+      const cqlParser = new CQLParser();
+      // get the CQL query param from 'query=' until the amphersand or end of the string
+      let query = /query=(\(.*\)|%28.*%29)/.exec(request.url)[1];
+      if (/^%28/.test(query)) {
+        query = decodeURIComponent(query);
+      }
+      cqlParser.parse(query);
+
+      const {
+        tree: {
+          lval,
+        }
+      } = cqlParser;
+
+      if (lval === 'sponsor*') {
+        return users.where({ barcode: 'sponsor' });
+      }
+      if (lval === 'proxy*') {
+        return users.where({ barcode: 'proxy' });
+      }
+    }
+
+    return users.all();
+  });
+
+  server.get('/users/:id', (schema, request) => {
+    return schema.users.find(request.params.id).attrs;
+  });
+
+  server.put('/users/:id', (schema, request) => {
+    return schema.users.find(request.params.id).attrs;
+  });
+
+  server.get('/proxiesfor', ({ proxiesfors }, request) => {
+    if (request.queryParams.query) {
+      const cqlParser = new CQLParser();
+      // get the CQL query param from 'query=' until the amphersand or end of the string
+      let query = /query=(\(.*\)|%28.*%29)/.exec(request.url)[1];
+      if (/^%28/.test(query)) {
+        query = decodeURIComponent(query);
+      }
+      cqlParser.parse(query);
+
+      const {
+        tree: {
+          field,
+          term,
+        }
+      } = cqlParser;
+
+      return proxiesfors.where({ [field]: term });
+    }
+
+    return proxiesfors.all();
+  });
+
+  server.post('/proxiesfor', (schema, { requestBody }) => {
+    const proxyFor = JSON.parse(requestBody);
+    return server.create('proxiesfor', proxyFor);
+  });
+};

--- a/test/bigtest/network/serializers/proxiesfor.js
+++ b/test/bigtest/network/serializers/proxiesfor.js
@@ -1,0 +1,16 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  serialize(...args) {
+    const json = ApplicationSerializer.prototype.serialize.apply(this, args);
+
+    if (args[1].method === 'POST') {
+      return json.proxiesfor;
+    }
+
+    json.totalRecords = json.proxiesfors.length;
+    json.proxiesFor = json.proxiesfors;
+    delete json.proxiesfors;
+    return json;
+  }
+});

--- a/test/bigtest/tests/user-proxy-edit-test.js
+++ b/test/bigtest/tests/user-proxy-edit-test.js
@@ -1,0 +1,103 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import {
+  Interactor
+} from '@bigtest/interactor';
+import { expect } from 'chai';
+
+import findUser from '@folio/plugin-find-user';
+
+import setupApplication from '../helpers/setup-application';
+import UserFormPage from '../interactors/user-form-page';
+import InstanceViewPage from '../interactors/user-view-page';
+import UsersInteractor from '../interactors/users';
+import FindUserInteractor from '@folio/plugin-find-user/test/bigtest/interactors/findUser';
+
+describe.only('User Edit: Proxy/Sponsor', () => {
+  setupApplication({
+    scenarios: ['user-proxy-edit'],
+    modules: [{
+      type: 'plugin',
+      name: '@folio/ui-plugin-find-user',
+      pluginType: 'find-user',
+      displayName: 'ui-plugin-find-user.meta.title',
+      module: findUser,
+    }],
+    translations: {
+      'ui-plugin-find-user': 'ui-plugin-find-user'
+    },
+  });
+
+  const users = new UsersInteractor();
+  const findUserPlugin = new FindUserInteractor();
+
+  beforeEach(async function () {
+    this.visit('/users/preview/test-user-proxy-unique-id');
+    await InstanceViewPage.whenLoaded();
+  });
+
+  it('edit button is present', () => {
+    expect(InstanceViewPage.editButtonPresent).to.be.true;
+  });
+
+  describe('visiting the edit user page', () => {
+    beforeEach(async function () {
+      await InstanceViewPage.clickEditButton();
+      await UserFormPage.whenLoaded();
+    });
+
+    it('displays the title in the pane header', () => {
+      expect(UserFormPage.title).to.not.equal('loading');
+    });
+
+    describe('Edit sponsor', () => {
+      beforeEach(async () => {
+        await findUserPlugin.button.click();
+      });
+
+      it('should display the sponsor modal', () => {
+        expect(findUserPlugin.modal.isPresent).to.be.true;
+      });
+
+      describe('Edit sponsor', () => {
+        beforeEach(async () => {
+          await findUserPlugin.modal.searchField.fill('sponsor');
+          await findUserPlugin.modal.searchButton.click();
+          await findUserPlugin.modal.instances(1).click();
+        });
+
+        it('form should list a selected sponsor', () => {
+          expect(UserFormPage.proxySection.sponsorCount).to.equal(1);
+        });
+
+        describe('Saving a sponsor', () => {
+          beforeEach(async () => {
+            await UserFormPage.submitButton.click();
+            await InstanceViewPage.whenLoaded();
+          });
+
+          it('should navigate to the detail view', () => {
+            expect(users.$root).to.exist;
+          });
+
+          it.only('should display proxies in detail view', () => {
+            expect(InstanceViewPage.proxySection.sponsorCount).to.equal(1);
+          });
+        });
+      });
+    });
+
+    describe('pane header menu', () => {
+      beforeEach(async () => {
+        await UserFormPage.cancelButton.click();
+      });
+
+      it('should redirect to view users page after click', () => {
+        expect(users.$root).to.exist;
+      });
+    });
+  });
+});

--- a/test/bigtest/tests/user-proxy-edit-test.js
+++ b/test/bigtest/tests/user-proxy-edit-test.js
@@ -47,7 +47,7 @@ describe('User Edit: Proxy/Sponsor', () => {
     });
 
     it('displays the title in the pane header', () => {
-      expect(UserFormPage.title).to.not.equal('loading');
+      expect(UserFormPage.title).to.not.equal('Edit User');
     });
 
     describe('Edit sponsor', () => {
@@ -82,6 +82,17 @@ describe('User Edit: Proxy/Sponsor', () => {
 
           it('should display proxies in detail view', () => {
             expect(InstanceViewPage.proxySection.sponsorCount).to.equal(1);
+          });
+
+          describe('Back to edit view', () => {
+            beforeEach(async () => {
+              await InstanceViewPage.clickEditButton();
+              await UserFormPage.whenLoaded();
+            });
+
+            it('should navigate to the edit view', () => {
+              expect(UserFormPage.title).to.not.equal('Edit User');
+            });
           });
         });
       });

--- a/test/bigtest/tests/user-proxy-edit-test.js
+++ b/test/bigtest/tests/user-proxy-edit-test.js
@@ -3,20 +3,17 @@ import {
   describe,
   it,
 } from '@bigtest/mocha';
-import {
-  Interactor
-} from '@bigtest/interactor';
 import { expect } from 'chai';
 
 import findUser from '@folio/plugin-find-user';
+import FindUserInteractor from '@folio/plugin-find-user/test/bigtest/interactors/findUser';
 
 import setupApplication from '../helpers/setup-application';
 import UserFormPage from '../interactors/user-form-page';
 import InstanceViewPage from '../interactors/user-view-page';
 import UsersInteractor from '../interactors/users';
-import FindUserInteractor from '@folio/plugin-find-user/test/bigtest/interactors/findUser';
 
-describe.only('User Edit: Proxy/Sponsor', () => {
+describe('User Edit: Proxy/Sponsor', () => {
   setupApplication({
     scenarios: ['user-proxy-edit'],
     modules: [{
@@ -83,7 +80,7 @@ describe.only('User Edit: Proxy/Sponsor', () => {
             expect(users.$root).to.exist;
           });
 
-          it.only('should display proxies in detail view', () => {
+          it('should display proxies in detail view', () => {
             expect(InstanceViewPage.proxySection.sponsorCount).to.equal(1);
           });
         });


### PR DESCRIPTION
# Problem(s)
Proxy edit workflow wasn't really testable.
Adding a single sponsor caused multiple to show up when navigating back to the user detail page upon success.

# Approach
Added facilities to test proxy edit workflow.
Ended up removing the `componentDidMount` method of `withProxy` and adjusting its `cDU` method.

It's possible that loading proxies/sponsors was okay on mount, and the save process needs to be refactored so that we only get transferred to the page without, I believe, an updated resource in tow...

Curious to see if this passes CI tests also...