### PR TITLE
UIU-1407 and UIU-1408 - Fees Fines check-all checkboxes not working.

### DIFF
--- a/src/components/Accounts/Actions/WarningModal.js
+++ b/src/components/Accounts/Actions/WarningModal.js
@@ -119,6 +119,11 @@ class WarningModal extends React.Component {
     };
   }
 
+  rowUpdater = (a) => {
+    const { checkedAccounts } = this.state;
+    return !!(checkedAccounts[a.id]);
+  }
+
   onClickContinue() {
     const { checkedAccounts } = this.state;
     const values = Object.values(checkedAccounts);
@@ -201,6 +206,7 @@ class WarningModal extends React.Component {
               sortOrder={sortOrder[0]}
               sortDirection={`${sortDirection[0]}ending`}
               contentData={accountOrdered}
+              rowUpdater={this.rowUpdater}
             />
           </Col>
         </Row>

--- a/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
+++ b/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
@@ -204,7 +204,7 @@ class ViewFeesFines extends React.Component {
     return {
       '  ': f => (
         <input
-          checked={accounts.find(a => a.id === f.id)}
+          checked={(accounts.findIndex(a => a.id === f.id) !== -1)}
           onClick={e => this.toggleItem(e, f)}
           type="checkbox"
         />
@@ -285,6 +285,12 @@ class ViewFeesFines extends React.Component {
       allChecked: !allChecked
     }));
   }
+
+  rowUpdater = (f) => {
+    const accounts = this.props.selectedAccounts;
+    return this.state.allChecked ||
+    (accounts.findIndex(a => a.id === f.id) !== -1);
+  };
 
   handleOptionsChange(itemMeta, e) {
     e.preventDefault();
@@ -439,6 +445,7 @@ class ViewFeesFines extends React.Component {
         sortOrder={sortOrder[0]}
         sortDirection={`${sortDirection[0]}ending`}
         onRowClick={this.onRowClick}
+        rowUpdater={this.rowUpdater}
       />
     );
   }


### PR DESCRIPTION
## Problem
Check-all checkboxes on Fees/Fines listings are not working!

There's a few things wrong here with Fees/Fines... I think this will need #1104 or similar to see the warning modal working properly.

## Approach
Used the `rowUpdater` prop of MCL to pass in the checked status.