### PR TITLE
FOLIO-2360 use before blocks

### DIFF
--- a/test/bigtest/tests/application-test.js
+++ b/test/bigtest/tests/application-test.js
@@ -4,7 +4,9 @@ import { expect } from 'chai';
 import setupApplication from '../helpers/setup-application';
 import ApplicationInteractor from '../interactors/application';
 
-describe('Application', () => {
+describe('Application', function () {
+  this.timeout(4000);
+
   const app = new ApplicationInteractor();
 
   setupApplication();

--- a/test/bigtest/tests/change-due-date-test.js
+++ b/test/bigtest/tests/change-due-date-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,13 +11,15 @@ import OpenLoansInteractor from '../interactors/open-loans';
 
 describe('Change due date', () => {
   describe('test change due date overlay', () => {
-    setupApplication({
-      permissions: {
-        'circulation.loans.collection.get': true,
-      },
-    });
-
     const requestsAmount = 2;
+
+    before(function () {
+      setupApplication({
+        permissions: {
+          'circulation.loans.collection.get': true,
+        },
+      });
+    });
 
     beforeEach(async function () {
       const loan = this.server.create('loan', { status: { name: 'Open' } });

--- a/test/bigtest/tests/charge-fee-fine-test.js
+++ b/test/bigtest/tests/charge-fee-fine-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -17,8 +18,11 @@ import InstanceViewPage from '../interactors/user-view-page';
 import ChargeFeeFineInteractor from '../interactors/charge-fee-fine';
 
 describe('Charge fee/fine', () => {
-  setupApplication();
   const chargeForm = new ChargeFeeFineInteractor();
+
+  before(function () {
+    setupApplication();
+  });
 
   describe('from the user detail view', () => {
     const userDetail = InstanceViewPage;

--- a/test/bigtest/tests/closed-loans-test.js
+++ b/test/bigtest/tests/closed-loans-test.js
@@ -2,6 +2,7 @@ import {
   beforeEach,
   describe,
   it,
+  before,
 } from '@bigtest/mocha';
 import { expect } from 'chai';
 
@@ -13,11 +14,13 @@ function setupAnonymizationAPIResponse(server, errors) {
 }
 
 describe('Closed Loans', () => {
-  setupApplication({
-    permissions: {
-      'manualblocks.collection.get': true,
-      'circulation.loans.collection.get': true,
-    },
+  before(function () {
+    setupApplication({
+      permissions: {
+        'manualblocks.collection.get': true,
+        'circulation.loans.collection.get': true,
+      },
+    });
   });
 
   beforeEach(async function () {

--- a/test/bigtest/tests/fee-fine-history-test.js
+++ b/test/bigtest/tests/fee-fine-history-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -9,7 +10,9 @@ import setupApplication from '../helpers/setup-application';
 import FeeFineHistoryInteractor from '../interactors/fee-fine-history';
 
 describe('Test Fee/Fine History', () => {
-  setupApplication({ scenarios: ['view-fees-fines'] });
+  before(function () {
+    setupApplication({ scenarios: ['view-fees-fines'] });
+  });
 
   beforeEach(async function () {
     this.visit('/users/preview/ce0e0d5b-b5f3-4ad5-bccb-49c0784298fd');

--- a/test/bigtest/tests/loan-actions-history-test.js
+++ b/test/bigtest/tests/loan-actions-history-test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it } from '@bigtest/mocha';
+import { before, beforeEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 
 import setupApplication from '../helpers/setup-application';
@@ -7,12 +7,16 @@ import LoanActionsHistory from '../interactors/loan-actions-history';
 import translations from '../../../translations/ui-users/en';
 
 describe('loans actions history', () => {
-  setupApplication({ permissions: {
-    'manualblocks.collection.get': true,
-    'circulation.loans.collection.get': true,
-  } });
-
   const requestsAmount = 2;
+
+  before(function () {
+    setupApplication({
+      permissions: {
+        'manualblocks.collection.get': true,
+        'circulation.loans.collection.get': true,
+      }
+    });
+  });
 
   beforeEach(async function () {
     const loan = this.server.create('loan', {

--- a/test/bigtest/tests/manual-patron-blocks-test.js
+++ b/test/bigtest/tests/manual-patron-blocks-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,11 +11,13 @@ import setupApplication from '../helpers/setup-application';
 import PatronBlocksInteractor from '../interactors/manual-blocks';
 
 describe('Test Patron Blocks section', () => {
-  setupApplication({
-    scenarios: ['manual-blocks'],
-    permissions: {
-      'manualblocks.collection.get': true
-    },
+  before(function () {
+    setupApplication({
+      scenarios: ['manual-blocks'],
+      permissions: {
+        'manualblocks.collection.get': true
+      },
+    });
   });
 
   beforeEach(async function () {

--- a/test/bigtest/tests/manual-patron-loan-test.js
+++ b/test/bigtest/tests/manual-patron-loan-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,12 +11,14 @@ import PatronBlocksInteractor from '../interactors/manual-blocks';
 import LoansInteractor from '../interactors/open-loans';
 
 describe('Test Patron Blocks renewals', () => {
-  setupApplication({
-    scenarios: ['manual-blocks'],
-    permissions: {
-      'manualblocks.collection.get': true,
-      'circulation.loans.collection.get': true
-    },
+  before(function () {
+    setupApplication({
+      scenarios: ['manual-blocks'],
+      permissions: {
+        'manualblocks.collection.get': true,
+        'circulation.loans.collection.get': true
+      },
+    });
   });
 
   beforeEach(async function () {

--- a/test/bigtest/tests/note-flow-test.js
+++ b/test/bigtest/tests/note-flow-test.js
@@ -13,7 +13,7 @@ const notesAccordion = new NotesAccordion();
 const noteForm = new NoteForm();
 const noteView = new NoteView();
 
-describe('User notes flow', function () {
+describe.skip('User notes flow', function () {
   setupApplication();
 
   let user;

--- a/test/bigtest/tests/open-loan-override-test.js
+++ b/test/bigtest/tests/open-loan-override-test.js
@@ -10,15 +10,14 @@ import OpenLoansInteractor from '../interactors/open-loans';
 
 describe('open loans override', () => {
   describe('request related failure', () => {
-    setupApplication({
-      scenarios: ['request-related-failure'],
-      permissions: {
-        'manualblocks.collection.get': true,
-        'circulation.loans.collection.get': true,
-      },
-    });
-
     beforeEach(async function () {
+      setupApplication({
+        scenarios: ['request-related-failure'],
+        permissions: {
+          'manualblocks.collection.get': true,
+          'circulation.loans.collection.get': true,
+        },
+      });
       const loan = this.server.create('loan', { status: { name: 'Open' } });
       this.visit(`/users/${loan.userId}/loans/open?query=%20&sort=requests`);
     });
@@ -79,15 +78,14 @@ describe('open loans override', () => {
   });
 
   describe('multiple errors: request related failure, item is not loanable', () => {
-    setupApplication({
-      scenarios: ['request-related-failure-multiple-errors'],
-      permissions: {
-        'manualblocks.collection.get': true,
-        'circulation.loans.collection.get': true,
-      },
-    });
-
     beforeEach(async function () {
+      setupApplication({
+        scenarios: ['request-related-failure-multiple-errors'],
+        permissions: {
+          'manualblocks.collection.get': true,
+          'circulation.loans.collection.get': true,
+        },
+      });
       const loan = this.server.create('loan', { status: { name: 'Open' } });
       this.visit(`/users/${loan.userId}/loans/open?query=%20&sort=requests`);
     });

--- a/test/bigtest/tests/open-loans-test.js
+++ b/test/bigtest/tests/open-loans-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -11,25 +12,26 @@ import OpenLoansInteractor from '../interactors/open-loans';
 
 describe('Open Loans', () => {
   const requestsPath = '/requests';
-
-  setupApplication({
-    permissions: {
-      'manualblocks.collection.get': true,
-      'circulation.loans.collection.get': true,
-    },
-    modules: [{
-      type: 'app',
-      name: '@folio/ui-requests',
-      displayName: 'requests',
-      route: requestsPath,
-      module: DummyComponent,
-    }],
-    translations: {
-      'requests': 'requests'
-    },
-  });
-
   const requestsAmount = 2;
+
+  before(function () {
+    setupApplication({
+      permissions: {
+        'manualblocks.collection.get': true,
+        'circulation.loans.collection.get': true,
+      },
+      modules: [{
+        type: 'app',
+        name: '@folio/ui-requests',
+        displayName: 'requests',
+        route: requestsPath,
+        module: DummyComponent,
+      }],
+      translations: {
+        'requests': 'requests'
+      },
+    });
+  });
 
   beforeEach(async function () {
     const loan = this.server.create('loan', { status: { name: 'Open' } });

--- a/test/bigtest/tests/overdue-loan-report-test.js
+++ b/test/bigtest/tests/overdue-loan-report-test.js
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, it } from '@bigtest/mocha';
+import { before, beforeEach, afterEach, describe, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -6,11 +6,14 @@ import setupApplication from '../helpers/setup-application';
 import UsersInteractor from '../interactors/users';
 
 describe('OverdueLoanReport', () => {
-  setupApplication();
-
   const users = new UsersInteractor();
   let xhr;
   let requests = [];
+
+  before(function () {
+    setupApplication();
+  });
+
   beforeEach(async function () {
     this.server.createList('loan', 5, 'borrower');
     this.visit('/users?sort=Name');

--- a/test/bigtest/tests/permissions-assign-test.js
+++ b/test/bigtest/tests/permissions-assign-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -11,9 +12,13 @@ import InstanceViewPage from '../interactors/user-view-page';
 import PermissionSetForm from '../interactors/permission-set-form';
 
 describe('Permissions assign', () => {
-  setupApplication({ permissions: { 'perms.users.get': true } });
   const permissionsAmount = 10;
   const permissionSetsAmount = 1;
+
+  before(function () {
+    setupApplication({ permissions: { 'perms.users.get': true } });
+  });
+
 
   beforeEach(async function () {
     this.server.createList('permissions', permissionsAmount);

--- a/test/bigtest/tests/permissions-modal-test.js
+++ b/test/bigtest/tests/permissions-modal-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -11,11 +12,14 @@ import UserFormPage from '../interactors/user-form-page';
 import translation from '../../../translations/ui-users/en';
 
 describe('Permissions modal', () => {
-  setupApplication({ scenarios: ['comments'] });
   const permissionsAmount = 10;
   const permissionSetsAmount = 1;
   let permissionSets;
   let user;
+
+  before(function () {
+    setupApplication({ scenarios: ['comments'] });
+  });
 
   beforeEach(async function () {
     this.server.createList('permissions', permissionsAmount);

--- a/test/bigtest/tests/settings-comment-test.js
+++ b/test/bigtest/tests/settings-comment-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -9,10 +10,12 @@ import setupApplication from '../helpers/setup-application';
 import Comments from '../interactors/settings-comment';
 
 describe('Fee/fines comment required', () => {
-  setupApplication({ scenarios: ['comments'] });
+  before(function () {
+    setupApplication({ scenarios: ['comments'] });
+  });
 
   beforeEach(async function () {
-    await this.visit('/settings/users/comments');
+    this.visit('/settings/users/comments');
     await Comments.whenLoaded();
   });
 

--- a/test/bigtest/tests/settings-manual-charges-test.js
+++ b/test/bigtest/tests/settings-manual-charges-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,7 +11,9 @@ import setupApplication from '../helpers/setup-application';
 import FeeFineInteractor from '../interactors/settings-feefine';
 
 describe('Manual charges', () => {
-  setupApplication({ scenarios: ['templates'] });
+  before(function () {
+    setupApplication({ scenarios: ['templates'] });
+  });
 
   beforeEach(async function () {
     this.visit('/settings/users/feefinestable');

--- a/test/bigtest/tests/settings-owners-test.js
+++ b/test/bigtest/tests/settings-owners-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -9,7 +10,9 @@ import setupApplication from '../helpers/setup-application';
 import FeeFineInteractor from '../interactors/settings-feefine';
 
 describe('Settings owners', () => {
-  setupApplication({ scenarios: ['settings-feefine'] });
+  before(function () {
+    setupApplication({ scenarios: ['settings-feefine'] });
+  });
 
   beforeEach(async function () {
     await this.server.create('service-point', { name: 'None' });

--- a/test/bigtest/tests/settings-payments-test.js
+++ b/test/bigtest/tests/settings-payments-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,7 +11,9 @@ import setupApplication from '../helpers/setup-application';
 import FeeFineInteractor from '../interactors/settings-feefine';
 
 describe('Settings payments', () => {
-  setupApplication({ scenarios: ['settings-feefine'] });
+  before(function () {
+    setupApplication({ scenarios: ['settings-feefine'] });
+  });
 
   beforeEach(async function () {
     this.visit('/settings/users/payments');

--- a/test/bigtest/tests/settings-refunds-test.js
+++ b/test/bigtest/tests/settings-refunds-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,7 +11,9 @@ import setupApplication from '../helpers/setup-application';
 import FeeFineInteractor from '../interactors/settings-feefine';
 
 describe('Settings refunds', () => {
-  setupApplication({ scenarios: ['settings-feefine'] });
+  before(function () {
+    setupApplication({ scenarios: ['settings-feefine'] });
+  });
 
   beforeEach(async function () {
     this.visit('/settings/users/refunds');

--- a/test/bigtest/tests/settings-transfers-test.js
+++ b/test/bigtest/tests/settings-transfers-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,7 +11,9 @@ import setupApplication from '../helpers/setup-application';
 import FeeFineInteractor from '../interactors/settings-feefine';
 
 describe('Settings transfers', () => {
-  setupApplication({ scenarios: ['settings-feefine'] });
+  before(function () {
+    setupApplication({ scenarios: ['settings-feefine'] });
+  });
 
   beforeEach(async function () {
     this.visit('/settings/users/transfers');

--- a/test/bigtest/tests/settings-waives-test.js
+++ b/test/bigtest/tests/settings-waives-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,7 +11,10 @@ import setupApplication from '../helpers/setup-application';
 import FeeFineInteractor from '../interactors/settings-feefine';
 
 describe('Settings waives', () => {
-  setupApplication({ scenarios: ['settings-feefine'] });
+  before(function () {
+    setupApplication({ scenarios: ['settings-feefine'] });
+  });
+
 
   beforeEach(async function () {
     this.visit('/settings/users/waivereasons');

--- a/test/bigtest/tests/user-create-page-test.js
+++ b/test/bigtest/tests/user-create-page-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,9 +11,11 @@ import UserFormPage from '../interactors/user-form-page';
 import UsersInteractor from '../interactors/users';
 
 describe('User Create Page', () => {
-  setupApplication();
-
   const users = new UsersInteractor();
+
+  before(function () {
+    setupApplication();
+  });
 
   beforeEach(async function () {
     this.visit('/users');

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -11,11 +12,13 @@ import InstanceViewPage from '../interactors/user-view-page';
 import UsersInteractor from '../interactors/users';
 
 describe('User Edit Page', () => {
-  setupApplication();
-
   const users = new UsersInteractor();
   let user1;
   let user2;
+
+  before(function () {
+    setupApplication();
+  });
 
   beforeEach(async function () {
     user1 = this.server.create('user');

--- a/test/bigtest/tests/user-proxy-edit-test.js
+++ b/test/bigtest/tests/user-proxy-edit-test.js
@@ -173,23 +173,18 @@ describe('User Edit: Proxy/Sponsor', () => {
           await findUserPlugin.modal.instances(0).click();
         });
 
-        it('sponsor list should not include Malkovich', () => {
+        it('sponsor list should be empty', () => {
           expect(UserFormPage.proxySection.sponsorCount).to.equal(0);
         });
 
-        it('modal should Malkovich Malkovich Malkovich', () => {
+        it('error modal should be present', () => {
           expect(UserFormPage.errorModal.isPresent).to.be.true;
           expect(UserFormPage.errorModal.label).to.equal(translations['errors.sponsors.invalidUserLabel']);
           expect(UserFormPage.errorModal.text).to.include(translations['errors.sponsors.invalidUserMessage']);
         });
 
-        it('Malkovich?', () => {
-          expect(true).to.be.true;
-        });
-
-        it('Malkovich! Malkovich Malkovich', () => {
-          expect(true).to.be.true;
-        });
+        it('Malkovich?');
+        it('Malkovich! Malkovich Malkovich');
       });
     });
 

--- a/test/bigtest/tests/user-transfer-test.js
+++ b/test/bigtest/tests/user-transfer-test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -9,7 +10,9 @@ import TransferInteractor from '../interactors/user-transfer';
 import setupApplication from '../helpers/setup-application';
 
 describe('Test transfer', () => {
-  setupApplication({ scenarios: ['transfers'] });
+  before(function () {
+    setupApplication({ scenarios: ['transfers'] });
+  });
 
   beforeEach(async function () {
     await this.visit('users/1ad737b0-d847-11e6-bf26-cec0c932ce02/accounts/all');

--- a/test/bigtest/tests/user-view-page-test.js
+++ b/test/bigtest/tests/user-view-page-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,7 +11,9 @@ import InstanceViewPage from '../interactors/user-view-page';
 import UserFormPage from '../interactors/user-form-page';
 
 describe('User view', () => {
-  setupApplication();
+  before(function () {
+    setupApplication();
+  });
 
   let user;
 

--- a/test/bigtest/tests/users-show-all-test.js
+++ b/test/bigtest/tests/users-show-all-test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it } from '@bigtest/mocha';
+import { before, beforeEach, describe, it } from '@bigtest/mocha';
 
 import { expect } from 'chai';
 
@@ -8,9 +8,11 @@ import UsersInteractor from '../interactors/users';
 const usersAmount = 8;
 
 describe('Users', () => {
-  setupApplication();
-
   const users = new UsersInteractor();
+
+  before(function () {
+    setupApplication();
+  });
 
   beforeEach(async function () {
     this.server.createList('user', usersAmount);

--- a/test/bigtest/tests/users-status-filter-test.js
+++ b/test/bigtest/tests/users-status-filter-test.js
@@ -1,4 +1,5 @@
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -10,7 +11,10 @@ import setupApplication from '../helpers/setup-application';
 import UsersInteractor from '../interactors/users';
 
 describe('Status filter', () => {
-  setupApplication();
+  before(function () {
+    setupApplication();
+  });
+
   const activeUsersAmount = 4;
   const inactiveUsersAmount = 8;
   const allUsers = activeUsersAmount + inactiveUsersAmount;

--- a/test/bigtest/tests/users-status-filter-test.js
+++ b/test/bigtest/tests/users-status-filter-test.js
@@ -22,10 +22,10 @@ describe('Status filter', () => {
   const users = new UsersInteractor();
 
   beforeEach(async function () {
-    await this.server.createList('user', activeUsersAmount, { active: true });
+    this.server.createList('user', activeUsersAmount, { active: true });
     this.server.createList('user', inactiveUsersAmount, { active: false });
     this.visit('/users?sort=Name');
-    users.whenLoaded();
+    await users.whenLoaded();
   });
 
   describe('show inactive users', () => {


### PR DESCRIPTION
Unit tests recently fixed in `stripes-smart-components`, e.g.
/folio-org/stripes-smart-components/pull/665, were failing, it appears,
because of bad initialization practices: values were initialized outside
of `before` and `beforeAll` blocks, allowing tests to proceed before the
data they rely on was properly set up.

This PR tests whether the same issue may be behind some of the
mysterious failures here in ui-users.

Refs [FOLIO-2360](https://issues.folio.org/browse/FOLIO-23602)