### PR TITLE
UIU-1408 correctly handle MCL checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.26.1 (IN PROGRESS)
+
+* Correctly handle checkboxes in MCLs. Refs UIU-1408.
+
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)
 

--- a/src/components/Accounts/Actions/WarningModal.js
+++ b/src/components/Accounts/Actions/WarningModal.js
@@ -154,6 +154,10 @@ class WarningModal extends React.Component {
     );
   }
 
+  isSelected = ({ item }) => (
+    this.state.allChecked || !!this.state.checkedAccounts[item.id]
+  );
+
   render() {
     const { formatMessage } = this.props.intl;
     const {
@@ -201,6 +205,7 @@ class WarningModal extends React.Component {
               sortOrder={sortOrder[0]}
               sortDirection={`${sortDirection[0]}ending`}
               contentData={accountOrdered}
+              isSelected={this.isSelected}
             />
           </Col>
         </Row>


### PR DESCRIPTION
Checkboxes in the MCL in the `<WarningModal>` did not correctly reflect
their state because no `isSelected` function was passed to the MCL.

Refs [UIU-1408](https://issues.folio.org/browse/UIU-1408)