### PR TITLE
UIU-1410: Clear previous item data when open a new fee/fine form page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix navigation paths on cancel button click on loan details, open and closed loan lists pages. Refs UIU-1377.
 * Prevent loan details opening upon click in loans action menu without selecting link. Fixes UIU-1359.
 * Display correct user block on the edit form. Fixes UIU-1397.
+* Clear previous item data when open a new fee/fine form page. Fixes UIU-1410.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -47,14 +47,13 @@ class ChargeFeeFine extends React.Component {
       }),
     }).isRequired,
     stripes: PropTypes.object.isRequired,
-    handleAddRecords: PropTypes.func,
+
     okapi: PropTypes.object,
     selectedLoan: PropTypes.object,
     user: PropTypes.object,
-    onSubmit: PropTypes.func,
-    servicePointsIds: PropTypes.arrayOf(PropTypes.string),
-    defaultServicePointId: PropTypes.string,
     intl: intlShape.isRequired,
+    history: PropTypes.object,
+    location: PropTypes.object,
   };
 
   constructor(props) {

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -85,6 +85,8 @@ class ChargeForm extends React.Component {
     defaultServicePointId: PropTypes.string,
     location: PropTypes.object,
     history: PropTypes.object,
+    initialValues: PropTypes.object,
+    dispatch: PropTypes.func,
   }
 
   constructor(props) {

--- a/src/routes/ChargeFeesFinesContainer.js
+++ b/src/routes/ChargeFeesFinesContainer.js
@@ -53,6 +53,7 @@ class ChargeFeesFinesContainer extends React.Component {
     items: {
       type: 'okapi',
       records: 'items',
+      resourceShouldRefresh: true,
       path: (_q, _p, _r, _l, props) => {
         const { resources: { loanItem, activeRecord } } = props;
         if ((activeRecord && activeRecord.barcode) || (loanItem && loanItem.records.length > 0)) {


### PR DESCRIPTION
There is a lot of questionable code in fees/fines and I think we should consider reserving some time to refactor / clean it up. 

A quick fix here was to add a `resourceShouldRefresh` to make sure the items resource gets cleaned up.  