### PR TITLE
UIU-1344: Allow users to renew loans through override

### DIFF
--- a/package.json
+++ b/package.json
@@ -593,6 +593,7 @@
           "ui-users.loans.view",
           "ui-users.loans.edit",
           "ui-users.loans.renew",
+          "ui-users.loans.renew-override",
           "ui-users.settings.feefines",
           "circulation.loans.item.put",
           "circulation.renew-by-barcode.post",


### PR DESCRIPTION
## Purpose

Allow users to renew loans through override when they have "Users: User loans view, edit, renew (all)" permission in the scope of [UIU-1344](https://issues.folio.org/browse/UIU-1344).