### PR TITLE
UIU-1413: Add check if object has status field to avoid page crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Reset patronBlocks before refetching. Fixes UIU-1430 and UIU-1431.
 * Fix bug with wrong displaying of address type. Refs UIU-1404
 * Passing `notify` field to BE, when fee/fine is paying. Refs UIU-1413.
+* Fix page crash when a multiple fee/fine payment is made. Refs UIU-1413.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/Accounts/Actions/Actions.js
+++ b/src/components/Accounts/Actions/Actions.js
@@ -469,7 +469,10 @@ class Actions extends React.Component {
     const waives = _.get(resources, ['waives', 'records'], []);
     const transfers = _.get(resources, ['transfers', 'records'], []);
     const settings = _.get(resources, ['commentRequired', 'records', 0], {});
-    const warning = accounts.filter(a => a.status && a.status.name === 'Closed').length !== 0 && (actions.regular || actions.waiveMany || actions.transferMany) && params.accountstatus;
+    const closedAccounts = accounts.filter(a => a.status && a.status.name === 'Closed');
+    const isWarning = closedAccounts.length !== 0
+        && (actions.regular || actions.waiveMany || actions.transferMany)
+        && params.accountstatus;
     const warningModalLabelId = actions.regular
       ? 'ui-users.accounts.actions.payFeeFine'
       : actions.waiveMany
@@ -482,9 +485,9 @@ class Actions extends React.Component {
     const initialValues = { ownerId, amount, notify: true };
     const modals = [
       { action: 'payment', item: actions.pay, label: 'nameMethod', data: payments, comment: 'paid', open: actions.pay || (actions.regular && accounts.length === 1) },
-      { action: 'payment', form: 'payment-many-modal', label: 'nameMethod', accounts, data: payments, comment: 'paid', open: actions.regular && !warning && accounts.length > 1 },
-      { action: 'waive', item: actions.waiveModal, label: 'nameReason', data: waives, comment: 'waived', open: actions.waiveModal || (actions.waiveMany && !warning) },
-      { action: 'transfer', item: actions.transferModal, label: 'accountName', data: transfers, comment: 'transferredManually', open: actions.transferModal || (actions.transferMany && !warning) }
+      { action: 'payment', form: 'payment-many-modal', label: 'nameMethod', accounts, data: payments, comment: 'paid', open: actions.regular && !isWarning && accounts.length > 1 },
+      { action: 'waive', item: actions.waiveModal, label: 'nameReason', data: waives, comment: 'waived', open: actions.waiveModal || (actions.waiveMany && !isWarning) },
+      { action: 'transfer', item: actions.transferModal, label: 'accountName', data: transfers, comment: 'transferredManually', open: actions.transferModal || (actions.transferMany && !isWarning) }
     ];
 
     return (
@@ -493,7 +496,7 @@ class Actions extends React.Component {
           {label => (
             <WarningModal
               id="actions-warning-modal"
-              open={warning && !submitting}
+              open={isWarning && !submitting}
               accounts={accounts}
               onChangeAccounts={this.onChangeAccounts}
               stripes={stripes}

--- a/src/components/Accounts/Actions/Actions.js
+++ b/src/components/Accounts/Actions/Actions.js
@@ -469,8 +469,8 @@ class Actions extends React.Component {
     const waives = _.get(resources, ['waives', 'records'], []);
     const transfers = _.get(resources, ['transfers', 'records'], []);
     const settings = _.get(resources, ['commentRequired', 'records', 0], {});
-    const closedAccounts = accounts.filter(a => a.status && a.status.name === 'Closed');
-    const isWarning = closedAccounts.length !== 0
+    const hasClosedAccounts = accounts.some(a => a.status && a.status.name === 'Closed');
+    const isWarning = hasClosedAccounts
         && (actions.regular || actions.waiveMany || actions.transferMany)
         && params.accountstatus;
     const warningModalLabelId = actions.regular

--- a/src/components/Accounts/Actions/Actions.js
+++ b/src/components/Accounts/Actions/Actions.js
@@ -469,7 +469,7 @@ class Actions extends React.Component {
     const waives = _.get(resources, ['waives', 'records'], []);
     const transfers = _.get(resources, ['transfers', 'records'], []);
     const settings = _.get(resources, ['commentRequired', 'records', 0], {});
-    const warning = accounts.filter(a => a.status.name === 'Closed').length !== 0 && (actions.regular || actions.waiveMany || actions.transferMany) && params.accountstatus;
+    const warning = accounts.filter(a => a.status && a.status.name === 'Closed').length !== 0 && (actions.regular || actions.waiveMany || actions.transferMany) && params.accountstatus;
     const warningModalLabelId = actions.regular
       ? 'ui-users.accounts.actions.payFeeFine'
       : actions.waiveMany

--- a/src/components/Accounts/Actions/WarningModal.js
+++ b/src/components/Accounts/Actions/WarningModal.js
@@ -173,7 +173,7 @@ class WarningModal extends React.Component {
     };
 
     const values = Object.values(checkedAccounts);
-    const checkedClosed = values.filter(a => a.status && a.status.name === 'Closed');
+    const hasClosedAccounts = values.some(a => a.status && a.status.name === 'Closed');
 
     return (
       <Modal
@@ -207,7 +207,7 @@ class WarningModal extends React.Component {
         <Row end="xs">
           <Col xs>
             <Button id="warningTransferCancel" onClick={this.props.onClose}><FormattedMessage id="ui-users.feefines.modal.cancel" /></Button>
-            <Button id="warningTransferContinue" disabled={checkedClosed.length > 0 || values.length === 0} buttonStyle="primary" onClick={this.onClickContinue}><FormattedMessage id="ui-users.feefines.modal.submit" /></Button>
+            <Button id="warningTransferContinue" disabled={hasClosedAccounts || values.length === 0} buttonStyle="primary" onClick={this.onClickContinue}><FormattedMessage id="ui-users.feefines.modal.submit" /></Button>
           </Col>
         </Row>
       </Modal>

--- a/src/components/Accounts/Actions/WarningModal.js
+++ b/src/components/Accounts/Actions/WarningModal.js
@@ -136,7 +136,7 @@ class WarningModal extends React.Component {
     } = this.props;
 
     const selectedItemsAmount = accounts.length;
-    const closedItemsAmount = accounts.filter(a => a.status.name === 'Closed').length;
+    const closedItemsAmount = accounts.filter(a => a.status && a.status.name === 'Closed').length;
     const action = label === formatMessage({ id: 'ui-users.accounts.actions.payFeeFine' })
       ? <FormattedMessage id="ui-users.accounts.actions.warning.paymentAction" />
       : (label === formatMessage({ id: 'ui-users.accounts.actions.waiveFeeFine' }))
@@ -173,7 +173,7 @@ class WarningModal extends React.Component {
     };
 
     const values = Object.values(checkedAccounts);
-    const checkedClosed = values.filter(a => a.status.name === 'Closed');
+    const checkedClosed = values.filter(a => a.status && a.status.name === 'Closed');
 
     return (
       <Modal


### PR DESCRIPTION
### Purpose
Prevent page crash when multiple fee/fine items is paying 

---

### Issue
https://issues.folio.org/browse/UIU-1413

--- 

### Screenshot
![image](https://user-images.githubusercontent.com/55694637/71515173-b4bc1d80-28aa-11ea-8f02-9359636b559b.png)
