### PR TITLE
UIU-1344: Rename "Loans: All permissions" permission to "Users: User loans view, edit, renew (all)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Show requests information when user has view loans permission only. Refs UIU-1184.
 * Use a more efficient query when searching for an item by barcode to attach a fee/fine. Refs UIU-1380.
 * Use user's id instead of a barcode when navigating to requests module. Refs UIU-1370.
+* Rename "Loans: All permissions" permission to "Users: User loans view, edit, renew (all)". Refs UIU-1344.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/package.json
+++ b/package.json
@@ -586,7 +586,7 @@
       },
       {
         "permissionName": "ui-users.loans.all",
-        "displayName": "Loans: All permissions",
+        "displayName": "Users: User loans view, edit, renew (all)",
         "description": "Also includes requests, loan-policies and accounts permissions",
         "subPermissions": [
           "ui-users.view",

--- a/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
+++ b/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
@@ -347,7 +347,7 @@ class ViewFeesFines extends React.Component {
       <UncontrolledDropdown
         onSelectItem={this.handleOptionsChange}
       >
-        <Button id="ellipsis-button" data-role="toggle" buttonStyle="hover dropdownActive">
+        <Button data-test-ellipsis-button data-role="toggle" buttonStyle="hover dropdownActive">
           <strong>•••</strong>
         </Button>
         <DropdownMenu id="ellipsis-drop-down" data-role="menu">

--- a/src/views/AccountsListing/AccountsListing.js
+++ b/src/views/AccountsListing/AccountsListing.js
@@ -404,7 +404,7 @@ class AccountsHistory extends React.Component {
           pullRight
         >
           <Button
-            id="select-columns"
+            data-test-select-columns
             data-role="toggle"
             bottomMargin0
           >

--- a/test/bigtest/interactors/fee-fine-history.js
+++ b/test/bigtest/interactors/fee-fine-history.js
@@ -83,7 +83,7 @@ import CheckboxInteractor  from '@folio/stripes-components/lib/Checkbox/tests/in
   searchField = new SearchFieldInteractor('[class*=searchFieldWrap---]');
   checkList = collection('[class*=filterList---] [class*=listItem---]', CheckboxInteractor);
   col = new CheckboxInteractor('#column-item-0');
-  selectColumns = new ButtonInteractor('#select-columns');
+  selectColumns = new ButtonInteractor('[data-test-select-columns]');
 
   // file AccountsHistory
   openMenu = new ButtonInteractor('#open-accounts');

--- a/test/bigtest/interactors/fee-fine-history.js
+++ b/test/bigtest/interactors/fee-fine-history.js
@@ -20,7 +20,7 @@ import CheckboxInteractor  from '@folio/stripes-components/lib/Checkbox/tests/in
 @interactor class CellInteractor {
   content = text();
   selectOne = clickable('input[type="checkbox"]');
-  selectEllipsis = clickable('#ellipsis-button');
+  selectEllipsis = clickable('[data-test-ellipsis-button]');
 }
 
 @interactor class RowInteractor {
@@ -36,7 +36,6 @@ import CheckboxInteractor  from '@folio/stripes-components/lib/Checkbox/tests/in
 @interactor class History {
   mclViewFeesFines = new MultiColumnListInteractor('#list-accounts-history-view-feesfines');
   mclAccountActions = new MultiColumnListInteractor('#list-accountactions');
-  sectionIsPresent = isPresent('#accordion-toggle-button-accountsSection');
   section = text('#accordion-toggle-button-accountsSection h3');
 
   title = text('[class*=paneTitleLabel---]');
@@ -55,7 +54,7 @@ import CheckboxInteractor  from '@folio/stripes-components/lib/Checkbox/tests/in
   allFeesFines = text('#clickable-viewallaccounts');
 
   accountActionIsPresent = isPresent('#paneHeaderpane-account-action-history-pane-title');
-  ellipsisMenuIsPresent = isPresent('#ellipsis-drop-down');
+  ellipsisMenuIsPresent = isPresent('#OverlayContainer #ellipsis-drop-down');
   loanDetailsIsPresent = isPresent('#pane-loandetails');
 
   payModal = new ModalInteractor('#payment-modal');

--- a/test/bigtest/tests/fee-fine-history-test.js
+++ b/test/bigtest/tests/fee-fine-history-test.js
@@ -164,7 +164,7 @@ describe('Test Fee/Fine History', () => {
           await FeeFineHistoryInteractor.rows(3).cells(13).selectEllipsis();
         });
 
-        it('the ellipsis menu most be present', () => {
+        it('the ellipsis menu must be present', () => {
           expect(FeeFineHistoryInteractor.ellipsisMenuIsPresent).to.be.true;
         });
 


### PR DESCRIPTION
## Purpose

Rename "Loans: All permissions" permission to "Users: User loans view, edit, renew (all)" in the scope of [UIU-1344](https://issues.folio.org/browse/UIU-1344).

## Screenshot
<img width="1101" alt="Screen Shot 2019-12-05 at 13 11 33" src="https://user-images.githubusercontent.com/40821852/70230345-c9e8d500-1760-11ea-89a4-37d7ef316e1f.png">