### PR TITLE
UIU-1380 don't search items by barcode wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add service points to user. Refs UIU-1334.
 * Warn, but do not invalidate, when a proxy relationship is expired for any reason. Refs UIU-820.
 * Show requests information when user has view loans permission only. Refs UIU-1184.
+* Use a more efficient query when searching for an item by barcode to attach a fee/fine. Refs UIU-1380.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/src/routes/ChargeFeesFinesContainer.js
+++ b/src/routes/ChargeFeesFinesContainer.js
@@ -57,7 +57,7 @@ class ChargeFeesFinesContainer extends React.Component {
         const { resources: { loanItem, activeRecord } } = props;
         if ((activeRecord && activeRecord.barcode) || (loanItem && loanItem.records.length > 0)) {
           const itemBar = activeRecord.barcode || loanItem.records[0].barcode;
-          return itemBar ? `inventory/items?query=barcode=${itemBar}*` : null;
+          return itemBar ? `inventory/items?query=barcode==${itemBar}` : null;
         }
         return null;
       },


### PR DESCRIPTION
Searching for items by barcode wildcard is not performant on a
production system with millions of entries. The intent here is that a
barcode will be scanned in so there is really no need for a wildcard
search anyway; this is essentially "lookup by barcode" not "search by
barcode" and the query now reflects that.

Refs [UIU-1380](https://issues.folio.org/browse/UIU-1380)