### PR TITLE
UIU-1420 restore metadata to manual patron block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.26.1 (IN PROGRESS)
+
+* Add record last updated and created back to manual patron block. Fixes UIU-1420.
+
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)
 

--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -70,6 +70,7 @@ class PatronBlockForm extends React.Component {
     intl: intlShape.isRequired,
     stripes: PropTypes.object,
     currentValues: PropTypes.object,
+    initialValues: PropTypes.object,
   };
 
   constructor(props) {
@@ -146,6 +147,7 @@ class PatronBlockForm extends React.Component {
       intl,
       params,
       selectedItem,
+      initialValues,
       user = {},
       currentValues: {
         borrowing,
@@ -182,10 +184,10 @@ class PatronBlockForm extends React.Component {
                   onToggle={this.handleSectionToggle}
                   open={this.state.sections.blockInformationSection}
                 >
-                  {!_.isEmpty(selectedItem) ?
+                  {!_.isEmpty(initialValues) ?
                     <Row>
                       <Col xs={12} sm={10} md={7} lg={5}>
-                        <this.connectedViewMetaData metadata={selectedItem.metadata} />
+                        <this.connectedViewMetaData metadata={initialValues.metadata} />
                       </Col>
                     </Row> : ''
                 }

--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -62,7 +62,6 @@ class PatronBlockForm extends React.Component {
     submitting: PropTypes.bool,
     invalid: PropTypes.bool,
     params: PropTypes.object,
-    selectedItem: PropTypes.object,
     onDeleteItem: PropTypes.func,
     onClose: PropTypes.func,
     handleSubmit: PropTypes.func.isRequired,
@@ -146,7 +145,6 @@ class PatronBlockForm extends React.Component {
     const {
       intl,
       params,
-      selectedItem,
       initialValues,
       user = {},
       currentValues: {

--- a/src/components/PatronBlock/PatronBlockLayer.js
+++ b/src/components/PatronBlock/PatronBlockLayer.js
@@ -161,7 +161,6 @@ class PatronBlockLayer extends React.Component {
           onDeleteItem={this.showConfirm}
           user={user}
           onSubmit={this.onSubmit}
-          selectedItem={this.selectedItem}
           initialValues={initialValues}
           params={params}
         />


### PR DESCRIPTION
Derive metadata from `initialValues` instead of `selectedItem`, which was factored away (but not completely, hence this bug). 