### PR TITLE
UIU-1297: Retrieve up to max amount of overdue loans instead of 10 for CSV report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Refactor Routing. Switch to using SearchAndSortQuery. UIU-897
 * Resolve bug updating a user just after creation. Fixes UIU-1314.
 * Implement edit loan permission. Refs UIU-1177.
+* Retrieve up to max available amount of overdue loans instead of 10 for CSV report. Refs UIU-1297.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -17,6 +17,7 @@ import { UserSearch } from '../views';
 
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
+const MAX_LIMIT = 2147483647; // from https://s3.amazonaws.com/foliodocs/api/mod-circulation/p/circulation.html#circulation_loans_get
 
 const compileQuery = template(
   '(username="%{query}*" or personal.firstName="%{query}*" or personal.lastName="%{query}*" or personal.email="%{query}*" or barcode="%{query}*" or id="%{query}*" or externalSystemId="%{query}*")',
@@ -70,7 +71,7 @@ class UserSearchContainer extends React.Component {
       type: 'okapi',
       records: 'loans',
       accumulate: true,
-      path: () => `circulation/loans?query=(status="Open" and dueDate < ${getLoansOverdueDate()})`,
+      path: () => `circulation/loans?query=(status="Open" and dueDate < ${getLoansOverdueDate()})&limit=${MAX_LIMIT}`,
       permissionsRequired: 'circulation.loans.collection.get,accounts.collection.get',
     }
   });


### PR DESCRIPTION
## Purposes

Retrieve up to max amount (2147483647 according to the [doc](https://s3.amazonaws.com/foliodocs/api/mod-circulation/p/circulation.html#circulation_loans_get)) of overdue loans instead of 10 to add information about all records to the CSV report. The value 2147483647 was selected after discussion with PO and backend devs. Fix [UIU-1297 ](https://issues.folio.org/browse/UIU-1297)