### PR TITLE
UIU-1410: Refresh loan and loan items

### DIFF
--- a/src/routes/ChargeFeesFinesContainer.js
+++ b/src/routes/ChargeFeesFinesContainer.js
@@ -28,6 +28,7 @@ class ChargeFeesFinesContainer extends React.Component {
         return loanId ? `loan-storage/loans/${loanId}` : null;
       },
       clear: false,
+      resourceShouldRefresh: true,
       shouldRefresh: (resource, action, refresh) => {
         const { path } = action.meta;
         return refresh || (path && path.match(/link/));
@@ -35,7 +36,7 @@ class ChargeFeesFinesContainer extends React.Component {
     },
     loanItem: {
       type: 'okapi',
-      // path: 'inventory/items/%{activeRecord.itemId}'
+      resourceShouldRefresh: true,
       path: (_q, _p, _r, _l, props) => {
         const { resources: { loan, activeRecord } } = props;
         if ((activeRecord && activeRecord.itemId) || (loan && loan.records.length > 0)) {
@@ -43,7 +44,7 @@ class ChargeFeesFinesContainer extends React.Component {
           return itemId ? `inventory/items/${itemId}` : null;
         }
         return null;
-      }
+      },
     },
     curUserServicePoint: {
       type: 'okapi',


### PR DESCRIPTION
There were still some cases where `items` would get reloaded because of the stale data present in `loan` and `loanItems`. This PR should address it.

https://issues.folio.org/browse/UIU-1410

The code in `components/Accounts` is very very bad... 
 