### PR TITLE
UIU-1412 Go back to user's accounts when clicking on cancel or 'x' from fee/fine form.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Display correct user block on the edit form. Fixes UIU-1397.
 * Clear previous item data when open a new fee/fine form page. Fixes UIU-1410.
 * Add record last updated and created back to manual patron block. Fixes UIU-1420.
+* Go back to user's accounts when clicking on cancel or `x` from fee/fine form. Fixes UIU-1412.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -87,6 +87,7 @@ class ChargeForm extends React.Component {
     history: PropTypes.object,
     initialValues: PropTypes.object,
     dispatch: PropTypes.func,
+    match: PropTypes.object,
   }
 
   constructor(props) {
@@ -161,9 +162,19 @@ class ChargeForm extends React.Component {
     }));
   }
 
-  render() {
+  goToAccounts = () => {
     const {
       history,
+      match: {
+        params: { id },
+      },
+    } = this.props;
+
+    history.push(`/users/${id}/accounts/open`);
+  }
+
+  render() {
+    const {
       user,
       dispatch,
       initialValues,
@@ -201,7 +212,7 @@ class ChargeForm extends React.Component {
 
     const lastMenu = (
       <PaneMenu>
-        <Button id="cancelCharge" onClick={() => { this.props.history.goBack(); }} style={mg}><FormattedMessage id="ui-users.feefines.modal.cancel" /></Button>
+        <Button id="cancelCharge" onClick={this.goToAccounts} style={mg}><FormattedMessage id="ui-users.feefines.modal.cancel" /></Button>
         <Button
           id="chargeAndPay"
           disabled={this.props.pristine || this.props.submitting || this.props.invalid}
@@ -225,7 +236,7 @@ class ChargeForm extends React.Component {
         <Pane
           defaultWidth="100%"
           dismissible
-          onClose={() => { history.goBack(); }}
+          onClose={this.goToAccounts}
           paneTitle={(
             <FormattedMessage id="ui-users.charge.title" />
           )}

--- a/test/bigtest/tests/charge-fee-fine-test.js
+++ b/test/bigtest/tests/charge-fee-fine-test.js
@@ -79,7 +79,7 @@ describe('Charge fee/fine', () => {
             });
 
             it('navigate to previous page', function () {
-              expect(this.location.pathname).to.equal(`/users/preview/${loan.userId}`);
+              expect(this.location.pathname).to.equal(`/users/${loan.userId}/accounts/open`);
             });
           });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1412

This still feels wrong in some situations. I think the best would be to turn the fee/fine form into a plugin as @zburke suggested.