### PR TITLE
UIU-1297 provide 10k limit for overdue loans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.25.5 (IN PROGRESS)
+
+* Retrieve up to 10k loans in the overdue-loans report. Refs UIU-1297.
+
 ## [2.25.4](https://github.com/folio-org/ui-users/tree/v2.25.4) (2019-09-30)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.25.4)
 

--- a/src/Users.js
+++ b/src/Users.js
@@ -127,7 +127,7 @@ class Users extends React.Component {
     loans: {
       type: 'okapi',
       records: 'loans',
-      path: () => `circulation/loans?query=(status="Open" and dueDate < ${getLoansOverdueDate()})`,
+      path: () => `circulation/loans?query=(status="Open" and dueDate < ${getLoansOverdueDate()})&limit=10000`,
       permissionsRequired: 'circulation.loans.collection.get,accounts.collection.get',
     }
   });


### PR DESCRIPTION
Previously, there was no `limit` clause on the overdue loans report,
causing it to retrieve only the default row-count of 10. Sadly, there
are likely to be more than 10 overdue loans at any given time. Of
course, I have _never_ returned something past its due date, nor had my
borrowing privileges suspended at libraries in four different states I
don't know why you'd make that suggestion what kind of a person do you
think I am?

Now there's a limit clause of 10k.

Refs [UIU-1297](https://issues.folio.org/browse/UIU-1297)