### PR TITLE
UIU-1377: Fix cancel button on loan details, open and closed loan lists pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.27.0 (IN PROGRESS)
 * Add default settings for user status and preferred contact in new user creation. Refs UIU-1385.
+* Fix navigation paths on cancel button click on loan details, open and closed loan lists pages. Refs UIU-1377.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/Loans/ClosedLoans/ClosedLoans.js
+++ b/src/components/Loans/ClosedLoans/ClosedLoans.js
@@ -50,6 +50,7 @@ class ClosedLoans extends React.Component {
     user: PropTypes.object,
     intl: intlShape.isRequired,
     history: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -141,9 +142,15 @@ class ClosedLoans extends React.Component {
 
   onRowClick = (e, row) => {
     e.stopPropagation();
+
     if (e.target.type !== 'button') {
-      const { history, match: { params } } = this.props;
-      nav.onClickViewLoanActionsHistory(e, row, history, params);
+      const {
+        history,
+        match: { params },
+        location,
+      } = this.props;
+
+      nav.onClickViewLoanActionsHistory(e, row, history, params, location.state);
     }
   };
 

--- a/src/components/Loans/OpenLoans/OpenLoans.js
+++ b/src/components/Loans/OpenLoans/OpenLoans.js
@@ -14,6 +14,7 @@ import {
 class OpenLoans extends React.Component {
   static propTypes = {
     history: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
     isLoanChecked: PropTypes.func.isRequired,
     match: PropTypes.object.isRequired,
     loans: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -76,9 +77,15 @@ class OpenLoans extends React.Component {
 
   onRowClick = (e, row) => {
     e.stopPropagation();
+
     if (e.target.type !== 'button') {
-      const { history, match: { params } } = this.props;
-      nav.onClickViewLoanActionsHistory(e, row, history, params);
+      const {
+        history,
+        match: { params },
+        location
+      } = this.props;
+
+      nav.onClickViewLoanActionsHistory(e, row, history, params, location.state);
     }
   };
 

--- a/src/components/Loans/OpenLoans/OpenLoansControl.js
+++ b/src/components/Loans/OpenLoans/OpenLoansControl.js
@@ -44,6 +44,7 @@ class OpenLoansControl extends React.Component {
       id: PropTypes.string.isRequired,
     }).isRequired,
     history: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
     match: PropTypes.object,
     patronGroup: PropTypes.object.isRequired,
     requestCounts: PropTypes.object.isRequired,
@@ -372,7 +373,9 @@ class OpenLoansControl extends React.Component {
       patronGroup,
       patronBlocks,
       resources,
+      location,
     } = this.props;
+
     return (
       <div data-test-open-loans>
         <TableModel
@@ -391,6 +394,7 @@ class OpenLoansControl extends React.Component {
           stripes={stripes}
           feeFineCount={this.feeFineCount}
           history={history}
+          location={location}
           match={match}
           user={user}
           toggleAll={this.toggleAll}

--- a/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.js
@@ -50,6 +50,7 @@ class OpenLoansWithStaticData extends React.Component {
     onClosePatronBlockedModal: PropTypes.func.isRequired,
     feeFineCount: PropTypes.func.isRequired,
     history: PropTypes.object,
+    location: PropTypes.object,
     match: PropTypes.object,
   };
 
@@ -242,6 +243,7 @@ class OpenLoansWithStaticData extends React.Component {
           sortOrder={this.sortOrder}
           possibleColumns={possibleColumns}
           history={this.props.history}
+          location={this.props.location}
           match={this.props.match}
         />
         <Modals

--- a/src/components/UserDetailSections/UserLoans/UserLoans.js
+++ b/src/components/UserDetailSections/UserLoans/UserLoans.js
@@ -70,6 +70,7 @@ class UserLoans extends React.Component {
       accordionId,
       resources,
       match: { params },
+      location,
     } = this.props;
 
     const openLoansTotal = _.get(resources.openLoansCount, ['records', '0', 'totalRecords'], 0);
@@ -97,7 +98,10 @@ class UserLoans extends React.Component {
               <li key={index}>
                 <Link
                   id={item.id}
-                  to={`/users/${params.id}/loans/${item.status}`}
+                  to={{
+                    pathname: `/users/${params.id}/loans/${item.status}`,
+                    state: { search: location.search },
+                  }}
                 >
                   <FormattedMessage id={item.formattedMessageId} values={{ count: item.count }} />
                 </Link>

--- a/src/components/util/navigationHandlers.js
+++ b/src/components/util/navigationHandlers.js
@@ -14,8 +14,11 @@ export function onClickViewAllAccounts(e, loan, history, params) {
   history.push(`/users/${params.id}/accounts/all?loan=${loan.id}`);
 }
 
-export function onClickViewLoanActionsHistory(e, loan, history, params) {
-  history.push(`/users/${params.id}/loans/view/${loan.id}`);
+export function onClickViewLoanActionsHistory(e, loan, history, params, state) {
+  history.push({
+    pathname: `/users/${params.id}/loans/view/${loan.id}`,
+    state,
+  });
 }
 
 export function onClickViewChargeFeeFine(e, history, params) {

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -70,6 +70,7 @@ class LoanDetails extends React.Component {
     intl: intlShape.isRequired,
     match: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -251,18 +252,28 @@ class LoanDetails extends React.Component {
   }
 
   handleClose = () => {
-    const { loan, history, match: { params } } = this.props;
+    const {
+      loan,
+      history,
+      match: { params },
+      location,
+    } = this.props;
+
     // if this loan detail was accessed through a fee/fine, accountid will be present.
     if (params.accountid) {
       history.push(`/users/${params.id}/accounts/view/${params.accountid}`);
     }
+
     const loanStatus = loan.status ? loan.status.name.toLowerCase() : 'open';
-    history.push(`/users/${params.id}/loans/${loanStatus}`);
+
+    history.push({
+      pathname: `/users/${params.id}/loans/${loanStatus}`,
+      state: location.state,
+    });
   }
 
   render() {
     const {
-      history,
       loan,
       patronGroup,
       patronBlocks,
@@ -338,7 +349,7 @@ class LoanDetails extends React.Component {
             id="pane-loandetails"
             defaultWidth="100%"
             dismissible
-            onClose={() => { history.goBack(); }}
+            onClose={this.handleClose}
             paneTitle={(
               <FormattedMessage id="ui-users.loans.loanDetails">
                 {(loanDetails) => `${loanDetails} - ${getFullName(user)} (${upperFirst(patronGroup.group)})`}

--- a/src/views/LoansListing/LoansListing.js
+++ b/src/views/LoansListing/LoansListing.js
@@ -34,6 +34,7 @@ class LoansListing extends React.Component {
    */
   getSegmentedControls = () => {
     const {
+      location,
       match: { params },
     } = this.props;
 
@@ -44,7 +45,10 @@ class LoansListing extends React.Component {
           fullWidth
           id="loans-show-open"
           buttonStyle={params.loanstatus === 'open' ? 'primary' : 'default'}
-          to={{ pathname: `/users/${params.id}/loans/open` }}
+          to={{
+            pathname: `/users/${params.id}/loans/open`,
+            state: location.state,
+          }}
           replace
         >
           <FormattedMessage id="ui-users.loans.openLoans" />
@@ -54,7 +58,10 @@ class LoansListing extends React.Component {
           fullWidth
           id="loans-show-closed"
           buttonStyle={params.loanstatus === 'closed' ? 'primary' : 'default'}
-          to={{ pathname: `/users/${params.id}/loans/closed` }}
+          to={{
+            pathname: `/users/${params.id}/loans/closed`,
+            state: location.state,
+          }}
           replace
         >
           <FormattedMessage id="ui-users.loans.closedLoans" />
@@ -63,12 +70,21 @@ class LoansListing extends React.Component {
     );
   }
 
+  handleClose = () => {
+    const {
+      history,
+      location,
+      match: { params },
+    } = this.props;
+
+    history.push(`/users/preview/${params.id}${_.get(location, ['state', 'search'], '')}`);
+  }
+
   render() {
     const {
       user,
       patronGroup,
       match: { params },
-      history,
       loansHistory,
     } = this.props;
     const loanStatus = params.loanstatus;
@@ -82,7 +98,7 @@ class LoansListing extends React.Component {
           id="pane-loanshistory"
           defaultWidth="100%"
           dismissible
-          onClose={() => { history.goBack(); }}
+          onClose={this.handleClose}
           paneTitle={(
             <FormattedMessage id="ui-users.loans.title">
               {(title) => `${title} - ${getFullName(user)} (${_.upperFirst(patronGroup.group)})`}

--- a/test/bigtest/interactors/closed-loans.js
+++ b/test/bigtest/interactors/closed-loans.js
@@ -2,6 +2,7 @@ import {
   interactor,
   scoped,
   Interactor,
+  collection,
 } from '@bigtest/interactor';
 
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor'; // eslint-disable-line
@@ -14,6 +15,7 @@ import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumn
   anonymizationFeesFinesErrorModal = new Interactor('#anonymization-fees-fines-modal');
   anonymizationConfirmButton = new ButtonInteractor('#anonymization-fees-fines-modal-footer button');
   list = scoped('#list-loanshistory', MultiColumnListInteractor);
+  rowButtons = collection('[data-test-closed-loans] button[role="row"]', ButtonInteractor);
 
   whenLoaded() {
     return this.when(() => this.list.isVisible);

--- a/test/bigtest/interactors/loan-actions-history.js
+++ b/test/bigtest/interactors/loan-actions-history.js
@@ -1,6 +1,7 @@
 import {
   interactor,
   scoped,
+  ButtonInteractor,
 } from '@bigtest/interactor';
 
 import KeyValue from './KeyValue';
@@ -10,6 +11,7 @@ import KeyValue from './KeyValue';
 
   requests = scoped('[data-test-loan-actions-history-requests] div', KeyValue);
   feeFines = scoped('[data-test-loan-fees-fines] [data-test-kv-value]', KeyValue);
+  closeButton = scoped('button[icon=times]', ButtonInteractor);
 }
 
 export default new LoanActionsHistory();

--- a/test/bigtest/interactors/loans-listing-pane.js
+++ b/test/bigtest/interactors/loans-listing-pane.js
@@ -1,0 +1,17 @@
+import {
+  interactor,
+  scoped,
+  ButtonInteractor,
+} from '@bigtest/interactor';
+
+@interactor class LoansListingPane {
+  static defaultScope = '#pane-loanshistory';
+
+  closeButton = scoped('button[icon=times]', ButtonInteractor);
+
+  whenLoaded() {
+    return this.when(() => this.list.isVisible).timeout(4000);
+  }
+}
+
+export default new LoansListingPane();

--- a/test/bigtest/interactors/open-loans.js
+++ b/test/bigtest/interactors/open-loans.js
@@ -4,7 +4,7 @@ import {
   collection,
   count,
   Interactor,
-  property,
+  property
 } from '@bigtest/interactor';
 import moment from 'moment';
 
@@ -45,11 +45,11 @@ import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/inter
   actionDropdownRenewButton = new Interactor('[data-test-dropdown-content-renew-button]');
   actionDropdownChangeDueDateButton = new Interactor('[data-test-dropdown-content-change-due-date-button]');
   requestsCount = count('[data-test-list-requests]');
-
   bulkRenewalModal = new BulkRenewalModal();
   bulkOverrideModal = new BulkOverrideModal();
   changeDueDateOverlay = new ChangeDueDateOverlay();
   dueDateCalendarCellButton = new ButtonInteractor(`[data-test-date="${moment().format('MM/DD/YYYY')}"]`);
+  rowButtons = collection('[data-test-open-loans-list] button[role="row"]', ButtonInteractor);
 
   whenLoaded() {
     return this.when(() => this.list.isVisible);

--- a/test/bigtest/interactors/user-view-page.js
+++ b/test/bigtest/interactors/user-view-page.js
@@ -5,6 +5,7 @@ import {
   isPresent,
   scoped,
   count,
+  ButtonInteractor,
 } from '@bigtest/interactor';
 
 import proxyItemCSS from '../../../src/components/ProxyGroup/ProxyItem/ProxyItem.css';
@@ -22,6 +23,16 @@ import proxyItemCSS from '../../../src/components/ProxyGroup/ProxyItem/ProxyItem
   sponsorCount = count(`[data-test="sponsors"] .${proxyItemCSS.item}`);
 }
 
+@interactor class LoansSectionInteractor {
+  accordionButton = scoped('#accordion-toggle-button-loansSection', ButtonInteractor);
+  openLoans = scoped('#clickable-viewcurrentloans', ButtonInteractor);
+  closedLoans = scoped('#clickable-viewclosedloans', ButtonInteractor);
+
+  whenLoaded() {
+    return this.when(() => this.isPresent).timeout(5000);
+  }
+}
+
 @interactor class InstanceViewPage {
   title = text('[data-test-header-title]');
   headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
@@ -29,11 +40,13 @@ import proxyItemCSS from '../../../src/components/ProxyGroup/ProxyItem/ProxyItem
   editButtonPresent = isPresent('#clickable-edituser');
   clickEditButton = clickable('#clickable-edituser');
   proxySection = scoped('#proxySection', ProxySectionInteractor);
+  loansSection = scoped('#loansSection', LoansSectionInteractor);
   holdShelf = text('[data-test-hold-shelf]');
   delivery = text('[data-test-delivery]');
   fulfillmentPreference = text('[data-test-fulfillment-preference]');
   defaultPickupServicePoint = text('[data-test-default-pickup-service-point]');
   defaultDeliveryAddress = text('[data-test-default-delivery-address]');
+
   whenLoaded() {
     return this.when(() => this.isPresent).timeout(5000);
   }

--- a/test/bigtest/tests/closed-loans-test.js
+++ b/test/bigtest/tests/closed-loans-test.js
@@ -8,6 +8,8 @@ import { expect } from 'chai';
 
 import setupApplication from '../helpers/setup-application';
 import ClosedLoansInteractor from '../interactors/closed-loans';
+import UsersInteractor from '../interactors/users';
+import LoansListingPane from '../interactors/loans-listing-pane';
 
 function setupAnonymizationAPIResponse(server, errors) {
   server.post('/loan-anonymization/by-user/:id', { errors });
@@ -23,8 +25,10 @@ describe('Closed Loans', () => {
     });
   });
 
+  let user;
+
   beforeEach(async function () {
-    const user = this.server.create('user');
+    user = this.server.create('user');
     const loans = this.server.createList('loan', 5, 'feesAndFines', {
       userId: user.id,
       item: (i) => ({ ...this.item, barcode: i }),
@@ -46,6 +50,10 @@ describe('Closed Loans', () => {
 
   it('should be presented', () => {
     expect(ClosedLoansInteractor.isPresent).to.be.true;
+  });
+
+  it('should display close button', () => {
+    expect(LoansListingPane.closeButton.isPresent).to.be.true;
   });
 
   describe('loan list', () => {
@@ -95,6 +103,20 @@ describe('Closed Loans', () => {
       it('should close the error modal', () => {
         expect(ClosedLoansInteractor.anonymizationFeesFinesErrorModal.isPresent).to.be.false;
       });
+    });
+  });
+
+  describe('clicking the close button', () => {
+    const users = new UsersInteractor();
+
+    beforeEach(async () => {
+      await LoansListingPane.closeButton.click();
+    });
+
+    it('should navigate to user preview form', function () {
+      expect(users.isPresent).to.be.true;
+      expect(users.instance.isPresent).to.be.true;
+      expect(this.location.pathname.endsWith(`users/preview/${user.id}`)).to.be.true;
     });
   });
 });

--- a/test/bigtest/tests/open-loans-test.js
+++ b/test/bigtest/tests/open-loans-test.js
@@ -9,6 +9,8 @@ import { expect } from 'chai';
 import setupApplication from '../helpers/setup-application';
 import DummyComponent from '../helpers/DummyComponent';
 import OpenLoansInteractor from '../interactors/open-loans';
+import UsersInteractor from '../interactors/users';
+import LoansListingPane from '../interactors/loans-listing-pane';
 
 describe('Open Loans', () => {
   const requestsPath = '/requests';
@@ -33,16 +35,23 @@ describe('Open Loans', () => {
     });
   });
 
+  let userId = '';
+
   beforeEach(async function () {
     const loan = this.server.create('loan', { status: { name: 'Open' } });
+    userId = loan.userId;
 
     this.server.createList('request', requestsAmount, { itemId: loan.itemId });
-    this.visit(`/users/${loan.userId}/loans/open?query=%20&sort=requests`);
+    this.visit(`/users/${userId}/loans/open?query=%20&sort=requests`);
   });
 
   it('should be presented', () => {
     expect(OpenLoansInteractor.isPresent).to.be.true;
   }).timeout(4000);
+
+  it('should display the close button', () => {
+    expect(LoansListingPane.closeButton.isPresent).to.be.true;
+  });
 
   describe('loan list', () => {
     it('should be presented', () => {
@@ -108,6 +117,20 @@ describe('Open Loans', () => {
             expect(this.location.pathname).to.to.equal(requestsPath);
           });
         });
+      });
+    });
+
+    describe('clicking the close button', () => {
+      const users = new UsersInteractor();
+
+      beforeEach(async () => {
+        await LoansListingPane.closeButton.click();
+      });
+
+      it('should navigate to the user preview form', function () {
+        expect(users.isPresent).to.be.true;
+        expect(users.instance.isPresent).to.be.true;
+        expect(this.location.pathname.endsWith(`users/preview/${userId}`)).to.be.true;
       });
     });
   });

--- a/test/bigtest/tests/users-show-all-test.js
+++ b/test/bigtest/tests/users-show-all-test.js
@@ -1,43 +1,170 @@
-import { before, beforeEach, describe, it } from '@bigtest/mocha';
-
+import {
+  before,
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
 import { expect } from 'chai';
 
 import setupApplication from '../helpers/setup-application';
 import UsersInteractor from '../interactors/users';
+import InstanceViewPage from '../interactors/user-view-page';
+import OpenLoansInteractor from '../interactors/open-loans';
+import ClosedLoansInteractor from '../interactors/closed-loans';
+import LoanActionsHistory from '../interactors/loan-actions-history';
+import LoansListingPane from '../interactors/loans-listing-pane';
 
 const usersAmount = 8;
 
 describe('Users', () => {
-  const users = new UsersInteractor();
+  const usersInteractor = new UsersInteractor();
 
   before(function () {
-    setupApplication();
+    setupApplication({
+      permissions: {
+        'manualblocks.collection.get': true,
+        'circulation.loans.collection.get': true,
+      }
+    });
   });
 
+  let users;
+  let searchQuery = '';
+
   beforeEach(async function () {
-    this.server.createList('user', usersAmount);
+    users = this.server.createList('user', usersAmount);
     this.visit('/users?sort=Name');
 
-    await users.activeUserCheckbox.clickActive();
-    await users.activeUserCheckbox.clickInactive();
-    await users.whenResultsLoaded();
+    await usersInteractor.activeUserCheckbox.clickActive();
+    await usersInteractor.activeUserCheckbox.clickInactive();
+    await usersInteractor.whenResultsLoaded();
+
+    searchQuery = this.location.search;
   });
 
   it('shows the list of user items', () => {
-    expect(users.isVisible).to.equal(true);
+    expect(usersInteractor.isVisible).to.equal(true);
   });
 
   it('renders each user instance', () => {
-    expect(users.instances().length).to.be.equal(usersAmount);
+    expect(usersInteractor.instances().length).to.be.equal(usersAmount);
   });
 
   describe('clicking on the first user item', function () {
+    let openLoan;
+    let closedLoan;
+
     beforeEach(async function () {
-      await users.instances(0).click();
+      openLoan = this.server.create('loan', {
+        status: { name: 'Open' },
+        userId: users[0].id,
+        loanPolicyId: 'test'
+      });
+
+      closedLoan = this.server.create('loan', {
+        status: { name: 'Closed' },
+        userId: users[0].id,
+        loanPolicyId: 'test'
+      });
+
+      await usersInteractor.instances(0).click();
+      await InstanceViewPage.whenLoaded();
     });
 
-    it('loads the user instance details', function () {
-      expect(users.instance.isVisible).to.equal(true);
+    it('should load the user instance details', () => {
+      expect(usersInteractor.instance.isVisible).to.be.true;
+    });
+
+    it('should display the loans section', () => {
+      expect(InstanceViewPage.loansSection.isPresent).to.be.true;
+    });
+
+    describe('clicking on the accordion of the loans section', function () {
+      beforeEach(async function () {
+        await InstanceViewPage.whenLoaded();
+        await InstanceViewPage.loansSection.accordionButton.click();
+      });
+
+      it('should display links to closed and open loans ', () => {
+        expect(InstanceViewPage.loansSection.openLoans.isPresent).to.be.true;
+        expect(InstanceViewPage.loansSection.closedLoans.isPresent).to.be.true;
+      });
+
+      describe('clicking on the open loans link', function () {
+        beforeEach(async function () {
+          await InstanceViewPage.loansSection.openLoans.click();
+        });
+
+        it('should navigate to the list of open user loans ', function () {
+          expect(OpenLoansInteractor.isPresent).to.be.true;
+          expect(this.location.pathname.endsWith(`/users/${users[0].id}/loans/open`)).to.be.true;
+        });
+
+        describe('clicking on the first row', function () {
+          beforeEach(async function () {
+            await OpenLoansInteractor.rowButtons(0).click();
+          });
+
+          it('should navigate to the loan actions history', function () {
+            expect(LoanActionsHistory.isPresent).to.be.true;
+            expect(this.location.pathname.endsWith(`/users/${users[0].id}/loans/view/${openLoan.id}`)).to.be.true;
+          });
+
+          describe('clicking on the close buttons on loan actions history and open loan panes', function () {
+            beforeEach(async function () {
+              await LoanActionsHistory.closeButton.click();
+              await LoansListingPane.closeButton.click();
+            });
+
+            it('should navigate to the user preview page', () => {
+              expect(usersInteractor.instance.isVisible).to.be.true;
+            });
+
+            it('should have the correct url with query', function () {
+              expect(this.location.pathname.endsWith(`users/preview/${users[0].id}`)).to.be.true;
+              expect(this.location.search).to.equal(searchQuery);
+            });
+          });
+        });
+      });
+
+      describe('clicking on the closed loans link', function () {
+        beforeEach(async function () {
+          await InstanceViewPage.loansSection.closedLoans.click();
+        });
+
+        it('should navigate to the list of closed user loans ', function () {
+          expect(ClosedLoansInteractor.isPresent).to.be.true;
+          expect(this.location.pathname.endsWith(`/users/${users[0].id}/loans/closed`)).to.be.true;
+        });
+
+        describe('clicking on the first row', function () {
+          beforeEach(async function () {
+            await ClosedLoansInteractor.rowButtons(0).click();
+          });
+
+          it('should navigate to the loan actions history', function () {
+            expect(LoanActionsHistory.isPresent).to.be.true;
+            expect(this.location.pathname.endsWith(`/users/${users[0].id}/loans/view/${closedLoan.id}`)).to.be.true;
+          });
+
+          describe('clicking on the close buttons on loan actions history and closed loan panes', function () {
+            beforeEach(async function () {
+              await LoanActionsHistory.closeButton.click();
+              await LoansListingPane.closeButton.click();
+            });
+
+            it('should navigate to the user preview page', () => {
+              expect(usersInteractor.instance.isVisible).to.be.true;
+            });
+
+            it('should have the correct url with query', function () {
+              expect(this.location.pathname.endsWith(`users/preview/${users[0].id}`)).to.be.true;
+              expect(this.location.search).to.equal(searchQuery);
+            });
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Purposes

Fix close button handling for the next panes: loan actions history, open loans list, closed loans list. [Issue](https://issues.folio.org/browse/UIU-1377)