### PR TITLE
UIU-1412 return to user-profile when closing modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Reset patronBlocks before refetching. Fixes UIU-1430 and UIU-1431.
 * Add record last updated and created back to manual patron block. Fixes UIU-1420.
+* Go back to user's accounts when clicking on cancel or `x` from fee/fine form. Fixes UIU-1412.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -85,6 +85,9 @@ class ChargeForm extends React.Component {
     defaultServicePointId: PropTypes.string,
     location: PropTypes.object,
     history: PropTypes.object,
+    initialValues: PropTypes.object,
+    dispatch: PropTypes.func,
+    match: PropTypes.object,
   }
 
   constructor(props) {
@@ -159,9 +162,19 @@ class ChargeForm extends React.Component {
     }));
   }
 
-  render() {
+  goToAccounts = () => {
     const {
       history,
+      match: {
+        params: { id },
+      },
+    } = this.props;
+
+    history.push(`/users/${id}/accounts/open`);
+  }
+
+  render() {
+    const {
       user,
       dispatch,
       initialValues,
@@ -199,7 +212,7 @@ class ChargeForm extends React.Component {
 
     const lastMenu = (
       <PaneMenu>
-        <Button id="cancelCharge" onClick={() => { this.props.history.goBack(); }} style={mg}><FormattedMessage id="ui-users.feefines.modal.cancel" /></Button>
+        <Button id="cancelCharge" onClick={this.goToAccounts} style={mg}><FormattedMessage id="ui-users.feefines.modal.cancel" /></Button>
         <Button
           id="chargeAndPay"
           disabled={this.props.pristine || this.props.submitting || this.props.invalid}
@@ -223,7 +236,7 @@ class ChargeForm extends React.Component {
         <Pane
           defaultWidth="100%"
           dismissible
-          onClose={() => { history.goBack(); }}
+          onClose={this.goToAccounts}
           paneTitle={(
             <FormattedMessage id="ui-users.charge.title" />
           )}

--- a/src/views/AccountsListing/AccountsListing.js
+++ b/src/views/AccountsListing/AccountsListing.js
@@ -483,7 +483,7 @@ class AccountsHistory extends React.Component {
           defaultWidth="100%"
           dismissible
           padContent={false}
-          onClose={() => { history.goBack(); }}
+          onClose={() => { history.push(`/users/preview/${params.id}`); }}
           paneTitle={(
             <FormattedMessage id="ui-users.accounts.title">
               {(title) => (

--- a/test/bigtest/tests/charge-fee-fine-test.js
+++ b/test/bigtest/tests/charge-fee-fine-test.js
@@ -79,7 +79,7 @@ describe('Charge fee/fine', () => {
             });
 
             it('navigate to previous page', function () {
-              expect(this.location.pathname).to.equal(`/users/preview/${loan.userId}`);
+              expect(this.location.pathname).to.equal(`/users/${loan.userId}/accounts/open`);
             });
           });
 

--- a/test/bigtest/tests/user-proxy-edit-test.js
+++ b/test/bigtest/tests/user-proxy-edit-test.js
@@ -1,5 +1,6 @@
 import faker from 'faker';
 import {
+  before,
   beforeEach,
   describe,
   it,
@@ -83,7 +84,7 @@ describe('User Edit: Proxy/Sponsor', function () {
         });
 
         describe('Expire the relationship', () => {
-          beforeEach(async () => {
+          before(async () => {
             await UserFormPage.proxySection.expirationDate.fillAndBlur(faker.date.past(1).toJSON().substring(0, 10));
           });
 
@@ -102,7 +103,7 @@ describe('User Edit: Proxy/Sponsor', function () {
         });
 
         describe('Expire the user', () => {
-          beforeEach(async () => {
+          before(async () => {
             await UserFormPage.expirationDate.fillAndBlur('2019-01-01');
           });
 
@@ -147,7 +148,7 @@ describe('User Edit: Proxy/Sponsor', function () {
       });
 
       describe('Find an expired sponsor', () => {
-        beforeEach(async () => {
+        before(async () => {
           await findUserPlugin.modal.searchField.fill('expired');
           await findUserPlugin.modal.searchButton.click();
           await findUserPlugin.modal.instances(0).click();
@@ -172,7 +173,7 @@ describe('User Edit: Proxy/Sponsor', function () {
       });
 
       describe('Adding user as own sponsor should fail', () => {
-        beforeEach(async () => {
+        before(async () => {
           await findUserPlugin.modal.searchField.fill('self');
           await findUserPlugin.modal.searchButton.click();
           await findUserPlugin.modal.instances(0).click();


### PR DESCRIPTION
Go back to user's accounts when clicking on cancel or `x` from fee/fine form and accounts listing. 

Fixes [UIU-1412](https://issues.folio.org/browse/UIU-1412)