### PR TITLE
Remove sort logic duplications

### DIFF
--- a/src/components/Accounts/Actions/WarningModal.js
+++ b/src/components/Accounts/Actions/WarningModal.js
@@ -20,6 +20,8 @@ import {
   orderBy,
 } from 'lodash';
 
+import { calculateSortParams } from '../../util';
+
 class WarningModal extends React.Component {
   static propTypes = {
     accounts: PropTypes.arrayOf(PropTypes.object),
@@ -86,17 +88,18 @@ class WarningModal extends React.Component {
 
   onSort = (e, meta) => {
     if (!this.sortMap[meta.alias]) return;
-    let { sortOrder, sortDirection } = this.state;
 
-    if (sortOrder[0] !== meta.alias) {
-      sortOrder = [meta.alias, sortOrder[1]];
-      sortDirection = ['asc', sortDirection[1]];
-    } else {
-      const direction = (sortDirection[0] === 'desc') ? 'asc' : 'desc';
-      sortDirection = [direction, sortDirection[1]];
-    }
-    this.setState({ sortOrder, sortDirection });
-  }
+    const {
+      sortOrder,
+      sortDirection,
+    } = this.state;
+
+    this.setState(calculateSortParams({
+      sortOrder,
+      sortDirection,
+      sortValue: meta.alias,
+    }));
+  };
 
   getAccountsFormatter() {
     const { checkedAccounts } = this.state;

--- a/src/components/Accounts/Actions/WarningModal.js
+++ b/src/components/Accounts/Actions/WarningModal.js
@@ -121,7 +121,8 @@ class WarningModal extends React.Component {
 
   onClickContinue() {
     const { checkedAccounts } = this.state;
-    const values = Object.values(checkedAccounts) || [];
+    const values = Object.values(checkedAccounts);
+
     this.props.onChangeAccounts(values);
   }
 
@@ -171,8 +172,9 @@ class WarningModal extends React.Component {
       'Item': formatMessage({ id: 'ui-users.accounts.actions.warning.item' }),
     };
 
-    const values = Object.values(checkedAccounts) || [];
-    const checkedClosed = values.filter(a => a.status.name === 'Closed') || [];
+    const values = Object.values(checkedAccounts);
+    const checkedClosed = values.filter(a => a.status.name === 'Closed');
+
     return (
       <Modal
         id="warning-modal"

--- a/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
+++ b/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
@@ -19,7 +19,10 @@ import {
   FormattedDate,
 } from 'react-intl';
 
-import { nav } from '../../util';
+import {
+  calculateSortParams,
+  nav,
+} from '../../util';
 
 class ViewFeesFines extends React.Component {
   static propTypes = {
@@ -125,16 +128,18 @@ class ViewFeesFines extends React.Component {
   onSort(e, meta) {
     if (!this.sortMap[meta.name]) return;
 
-    let { sortOrder, sortDirection } = this.state;
+    const {
+      sortOrder,
+      sortDirection,
+    } = this.state;
 
-    if (sortOrder[0] !== meta.name) {
-      sortOrder = [meta.name, sortOrder[1]];
-      sortDirection = ['asc', sortDirection[1]];
-    } else {
-      const direction = (sortDirection[0] === 'desc') ? 'asc' : 'desc';
-      sortDirection = [direction, sortDirection[1]];
-    }
-    this.setState({ sortOrder, sortDirection });
+    this.setState(calculateSortParams({
+      sortOrder,
+      sortDirection,
+      sortValue: meta.name,
+      secondarySortOrderIndex: 1,
+      secondarySortDirectionIndex: 1,
+    }));
   }
 
   comments(f) {

--- a/src/components/Loans/ClosedLoans/ClosedLoans.js
+++ b/src/components/Loans/ClosedLoans/ClosedLoans.js
@@ -24,7 +24,10 @@ import {
   stripesShape,
 } from '@folio/stripes/core';
 
-import { nav } from '../../util';
+import {
+  calculateSortParams,
+  nav,
+} from '../../util';
 import ActionsBar from '../components/ActionsBar';
 import Label from '../../Label';
 import ErrorModal from '../../ErrorModal';
@@ -124,16 +127,16 @@ class ClosedLoans extends React.Component {
   onSort(e, meta) {
     if (!this.sortMap[meta.alias]) return;
 
-    let { sortOrder, sortDirection } = this.state;
+    const {
+      sortOrder,
+      sortDirection,
+    } = this.state;
 
-    if (sortOrder[0] !== meta.alias) {
-      sortOrder = [meta.alias, sortOrder[0]];
-      sortDirection = ['asc', sortDirection[0]];
-    } else {
-      const direction = (sortDirection[0] === 'desc') ? 'asc' : 'desc';
-      sortDirection = [direction, sortDirection[1]];
-    }
-    this.setState({ sortOrder, sortDirection });
+    this.setState(calculateSortParams({
+      sortOrder,
+      sortDirection,
+      sortValue: meta.alias
+    }));
   }
 
   onRowClick = (e, row) => {

--- a/src/components/Loans/ClosedLoans/ClosedLoans.js
+++ b/src/components/Loans/ClosedLoans/ClosedLoans.js
@@ -135,7 +135,7 @@ class ClosedLoans extends React.Component {
     this.setState(calculateSortParams({
       sortOrder,
       sortDirection,
-      sortValue: meta.alias
+      sortValue: meta.alias,
     }));
   }
 

--- a/src/components/Loans/OpenLoans/OpenLoans.js
+++ b/src/components/Loans/OpenLoans/OpenLoans.js
@@ -7,7 +7,10 @@ import { stripesShape } from '@folio/stripes/core';
 
 import css from './OpenLoans.css';
 
-import { nav } from '../../util';
+import {
+  calculateSortParams,
+  nav,
+} from '../../util';
 
 class OpenLoans extends React.Component {
   static propTypes = {
@@ -61,28 +64,16 @@ class OpenLoans extends React.Component {
 
     if (!sortMap[meta.alias]) return;
 
-    let {
+    const {
       sortOrder,
       sortDirection,
     } = this.state;
 
-    if (sortOrder[0] !== meta.alias) {
-      sortOrder = [meta.alias, sortOrder[0]];
-      sortDirection = ['asc', sortDirection[0]];
-    } else {
-      const direction = (sortDirection[0] === 'desc')
-        ? 'asc'
-        : 'desc';
-
-      sortDirection = [direction, sortDirection[1]];
-    }
-
-    this.setState(
-      {
-        sortOrder,
-        sortDirection,
-      }
-    );
+    this.setState(calculateSortParams({
+      sortOrder,
+      sortDirection,
+      sortValue: meta.alias,
+    }));
   };
 
   onRowClick = (e, row) => {

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.js
@@ -6,6 +6,8 @@ import {
   injectIntl,
   intlShape,
 } from 'react-intl';
+import moment from 'moment';
+
 import {
   Row,
   Col,
@@ -17,7 +19,8 @@ import {
 } from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
 
-import moment from 'moment';
+
+import { calculateSortParams } from '../../util';
 
 class PatronBlock extends React.Component {
   static manifest = Object.freeze({
@@ -116,16 +119,18 @@ class PatronBlock extends React.Component {
   onSort(e, meta) {
     if (!this.sortMap[meta.alias]) return;
 
-    let { sortOrder, sortDirection } = this.state;
+    const {
+      sortOrder,
+      sortDirection,
+    } = this.state;
 
-    if (sortOrder[0] !== meta.alias) {
-      sortOrder = [meta.alias, sortOrder[1]];
-      sortDirection = ['asc', sortDirection[1]];
-    } else {
-      const direction = (sortDirection[0] === 'desc') ? 'asc' : 'desc';
-      sortDirection = [direction, sortDirection[1]];
-    }
-    this.setState({ sortOrder, sortDirection });
+    this.setState(calculateSortParams({
+      sortOrder,
+      sortDirection,
+      sortValue: meta.alias,
+      secondarySortOrderIndex: 1,
+      secondarySortDirectionIndex: 1,
+    }));
   }
 
   onRowClick(e, row) {

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -2,7 +2,10 @@ import _ from 'lodash';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { requestStatuses } from '../../constants';
+import {
+  requestStatuses,
+  sortTypes,
+} from '../../constants';
 
 export function getFullName(user) {
   const lastName = _.get(user, 'personal.lastName', '');
@@ -91,4 +94,25 @@ export function getOpenRequestsPath(barcode) {
   const filterString = getOpenRequestStatusesFilterString();
 
   return `/requests?filters=${filterString}&query=${barcode}&sort=Request Date`;
+}
+
+export function calculateSortParams({
+  sortOrder,
+  sortValue,
+  sortDirection,
+  secondarySortOrderIndex = 0,
+  secondarySortDirectionIndex = 0,
+}) {
+  const sortParams = {};
+
+  if (sortOrder[0] !== sortValue) {
+    sortParams.sortOrder = [sortValue, sortOrder[secondarySortOrderIndex]];
+    sortParams.sortDirection = [sortTypes.ASC, sortDirection[secondarySortDirectionIndex]];
+  } else {
+    const direction = sortDirection[0] === sortTypes.DESC ? sortTypes.ASC : sortTypes.DESC;
+
+    sortParams.sortDirection = [direction, sortDirection[1]];
+  }
+
+  return sortParams;
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,3 +13,8 @@ export const deliveryFulfillmentValues = {
   HOLD_SHELF: 'Hold Shelf',
   DELIVERY: 'Delivery',
 };
+
+export const sortTypes = {
+  ASC: 'asc',
+  DESC: 'desc',
+};

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -18,7 +18,11 @@ import {
 } from '@folio/stripes/components';
 
 import { Actions } from '../../components/Accounts/Actions';
-import { getFullName, nav } from '../../components/util';
+import {
+  getFullName,
+  calculateSortParams,
+  nav,
+} from '../../components/util';
 
 import css from './AccountDetails.css';
 
@@ -162,16 +166,18 @@ class AccountDetails extends React.Component {
   onSort(e, meta) {
     if (!this.sortMap[meta.name] || e.target.type === 'button' || e.target.id === 'button') return;
 
-    let { sortOrder, sortDirection } = this.state;
+    const {
+      sortOrder,
+      sortDirection,
+    } = this.state;
 
-    if (sortOrder[0] !== meta.name) {
-      sortOrder = [meta.name, sortOrder[1]];
-      sortDirection = ['asc', sortDirection[1]];
-    } else {
-      const direction = (sortDirection[0] === 'desc') ? 'asc' : 'desc';
-      sortDirection = [direction, sortDirection[1]];
-    }
-    this.setState({ sortOrder, sortDirection });
+    this.setState(calculateSortParams({
+      sortOrder,
+      sortDirection,
+      sortValue: meta.name,
+      secondarySortOrderIndex: 1,
+      secondarySortDirectionIndex: 1,
+    }));
   }
 
   render() {


### PR DESCRIPTION
## Purpose

1) Move the duplicated code for sorting lists to the reusable function. The further work on this might be creating HOC so the sorting function will exist in one place only and thus calls of sort function will not be duplicated.
2) Additionally, handle Sonar "Conditionally executed blocks should be reachable" in a couple of places.