### PR TITLE
CIRC-567: Add translation for declared lost item status

### DIFF
--- a/src/components/data/static/loanActionMap.js
+++ b/src/components/data/static/loanActionMap.js
@@ -1,6 +1,7 @@
 export default {
   'checkedout': 'ui-users.data.loanActionMap.checkedOut',
   'checkedin': 'ui-users.data.loanActionMap.checkedIn',
+  'declaredLost': 'ui-users.data.loanActionMap.declaredLost',
   'renewed': 'ui-users.data.loanActionMap.renewed',
   'Operator': 'ui-users.data.loanActionMap.source',
   'holdrequested': 'ui-users.data.loanActionMap.holdRequested',

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -278,6 +278,7 @@
   "data.loanActionMap.dueDateChanged": "Due date changed",
   "data.loanActionMap.renewedThroughOverride": "Renewed through override",
   "data.loanActionMap.checkedOutThroughOverride": "Checked out through override",
+  "data.loanActionMap.declaredLost": "Declared lost",
 
   "action": "Action",
   "dueDate": "Due date",


### PR DESCRIPTION
# Purpose

The UI is not broken when I update a loan with the status "declared lost"


