### PR TITLE
UIU-1292: Retrieve up to 100k of requested user loans instead of 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 2.26.0 (IN PROGRESS)
 * Prevent manual anonymization of closed loans with fees/fines. Refs UIU-1083.
 * Update sponsor and proxy labels. Refs UIU-1018.
-
 * Implement permission assigment by batch. Refs UIU-1249
 * Fix the mechanism for the accumulation of overdue loans in CSV report. Refs UIU-1286.
 * Implement view loans permission. Refs UIU-1175.
@@ -12,6 +11,7 @@
 * Implement edit loan permission. Refs UIU-1177.
 * Retrieve up to max available amount of overdue loans instead of 10 for CSV report. Refs UIU-1297.
 * Implement loans renew permission. Refs UIU-1176.
+* Retrieve up to 100k of requested user loans instead of 100. Refs UIU-1292.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/src/routes/LoansListingContainer.js
+++ b/src/routes/LoansListingContainer.js
@@ -28,7 +28,7 @@ class LoansListingContainer extends React.Component {
     loansHistory: {
       type: 'okapi',
       records: 'loans',
-      path: 'circulation/loans?query=(userId=:{id}) sortby id&limit=100',
+      path: 'circulation/loans?query=(userId=:{id}) sortby id&limit=100000',
       permissionsRequired: 'circulation.loans.collection.get',
     },
     loanPolicies: {


### PR DESCRIPTION
## Purposes 

Retrieve up to 100k of requested user loans instead of 100 to fix the [issue](https://issues.folio.org/browse/UIU-1292).

## Screenshots

![more_than_100_loans_display](https://user-images.githubusercontent.com/50317804/68112648-73d30880-fefa-11e9-90c6-3b11f6de06ea.png)

