### PR TITLE
UIU-1359: Prevent loan details opening upon click in loans action menu without selecting link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.27.0 (IN PROGRESS)
 * Add default settings for user status and preferred contact in new user creation. Refs UIU-1385.
 * Fix navigation paths on cancel button click on loan details, open and closed loan lists pages. Refs UIU-1377.
+* Prevent loan details opening upon click in loans action menu without selecting link. Fixes UIU-1359.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { withRouter } from 'react-router-dom';
+
 import {
   Button,
   MenuItem,
@@ -13,6 +14,7 @@ import {
 } from '@folio/stripes/core';
 
 import Popdown from './Popdown';
+
 import css from './ActionsDropdown.css';
 
 class ActionsDropdown extends React.Component {
@@ -22,12 +24,7 @@ class ActionsDropdown extends React.Component {
     requestQueue: PropTypes.bool.isRequired,
     handleOptionsChange: PropTypes.func.isRequired,
     disableFeeFineDetails: PropTypes.bool,
-    match: PropTypes.object,
   };
-
-  itemClick = () => {
-    this.props.handleOptionsChange();
-  }
 
   renderDropdownTrigger = (triggerRef, onToggle, aria) => (
     <IconButton icon="ellipsis" ref={triggerRef} onClick={onToggle} {...aria} />
@@ -44,7 +41,7 @@ class ActionsDropdown extends React.Component {
 
     const itemDetailsLink = `/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`;
     const loanPolicyLink = `/settings/circulation/loan-policies/${loan.loanPolicyId}`;
-    const buttonDisabled = !this.props.stripes.hasPerm('ui-users.feesfines.actions.all');
+    const buttonDisabled = !stripes.hasPerm('ui-users.feesfines.actions.all');
 
     return (
       <Popdown
@@ -98,8 +95,8 @@ class ActionsDropdown extends React.Component {
             >
               <Button
                 buttonStyle="dropdownItem"
-                onClick={(e) => { handleOptionsChange({ loan, action:'changeDueDate' }, e); }}
                 data-test-dropdown-content-change-due-date-button
+                onClick={(e) => { handleOptionsChange({ loan, action:'changeDueDate' }, e); }}
               >
                 <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
               </Button>
@@ -139,7 +136,10 @@ class ActionsDropdown extends React.Component {
             }}
             onSelectItem={handleOptionsChange}
           >
-            <Button buttonStyle="dropdownItem" disabled={disableFeeFineDetails}>
+            <Button
+              buttonStyle="dropdownItem"
+              disabled={disableFeeFineDetails}
+            >
               <FormattedMessage id="ui-users.loans.feeFineDetails" />
             </Button>
           </MenuItem>
@@ -151,11 +151,12 @@ class ActionsDropdown extends React.Component {
               }}
               onSelectItem={handleOptionsChange}
             >
-              <div data-test-dropdown-content-request-queue>
-                <Button buttonStyle="dropdownItem">
-                  <FormattedMessage id="ui-users.loans.details.requestQueue" />
-                </Button>
-              </div>
+              <Button
+                buttonStyle="dropdownItem"
+                data-test-dropdown-content-request-queue
+              >
+                <FormattedMessage id="ui-users.loans.details.requestQueue" />
+              </Button>
             </MenuItem>
           }
         </div>

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/Popdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/Popdown.js
@@ -51,6 +51,7 @@ const Popdown = ({ label, buttonProps, children, renderTrigger, portal }) => {
         isOpen={open}
         anchorRef={triggerRef}
         portal={portal ? portalEl : null}
+        overlayProps={{ onClick: e => { e.stopPropagation(); } }}
       >
         <RootCloseWrapper onRootClose={toggleMenu}>
           {children}

--- a/test/bigtest/interactors/open-loans.js
+++ b/test/bigtest/interactors/open-loans.js
@@ -41,6 +41,7 @@ import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/inter
   list = scoped('[data-test-open-loans-list]');
   requests = collection('[data-test-list-requests]');
   actionDropdowns = collection('[data-test-actions-dropdown]');
+  actionDropdownContainer = new Interactor('[class*=actionDropDown---]');
   actionDropdownRequestQueue = new Interactor('[data-test-dropdown-content-request-queue]');
   actionDropdownRenewButton = new Interactor('[data-test-dropdown-content-renew-button]');
   actionDropdownChangeDueDateButton = new Interactor('[data-test-dropdown-content-change-due-date-button]');

--- a/test/bigtest/tests/open-loans-test.js
+++ b/test/bigtest/tests/open-loans-test.js
@@ -108,13 +108,23 @@ describe('Open Loans', () => {
           expect(OpenLoansInteractor.actionDropdownRequestQueue.isPresent).to.be.true;
         });
 
-        describe('click request queue', () => {
+        describe('clicking on request queue dropdown item', () => {
           beforeEach(async () => {
-            await OpenLoansInteractor.actionDropdownRequestQueue.click('button');
+            await OpenLoansInteractor.actionDropdownRequestQueue.click();
           });
 
-          it('should be redirected to "requests"', function () {
+          it('should redirect to "requests"', function () {
             expect(this.location.pathname).to.to.equal(requestsPath);
+          });
+        });
+
+        describe('clicking on dropdown container', () => {
+          beforeEach(async () => {
+            await OpenLoansInteractor.actionDropdownContainer.click();
+          });
+
+          it('should not close the dropdown', function () {
+            expect(OpenLoansInteractor.actionDropdownContainer.isPresent).to.be.true;
           });
         });
       });


### PR DESCRIPTION
## Purpose

Prevent loan details opening upon click in loans action menu without selecting link in the scope of [UIU-1359](https://issues.folio.org/browse/UIU-1359).

## Screenshots

### Previous behavior
![prev](https://user-images.githubusercontent.com/40821852/70701513-26a23d80-1cd5-11ea-9364-28d2eeddb80c.gif)

### Current behavior
![current](https://user-images.githubusercontent.com/40821852/70704210-38d2aa80-1cda-11ea-8c65-50d29bd41154.gif)
