### PR TITLE
UIU-1177: Implement edit loan permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Implement view loans permission. Refs UIU-1175.
 * Refactor Routing. Switch to using SearchAndSortQuery. UIU-897
 * Resolve bug updating a user just after creation. Fixes UIU-1314.
+* Implement edit loan permission. Refs UIU-1177.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/package.json
+++ b/package.json
@@ -568,12 +568,15 @@
       {
         "permissionName": "ui-users.loans.edit",
         "displayName": "Users: User loan edit",
-        "description": "Also includes basic permissions to view loans",
+        "description": "Also includes basic permissions to view users",
         "subPermissions": [
           "ui-users.view",
-          "ui-users.loans.view"
+          "circulation.requests.collection.get",
+          "circulation.loans.item.put",
+          "circulation.renew-by-barcode.post",
+          "circulation-storage.loans.item.get"
         ],
-        "visible": false
+        "visible": true
       },
       {
         "permissionName": "ui-users.loans.all",

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -7,9 +7,7 @@ import {
   MenuItem,
   IconButton,
 } from '@folio/stripes/components';
-import {
-  stripesShape,
-} from '@folio/stripes/core';
+import { stripesShape } from '@folio/stripes/core';
 
 import Popdown from './Popdown';
 import css from './ActionsDropdown.css';
@@ -84,21 +82,24 @@ class ActionsDropdown extends React.Component {
               <FormattedMessage id="ui-users.renew" />
             </Button>
           </MenuItem>
-          <MenuItem
-            itemMeta={{
-              loan,
-              action: 'changeDueDate',
-            }}
-            onSelectItem={handleOptionsChange}
-          >
-            <Button
-              buttonStyle="dropdownItem"
-              onClick={(e) => { handleOptionsChange({ loan, action:'changeDueDate' }, e); }}
-              data-test-dropdown-content-change-due-date-button
+          {
+            stripes.hasPerm('ui-users.loans.edit') &&
+            <MenuItem
+              itemMeta={{
+                loan,
+                action: 'changeDueDate',
+              }}
+              onSelectItem={handleOptionsChange}
             >
-              <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
-            </Button>
-          </MenuItem>
+              <Button
+                buttonStyle="dropdownItem"
+                onClick={(e) => { handleOptionsChange({ loan, action:'changeDueDate' }, e); }}
+                data-test-dropdown-content-change-due-date-button
+              >
+                <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
+              </Button>
+            </MenuItem>
+          }
           <MenuItem
             itemMeta={{
               loan,

--- a/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
@@ -11,6 +11,7 @@ import {
   intlShape,
 } from 'react-intl';
 
+import { IfPermission } from '@folio/stripes/core';
 import {
   Button,
   Dropdown,
@@ -175,14 +176,16 @@ class OpenLoansSubHeader extends React.Component {
             >
               <FormattedMessage id="ui-users.renew" />
             </Button>
-            <Button
-              marginBottom0
-              id="change-due-date-all"
-              disabled={noSelectedLoans}
-              onClick={showChangeDueDateDialog}
-            >
-              <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
-            </Button>
+            <IfPermission perm="ui-users.loans.edit">
+              <Button
+                marginBottom0
+                id="change-due-date-all"
+                disabled={noSelectedLoans}
+                onClick={showChangeDueDateDialog}
+              >
+                <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
+              </Button>
+            </IfPermission>
             <ExportCsv
               data={recordsToCSV}
               onlyFields={this.columnHeadersMap}


### PR DESCRIPTION
## Purpose

Implement edit loan permission as part of [UIU-1177](https://issues.folio.org/browse/UIU-1177). This permission works in conjunction with permissions for viewing the loans.

## Screenshot

<img width="1103" alt="Screen Shot 2019-10-25 at 12 08 15 PM" src="https://user-images.githubusercontent.com/40821852/67558710-28fa0980-f720-11e9-92d7-99b3cbbca312.png">
