### PR TITLE
UIU-1184: Implement loans renew through override permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Retrieve up to max available amount of overdue loans instead of 10 for CSV report. Refs UIU-1297.
 * Implement loans renew permission. Refs UIU-1176.
 * Retrieve up to 100k of requested user loans instead of 100. Refs UIU-1292.
+* Implement loans renew through override permission. Refs UIU-1184.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/package.json
+++ b/package.json
@@ -549,6 +549,15 @@
         "visible": true
       },
       {
+        "permissionName": "ui-users.loans.renew-override",
+        "displayName": "Users: User loans renew through override",
+        "description": "Also includes backend permissions to perform loans renew through override",
+        "subPermissions": [
+          "circulation.override-renewal-by-barcode.post"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-users.loans.view",
         "displayName": "Users: User loans view",
         "description": "Also includes basic permissions to view users",

--- a/src/components/BulkOverrideDialog/BulkOverrideInfo.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideInfo.js
@@ -36,7 +36,7 @@ class BulkOverrideInfo extends React.Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
     mutator: PropTypes.shape({
-      override: PropTypes.shape({
+      renew: PropTypes.shape({
         POST: PropTypes.func.isRequired,
       }).isRequired,
     }).isRequired,

--- a/src/components/BulkRenewalDialog/BulkRenewInfo.js
+++ b/src/components/BulkRenewalDialog/BulkRenewInfo.js
@@ -9,7 +9,10 @@ import {
   Layout,
 } from '@folio/stripes/components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { stripesShape } from '@folio/stripes/core';
+import {
+  stripesShape,
+  IfPermission,
+} from '@folio/stripes/core';
 
 import BulkOverrideDialog from '../BulkOverrideDialog';
 import BulkRenewedLoansList from './BulkRenewedLoansList';
@@ -137,15 +140,17 @@ class BulkRenewInfo extends React.Component {
             errorMessages={errorMessages}
           />
           <Layout className="textRight">
-            {
-              !isEmpty(overridableLoans) &&
-              <Button
-                data-test-override-button
-                onClick={this.openBulkOverrideDialog}
-              >
-                <FormattedMessage id="ui-users.button.override" />
-              </Button>
-            }
+            <IfPermission perm="ui-users.loans.renew-override">
+              {
+                !isEmpty(overridableLoans) &&
+                <Button
+                  data-test-override-button
+                  onClick={this.openBulkOverrideDialog}
+                >
+                  <FormattedMessage id="ui-users.button.override" />
+                </Button>
+              }
+            </IfPermission>
             <Button
               buttonStyle="primary"
               onClick={onCancel}

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -57,7 +57,7 @@ class LoanDetails extends React.Component {
     patronGroup: PropTypes.object,
     user: PropTypes.object,
     loanActionsWithUser: PropTypes.arrayOf(PropTypes.object),
-    loanPolicies: PropTypes.arrayOf(PropTypes.object),
+    loanPolicies: PropTypes.object,
     requestCounts: PropTypes.object,
     renew: PropTypes.func,
     patronBlocks: PropTypes.arrayOf(PropTypes.object),


### PR DESCRIPTION
## Purpose

Implement loans renew through override permission as part of [UIU-1184](https://issues.folio.org/browse/UIU-1184). This permission works in conjunction with permissions for viewing the loans and loans renew.

## Screenshot

<img width="1091" alt="Screenshot" src="https://user-images.githubusercontent.com/40821852/68293591-eed12600-0096-11ea-8d97-1ff0640a9e64.png">

