### PR TITLE
UIU-1184: Show requests information when user has view loans permission only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Implement loans renew through override permission. Refs UIU-1184.
 * Add service points to user. Refs UIU-1334.
 * Warn, but do not invalidate, when a proxy relationship is expired for any reason. Refs UIU-820.
+* Show requests information when user has view loans permission only. Refs UIU-1184.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/package.json
+++ b/package.json
@@ -544,7 +544,8 @@
         "displayName": "Users: User loans renew",
         "description": "Also includes backend permissions to perform loans renew",
         "subPermissions": [
-          "circulation.renew-by-barcode.post"
+          "circulation.renew-by-barcode.post",
+          "inventory-storage.location-units.libraries.collection.get"
         ],
         "visible": true
       },
@@ -564,9 +565,10 @@
         "subPermissions": [
           "ui-users.view",
           "circulation.loans.collection.get",
+          "circulation.requests.collection.get",
           "circulation-storage.loan-policies.collection.get",
-          "accounts.collection.get",
           "circulation-storage.loans-history.collection.get",
+          "accounts.collection.get",
           "comments.collection.get"
         ],
         "visible": true
@@ -576,7 +578,6 @@
         "displayName": "Users: User loan edit",
         "description": "Also includes backend permissions to perform loan edit",
         "subPermissions": [
-          "circulation.requests.collection.get",
           "circulation.loans.item.put",
           "circulation.renew-by-barcode.post",
           "circulation-storage.loans.item.get"

--- a/src/components/Loans/OpenLoans/OpenLoans.js
+++ b/src/components/Loans/OpenLoans/OpenLoans.js
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { MultiColumnList } from '@folio/stripes/components';
-import { stripesShape } from '@folio/stripes/core';
 
 import css from './OpenLoans.css';
 
@@ -14,7 +13,6 @@ import {
 
 class OpenLoans extends React.Component {
   static propTypes = {
-    stripes: stripesShape.isRequired,
     history: PropTypes.object.isRequired,
     isLoanChecked: PropTypes.func.isRequired,
     match: PropTypes.object.isRequired,
@@ -88,7 +86,6 @@ class OpenLoans extends React.Component {
     const {
       visibleColumns,
       possibleColumns,
-      stripes,
     } = this.props;
 
     const visibleColumnsMap = visibleColumns.reduce((map, e) => {
@@ -97,15 +94,9 @@ class OpenLoans extends React.Component {
       return map;
     }, {});
 
-    let columnsToDisplay = possibleColumns.filter((e) => {
+    return possibleColumns.filter((e) => {
       return (visibleColumnsMap[e] === undefined || visibleColumnsMap[e] === true);
     });
-
-    if (!stripes.hasPerm(this.permissions.allRequests)) {
-      columnsToDisplay = columnsToDisplay.filter(col => col !== 'requests');
-    }
-
-    return columnsToDisplay;
   };
 
   rowUpdater = ({ id, itemId }) => {

--- a/src/components/Wrappers/withRenew.js
+++ b/src/components/Wrappers/withRenew.js
@@ -41,7 +41,6 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
   constructor(props) {
     super(props);
 
-    this.permissions = { allRequests: 'ui-users.requests.all' };
     this.connectedBulkRenewalDialog = props.stripes.connect(BulkRenewalDialog);
     this.state = {
       loans: [],
@@ -219,7 +218,6 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
    */
   getOpenRequestsCount = () => {
     const {
-      stripes,
       mutator: {
         requests: {
           reset,
@@ -229,10 +227,6 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
     } = this.props;
 
     const { loans } = this.state;
-
-    if (!stripes.hasPerm(this.permissions.allRequests)) {
-      return;
-    }
 
     // step through the loans list in small batches in order to create a
     // short-enough query string that we can avoid a "414 Request URI Too Long"

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -1,4 +1,3 @@
-import { get, upperFirst, isEmpty } from 'lodash';
 import React from 'react';
 import {
   FormattedMessage,
@@ -9,6 +8,12 @@ import {
 import { compose } from 'redux';
 import Link from 'react-router-dom/Link';
 import PropTypes from 'prop-types';
+import {
+  get,
+  upperFirst,
+  isEmpty,
+} from 'lodash';
+
 import { ChangeDueDateDialog } from '@folio/stripes/smart-components';
 import {
   Paneset,
@@ -22,6 +27,7 @@ import {
   Col,
 } from '@folio/stripes/components';
 import { IfPermission } from '@folio/stripes/core';
+
 import PatronBlockModal from '../../components/PatronBlock/PatronBlockModal';
 import {
   getFullName,
@@ -309,7 +315,7 @@ class LoanDetails extends React.Component {
     const contributorsLength = contributorsListString.length;
     const loanStatus = get(loan, ['status', 'name'], '-');
     const buttonDisabled = (loanStatus && loanStatus === 'Closed');
-    // Number of characters to trucate the string = 77
+    // Number of characters to truncate the string = 77
     const listTodisplay = (contributorsList === '-') ? '-' : (contributorsListString.length >= 77) ? `${contributorsListString.substring(0, 77)}...` : `${contributorsListString.substring(0, contributorsListString.length - 2)}`;
     const nonRenewedLabel = <FormattedMessage id="ui-users.loans.items.nonRenewed.label" />;
     const failedRenewalsSubHeading = (
@@ -458,17 +464,15 @@ class LoanDetails extends React.Component {
                   value={this.viewFeeFine()}
                 />
               </Col>
-              <IfPermission perm="ui-users.requests.all">
-                <Col
-                  data-test-loan-actions-history-requests
-                  xs={2}
-                >
-                  <KeyValue
-                    label={<FormattedMessage id="ui-users.loans.details.requestQueue" />}
-                    value={requestQueueValue}
-                  />
-                </Col>
-              </IfPermission>
+              <Col
+                data-test-loan-actions-history-requests
+                xs={2}
+              >
+                <KeyValue
+                  label={<FormattedMessage id="ui-users.loans.details.requestQueue" />}
+                  value={requestQueueValue}
+                />
+              </Col>
               <Col xs={2}>
                 <KeyValue
                   label={<FormattedMessage id="ui-users.loans.details.lost" />}


### PR DESCRIPTION
## Purpose

Show requests information when a user has view loans permission only. Part of [UIU-1184](https://issues.folio.org/browse/UIU-1184). 

## Screenshots

### Requests column in user loans list
<img width="1676" alt="Screen Shot 2019-11-11 at 14 35 24" src="https://user-images.githubusercontent.com/40821852/68587886-d6934980-0490-11ea-935d-40fd30d86183.png">

### Request queue information in user loan details
<img width="1676" alt="Screen Shot 2019-11-11 at 14 35 58" src="https://user-images.githubusercontent.com/40821852/68587892-d85d0d00-0490-11ea-99da-a5083a08a973.png">