### PR TITLE
UIU-1176: Implement loans renew permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Resolve bug updating a user just after creation. Fixes UIU-1314.
 * Implement edit loan permission. Refs UIU-1177.
 * Retrieve up to max available amount of overdue loans instead of 10 for CSV report. Refs UIU-1297.
+* Implement loans renew permission. Refs UIU-1176.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/package.json
+++ b/package.json
@@ -541,13 +541,10 @@
       },
       {
         "permissionName": "ui-users.loans.renew",
-        "displayName": "Loans: Renew loans",
-        "description": "Also includes basic permissions to view users",
+        "displayName": "Users: User loans renew",
+        "description": "Also includes backend permissions to perform loans renew",
         "subPermissions": [
-          "ui-users.view",
-          "circulation.loans.collection.get",
-          "circulation.loans.item.get",
-          "circulation.renew-by-id.post"
+          "circulation.renew-by-barcode.post"
         ],
         "visible": true
       },

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -67,21 +67,26 @@ class ActionsDropdown extends React.Component {
               </Button>
             </MenuItem>
           }
-          <MenuItem
-            itemMeta={{
-              loan,
-              action: 'renew',
-            }}
-            onSelectItem={handleOptionsChange}
-          >
-            <Button
-              buttonStyle="dropdownItem"
-              onClick={(e) => { handleOptionsChange({ loan, action:'renew' }, e); }}
-              data-test-dropdown-content-renew-button
+          {
+            stripes.hasPerm('ui-users.loans.renew') &&
+            <MenuItem
+              itemMeta={{
+                loan,
+                action: 'renew',
+              }}
+              onSelectItem={handleOptionsChange}
             >
-              <FormattedMessage id="ui-users.renew" />
-            </Button>
-          </MenuItem>
+              <Button
+                buttonStyle="dropdownItem"
+                data-test-dropdown-content-renew-button
+                onClick={(e) => {
+                  handleOptionsChange({ loan, action: 'renew' }, e);
+                }}
+              >
+                <FormattedMessage id="ui-users.renew" />
+              </Button>
+            </MenuItem>
+          }
           {
             stripes.hasPerm('ui-users.loans.edit') &&
             <MenuItem

--- a/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  size,
   cloneDeep,
+  isEmpty,
 } from 'lodash';
 
 import {
@@ -120,7 +120,7 @@ class OpenLoansSubHeader extends React.Component {
       toggleDropdownState,
     } = this.state;
 
-    const noSelectedLoans = size(checkedLoans) === 0;
+    const noSelectedLoans = isEmpty(checkedLoans);
     const resultCount = <FormattedMessage id="ui-users.resultCount" values={{ count: loans.length }} />;
     const clonedLoans = cloneDeep(loans);
     const recordsToCSV = buildRecords(clonedLoans);
@@ -165,17 +165,19 @@ class OpenLoansSubHeader extends React.Component {
         }
         contentEnd={
           <span>
-            <Button
-              marginBottom0
-              id="renew-all"
-              disabled={noSelectedLoans}
-              onClick={countRenews.length > 0
-                ? openPatronBlockedModal
-                : renewSelected
-              }
-            >
-              <FormattedMessage id="ui-users.renew" />
-            </Button>
+            <IfPermission perm="ui-users.loans.renew">
+              <Button
+                marginBottom0
+                id="renew-all"
+                disabled={noSelectedLoans}
+                onClick={!isEmpty(countRenews)
+                  ? openPatronBlockedModal
+                  : renewSelected
+                }
+              >
+                <FormattedMessage id="ui-users.renew" />
+              </Button>
+            </IfPermission>
             <IfPermission perm="ui-users.loans.edit">
               <Button
                 marginBottom0


### PR DESCRIPTION
## Purpose

Implement loans renew permission as part of [UIU-1176](https://issues.folio.org/browse/UIU-1176). This permission works in conjunction with permissions for viewing the loans.

## Screenshot

<img width="1091" alt="Screen Shot 2019-10-31 at 13 20 32" src="https://user-images.githubusercontent.com/40821852/67942764-411ace80-fbe1-11e9-9820-2434f2adb386.png">

