### PR TITLE
UIU-1438: Omit 'notify' field upon creating fee/fine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Replace "Fee/Fine History: Can create, edit and remove accounts" permission with "Users: Can create, edit and remove fees/fines" one for restricting access to the accounts history. Refs UIU-1384.
 * Fix page crash when a multiple fee/fine payment is made. Refs UIU-1413.
 * Refactor open and closed loans lists to use <Dropdown /> from stripes-components
+* Omit 'notify' field upon creating fee/fine in order to prevent backend error. Fixes UIU-1438.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -285,7 +285,8 @@ class ChargeFeeFine extends React.Component {
       }
       this.type.paymentStatus.name = paymentStatus;
       this.props.mutator.activeRecord.update({ id: this.type.id });
-      return this.props.mutator.accounts.PUT(this.type);
+
+      return this.props.mutator.accounts.PUT(_.omit(this.type, ['notify']));
     })
       .then(() => this.newAction({ paymentMethod: values.method }, this.type.id,
         this.type.paymentStatus.name, values.amount,


### PR DESCRIPTION
## Purpose

Omit 'notify' field upon creating fee/fine in order to prevent backend error in the scope of [UIU-1438](https://issues.folio.org/browse/UIU-1438).

## Screenshot
<img width="1629" alt="Error" src="https://user-images.githubusercontent.com/40821852/71724425-f0ba2a00-2e38-11ea-9c60-734dd7ed8b25.png">
