### PR TITLE
UIU-1252 - Edit User Record : Using Enter key should Save or Cancel changes IF in focus

### DIFF
--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep';
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
 import { AppIcon } from '@folio/stripes/core';
 import {
@@ -165,15 +165,9 @@ class UserForm extends React.Component {
       },
     };
 
-    this.handleExpandAll = this.handleExpandAll.bind(this);
-    this.handleSectionToggle = this.handleSectionToggle.bind(this);
-    this.toggleAllSections = this.toggleAllSections.bind(this);
-    this.collapseAllSections = this.collapseAllSections.bind(this);
-    this.expandAllSections = this.expandAllSections.bind(this);
-
-    this.ignoreEnterKey = this.ignoreEnterKey.bind(this);
     this.closeButton = React.createRef();
     this.saveButton = React.createRef();
+    this.cancelButton = React.createRef();
 
     this.keyboardCommands = [
       {
@@ -223,18 +217,23 @@ class UserForm extends React.Component {
     );
   }
 
-  handleExpandAll(sections) {
+  handleExpandAll = (sections) => {
     this.setState({ sections });
   }
 
-  // eslint-disable-next-line class-methods-use-this
   ignoreEnterKey = (e) => {
-    if (e.target !== this.saveButton.current) {
+    const allowedControls = [
+      this.closeButton.current,
+      this.saveButton.current,
+      this.cancelButton.current,
+    ];
+
+    if (!allowedControls.includes(e.target)) {
       e.preventDefault();
     }
   };
 
-  handleSectionToggle({ id }) {
+  handleSectionToggle = ({ id }) => {
     this.setState((curState) => {
       const newState = cloneDeep(curState);
       newState.sections[id] = !newState.sections[id];
@@ -243,7 +242,7 @@ class UserForm extends React.Component {
     });
   }
 
-  toggleAllSections(expand) {
+  toggleAllSections = (expand) => {
     this.setState((curState) => {
       const newSections = expandAllFunction(curState.sections, expand);
 
@@ -253,12 +252,12 @@ class UserForm extends React.Component {
     });
   }
 
-  expandAllSections(e) {
+  expandAllSections = (e) => {
     e.preventDefault();
     this.toggleAllSections(true);
   }
 
-  collapseAllSections(e) {
+  collapseAllSections = (e) => {
     e.preventDefault();
     this.toggleAllSections(false);
   }
@@ -295,6 +294,7 @@ class UserForm extends React.Component {
         marginBottom0
         id="clickable-cancel"
         buttonStyle="default mega"
+        buttonRef={this.cancelButton}
         onClick={onCancel}
       >
         <FormattedMessage id="ui-users.cancel" />


### PR DESCRIPTION
# Purpose
Allow to the user cancel form editing by click on the enter key when cancel button is focused.

# Link
https://issues.folio.org/browse/UIU-1252

# Approach
Currently User form wrapped in HasCommand component and one of its command is used to deny handle enter click everywhere except save button. In order to save such behavior I've created list of allowed controls that can use this key in order to save or cancel form editing.