### PR TITLE
four-second test-timeouts

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,2 +1,11 @@
 /** @param {import('karma').Config} config */
-module.exports = config => config.set({ client: { captureConsole: false } });
+module.exports = config => {
+  config.set({
+    client: {
+      captureConsole: false,
+      mocha: {
+        timeout: 4000,
+      },
+    }
+  });
+};


### PR DESCRIPTION
There have been a lot of test failures on PRs in this repository that seem completely unrelated to the PRs themselves. It's maddening. In many cases, the failure is not even a test failure but complaint that the "convergence exceeded the 2000ms timeout". 

This change bumps Mocha's default timeout to 4000ms, doubling the default 2000ms timeout. Maybe it will help and I can feel like I accomplished at least one thing today. 