### PR TITLE
UIU-1384: Replace "Fee/Fine History: Can create, edit and remove accounts" permission with "Users: Can create, edit and remove fees/fines" one for restricting access to the accounts history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Reset patronBlocks before refetching. Fixes UIU-1430 and UIU-1431.
 * Fix bug with wrong displaying of address type. Refs UIU-1404
 * Passing `notify` field to BE, when fee/fine is paying. Refs UIU-1413.
+* Replace "Fee/Fine History: Can create, edit and remove accounts" permission with "Users: Can create, edit and remove fees/fines" one for restricting access to the accounts history. Refs UIU-1384.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -15,14 +15,6 @@ export function getFullName(user) {
   return `${lastName}${firstName ? ', ' : ' '}${firstName}${middleName ? ' ' : ''}${middleName}`;
 }
 
-export function getRowURL(user) {
-  return `/users/view/${user.id}`;
-}
-
-export function isSubstringsInString(listSubStrings, testString) {
-  return new RegExp(listSubStrings.join('|')).test(testString);
-}
-
 export function eachPromise(arr, fn) {
   if (!Array.isArray(arr)) return Promise.reject(new Error('Array not found'));
   return arr.reduce((prev, cur) => (prev.then(() => fn(cur))), Promise.resolve());

--- a/src/index.js
+++ b/src/index.js
@@ -247,7 +247,7 @@ class UsersRouting extends React.Component {
               path={`${base}/:id/accounts/:accountstatus/charge`}
               exact
               render={(props) => (
-                <IfPermission perm="ui-users.accounts">
+                <IfPermission perm="ui-users.feesfines.actions.all">
                   <Routes.FeesFinesContainer {...props} />
                 </IfPermission>
               )}
@@ -255,7 +255,7 @@ class UsersRouting extends React.Component {
             <Route
               path={`${base}/:id/accounts/view/:accountid`}
               render={(props) => (
-                <IfPermission perm="ui-users.accounts">
+                <IfPermission perm="ui-users.feesfines.actions.all">
                   <Routes.AccountDetailsContainer {...props} />
                 </IfPermission>
               )}

--- a/src/index.js
+++ b/src/index.js
@@ -265,7 +265,7 @@ class UsersRouting extends React.Component {
               exact
               component={Routes.AccountsListingContainer}
               render={(props) => (
-                <IfPermission perm="ui-users.accounts">
+                <IfPermission perm="ui-users.feesfines.actions.all">
                   <Routes.AccountsListingContainer {...props} />
                 </IfPermission>
               )}

--- a/src/views/AccountsListing/AccountsListing.js
+++ b/src/views/AccountsListing/AccountsListing.js
@@ -156,7 +156,6 @@ class AccountsHistory extends React.Component {
     this.onChangeActions = this.onChangeActions.bind(this);
     this.onChangeSelected = this.onChangeSelected.bind(this);
     this.onChangeSelectedAccounts = this.onChangeSelectedAccounts.bind(this);
-    this.connectedViewFeesFines = props.stripes.connect(ViewFeesFines);
     this.connectedActions = props.stripes.connect(Actions);
 
     this.accounts = [];

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -495,7 +495,7 @@ class UserDetail extends React.Component {
                     {...this.props}
                   />
                 </IfPermission>
-                <IfPermission perm="ui-users.accounts">
+                <IfPermission perm="ui-users.feesfines.actions.all">
                   <UserAccounts
                     expanded={sections.accountsSection}
                     onToggle={this.handleSectionToggle}


### PR DESCRIPTION
## Purpose

Replace `Fee/Fine History: Can create, edit and remove accounts` permission with `Users: Can create, edit and remove fees/fines` one for restricting access to the account's history.

Dependency on `Fee/Fine History: Can create, edit and remove accounts` was introduced as a part of loans view permission ([UIU-1175](https://issues.folio.org/browse/UIU-1175)) in order to hide accounts accordion from the user details page and restrict the access to the accounts page. [According to Holly Mistlebauer](https://issues.folio.org/browse/UIU-1175?focusedCommentId=65556&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-65556) the `Fee/Fine History: Can create, edit and remove accounts` is stale permission and as an MVP the `Users: Can create, edit and remove fees/fines` one should be used instead.