### PR TITLE
UIU-1155: Add style improvements, replace current user service points with all

### DIFF
--- a/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.js
+++ b/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.js
@@ -5,7 +5,7 @@ import { get } from 'lodash';
 import { stripesConnect } from '@folio/stripes/core';
 import {
   Col,
-  KeyValue,
+  Label,
 } from '@folio/stripes/components';
 
 import CreatePasswordModal from './Modals/CreatePasswordModal';
@@ -124,23 +124,21 @@ class CreateResetPasswordControl extends React.Component {
       ? 'ui-users.extended.sendResetPassword'
       : 'ui-users.extended.sendCreatePassword';
 
-    const fieldLabel = <FormattedMessage id="ui-users.extended.folioPassword" />;
-    const contentText = <FormattedMessage id={linkTextKey} />;
-
     return (
       <Col
         xs={12}
         md={3}
       >
-        <KeyValue label={fieldLabel}>
-          <button
-            type="button"
-            className={css.resetPasswordButton}
-            onClick={this.handleLinkClick}
-          >
-            {contentText}
-          </button>
-        </KeyValue>
+        <Label tagName="div">
+          <FormattedMessage id="ui-users.extended.folioPassword" />
+        </Label>
+        <button
+          type="button"
+          className={css.resetPasswordButton}
+          onClick={this.handleLinkClick}
+        >
+          <FormattedMessage id={linkTextKey} />
+        </button>
         {isLocalPasswordSet
           ? this.resetPasswordModal()
           : this.createPasswordModal()

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -8,7 +8,7 @@ import {
   Row,
   Col,
   Accordion,
-  KeyValue,
+  Label,
   Datepicker,
   Headline
 } from '@folio/stripes/components';
@@ -105,9 +105,10 @@ class EditExtendedInfo extends Component {
             xs={12}
             md={3}
           >
-            <KeyValue label={<FormattedMessage id="ui-users.extended.folioNumber" />}>
-              {userId || '-'}
-            </KeyValue>
+            <Label tagName="div">
+              <FormattedMessage id="ui-users.extended.folioNumber" />
+            </Label>
+            <div>{userId || '-'}</div>
           </Col>
         </Row>
         <Row>

--- a/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/RequestPreferencesEdit.css
+++ b/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/RequestPreferencesEdit.css
@@ -1,3 +1,9 @@
+@import "@folio/stripes-components/lib/variables.css";
+
 .heading {
-  margin-bottom: 0.5em;
+  font-weight: var(--text-weight-bold);
+}
+
+.rowMargin {
+  margin-bottom: var(--gutter);
 }

--- a/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/RequestPreferencesEdit.js
+++ b/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/RequestPreferencesEdit.js
@@ -20,7 +20,9 @@ import {
   Col,
   Select,
   Checkbox,
+  Label,
 } from '@folio/stripes/components';
+
 import { deliveryFulfillmentValues } from '../../../../constants';
 import { addressTypesShape } from '../../../../shapes';
 import { nullOrStringIsRequiredTypeValidator } from '../../../../customTypeValidators';
@@ -85,7 +87,7 @@ class RequestPreferencesEdit extends Component {
     return (
       <Field
         name="requestPreferences.defaultServicePointId"
-        label={<FormattedMessage id="ui-users.requests.defaultServicePoint" />}
+        label={<FormattedMessage id="ui-users.requests.defaultPickupServicePoint" />}
         dataOptions={resultOptions}
         component={Select}
         parse={this.defaultServicePointFieldParser}
@@ -97,7 +99,7 @@ class RequestPreferencesEdit extends Component {
     return value === '' ? null : value;
   }
 
-  renderFulfilmentPreferenceSelect() {
+  renderFulfillmentPreferenceSelect() {
     const { intl } = this.props;
     const options = [
       {
@@ -168,12 +170,15 @@ class RequestPreferencesEdit extends Component {
           <Col
             xs={12}
             md={6}
-            className={styles.heading}
           >
-            <FormattedMessage id="ui-users.requests.preferences" />
+            <Label tagName="div">
+              <span className={styles.heading}>
+                <FormattedMessage id="ui-users.requests.preferences" />
+              </span>
+            </Label>
           </Col>
         </Row>
-        <Row className={styles.heading}>
+        <Row className={styles.rowMargin}>
           <Col xs={12} md={6}>
             <Field
               name="requestPreferences.holdShelf"
@@ -193,15 +198,15 @@ class RequestPreferencesEdit extends Component {
             />
           </Col>
         </Row>
-        <Row className={styles.heading}>
+        <Row>
           <Col xs={12} md={6}>
             {this.renderServicePointSelect()}
           </Col>
           <Col xs={12} md={6}>
-            { deliveryAvailable && this.renderFulfilmentPreferenceSelect() }
+            { deliveryAvailable && this.renderFulfillmentPreferenceSelect() }
           </Col>
         </Row>
-        <Row className={styles.heading}>
+        <Row>
           <Col mdOffset={6} xs={12} md={6}>
             { deliveryAvailable && this.renderDefaultDeliveryAddressSelect() }
           </Col>
@@ -217,7 +222,7 @@ const selectNonEmptyAddresses = fp.pipe([
   fp.filter(address => !isEmpty(address)),
 ]);
 const selectServicePointsWithPickupLocation = fp.pipe([
-  fp.getOr([], 'okapi.currentUser.servicePoints'),
+  fp.getOr([], 'folio_users_service_points.records'),
   fp.filter(servicePoint => servicePoint.pickupLocation),
   fp.sortBy('name'),
 ]);

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -99,6 +99,7 @@ class UserRecordContainer extends React.Component {
     },
     requestPreferences: {
       type: 'okapi',
+      throwErrors: false,
       GET: {
         path: 'request-preference-storage/request-preference',
         params: {

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -367,7 +367,7 @@
   "requests.numOpenRequests": "{count, number} {count, plural, one {open request} other {open requests}}",
   "requests.numClosedRequests": "{count, number} {count, plural, one {closed request} other {closed requests}}",
   "requests.preferences": "Request preferences",
-  "requests.defaultServicePoint": "Default service point",
+  "requests.defaultPickupServicePoint": "Default pickup service point",
   "requests.fulfillmentPreference": "Fulfillment preference",
   "requests.defaultDeliveryAddress": "Default delivery address",
   "requests.deliveryYes": "Delivery - Yes",


### PR DESCRIPTION
Improvements:
- Bold the Request preferences label
- Change the label from "Default service point" to "Default pickup service point"
- Unbold the FOLIO number label
- Unbold FOLIO password label
- Use all service points exсept of current user's
- Avoid raising of the permission errors during request preferences requests as permissions are out of scope