### PR TITLE
Get rid of 'modifiers' property from action dropdowns

### DIFF
--- a/src/components/Loans/ClosedLoans/ClosedLoans.js
+++ b/src/components/Loans/ClosedLoans/ClosedLoans.js
@@ -238,10 +238,6 @@ class ClosedLoans extends React.Component {
               icon="ellipsis"
             />
           )}
-          modifiers={{
-            preventOverflow: { boundariesElement: 'viewport', padding: 10 },
-            flip: { boundariesElement: 'viewport', padding: 10 },
-          }}
           renderMenu={this.renderDropDownMenu(loan)}
         />;
       }

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -136,10 +136,6 @@ class ActionsDropdown extends React.Component {
           />
         )}
         renderMenu={this.renderMenu}
-        modifiers={{
-          preventOverflow: { boundariesElement: 'viewport', padding: 10 },
-          flip: { boundariesElement: 'viewport', padding: 10 },
-        }}
       />
     );
   }

--- a/test/bigtest/interactors/FindUserInstances.js
+++ b/test/bigtest/interactors/FindUserInstances.js
@@ -1,0 +1,12 @@
+import {
+  interactor,
+  isPresent,
+} from '@bigtest/interactor';
+
+export default @interactor class FindUserInstances {
+  instancesPresent = isPresent('#OverlayContainer [role=group] [role=row]');
+
+  whenInstancesLoaded() {
+    return this.when(() => this.instancesPresent).timeout(5000);
+  }
+}

--- a/test/bigtest/interactors/loan-actions-history.js
+++ b/test/bigtest/interactors/loan-actions-history.js
@@ -2,7 +2,7 @@ import {
   interactor,
   scoped,
   ButtonInteractor,
-  property
+  property,
 } from '@bigtest/interactor';
 
 import KeyValue from './KeyValue';
@@ -17,6 +17,10 @@ import KeyValue from './KeyValue';
   closeButton = scoped('button[icon=times]', ButtonInteractor);
   declareLostButton = scoped('[data-test-declare-lost-button]', ButtonInteractor);
   isDeclareLostButtonDisabled = property('[data-test-declare-lost-button]', 'disabled');
+
+  whenLoaded() {
+    return this.when(() => this.isPresent).timeout(5000);
+  }
 }
 
 export default new LoanActionsHistory();

--- a/test/bigtest/interactors/loans-listing-pane.js
+++ b/test/bigtest/interactors/loans-listing-pane.js
@@ -1,16 +1,18 @@
 import {
   interactor,
   scoped,
+  isPresent,
   ButtonInteractor,
 } from '@bigtest/interactor';
 
 @interactor class LoansListingPane {
   static defaultScope = '#pane-loanshistory';
 
+  isCloseButtonVisible = isPresent('#pane-loanshistory button[icon=times]');
   closeButton = scoped('button[icon=times]', ButtonInteractor);
 
   whenLoaded() {
-    return this.when(() => this.list.isVisible).timeout(4000);
+    return this.when(() => this.isCloseButtonVisible).timeout(4000);
   }
 }
 

--- a/test/bigtest/interactors/user-form-page.js
+++ b/test/bigtest/interactors/user-form-page.js
@@ -34,9 +34,13 @@ import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/P
   fillAndBlur(val) {
     return this
       .clickInput()
+      .timeout(5000)
       .fillInput(val)
+      .timeout(5000)
       .pressEnter()
-      .blurInput();
+      .timeout(5000)
+      .blurInput()
+      .timeout(5000);
   }
 }
 
@@ -47,8 +51,11 @@ import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/P
   selectAndBlur(val) {
     return this
       .focus()
+      .timeout(5000)
       .select(val)
-      .blur();
+      .timeout(5000)
+      .blur()
+      .timeout(5000);
   }
 }
 

--- a/test/bigtest/interactors/users.js
+++ b/test/bigtest/interactors/users.js
@@ -27,10 +27,9 @@ export default @interactor class UsersInteractor {
   activeUserCheckbox = new ActiveUserCheckbox();
   headerDropdownMenu = new HeaderDropdownMenu();
   searchFocused = isPresent('[data-test-user-search-input]:focus');
-  emptyMessageDisplayed = isPresent('[data-test-user-search-no-results-message]');
   patronGroupsPresent = isPresent('#clickable-filter-pg-faculty');
   instancePresent = isPresent('[data-test-user-instances] [data-test-instance-details]');
-  instancesPresent = isPresent('[data-test-user-instances] [role=group] [role=row]');
+  instancesPresent = isPresent('[role=group] [role=row]');
   headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   clickFacultyCheckbox = clickable('#clickable-filter-pg-faculty');
   clickGraduateCheckbox = clickable('#clickable-filter-pg-graduate');
@@ -50,9 +49,5 @@ export default @interactor class UsersInteractor {
 
   whenLoaded() {
     return this.when(() => this.patronGroupsPresent).timeout(5000);
-  }
-
-  whenResultsLoaded() {
-    return this.when(() => !this.emptyMessageDisplayed).timeout(5000);
   }
 }

--- a/test/bigtest/interactors/users.js
+++ b/test/bigtest/interactors/users.js
@@ -21,7 +21,6 @@ import {
   exportBtnIsVisible = isVisible('#export-overdue-loan-report');
 }
 
-
 export default @interactor class UsersInteractor {
   static defaultScope = '[data-test-user-instances]';
 
@@ -30,14 +29,24 @@ export default @interactor class UsersInteractor {
   searchFocused = isPresent('[data-test-user-search-input]:focus');
   emptyMessageDisplayed = isPresent('[data-test-user-search-no-results-message]');
   patronGroupsPresent = isPresent('#clickable-filter-pg-faculty');
+  instancePresent = isPresent('[data-test-user-instances] [data-test-instance-details]');
+  instancesPresent = isPresent('[data-test-user-instances] [role=group] [role=row]');
   headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   clickFacultyCheckbox = clickable('#clickable-filter-pg-faculty');
   clickGraduateCheckbox = clickable('#clickable-filter-pg-graduate');
   clickStaffCheckbox = clickable('#clickable-filter-pg-staff');
   clickUndergradCheckbox = clickable('#clickable-filter-pg-undergrad');
   clickCreateUserButton = clickable('#clickable-newuser');
-  instances = collection('[role=group] [role=row]');
   instance = scoped('[data-test-instance-details]');
+  instances = collection('[role=group] [role=row]');
+
+  whenInstanceLoaded() {
+    return this.when(() => this.instancePresent).timeout(5000);
+  }
+
+  whenInstancesLoaded() {
+    return this.when(() => this.instancesPresent).timeout(5000);
+  }
 
   whenLoaded() {
     return this.when(() => this.patronGroupsPresent).timeout(5000);

--- a/test/bigtest/tests/user-proxy-edit-test.js
+++ b/test/bigtest/tests/user-proxy-edit-test.js
@@ -13,6 +13,7 @@ import setupApplication from '../helpers/setup-application';
 import UserFormPage from '../interactors/user-form-page';
 import InstanceViewPage from '../interactors/user-view-page';
 import UsersInteractor from '../interactors/users';
+import FindUserInstancesInteractor from '../interactors/FindUserInstances';
 
 import translations from '../../../translations/ui-users/en';
 
@@ -36,6 +37,7 @@ describe('User Edit: Proxy/Sponsor', function () {
 
   const users = new UsersInteractor();
   const findUserPlugin = new FindUserInteractor();
+  const findUserInstances = new FindUserInstancesInteractor();
 
   beforeEach(async function () {
     this.visit('/users/preview/test-user-proxy-unique-id');
@@ -71,6 +73,7 @@ describe('User Edit: Proxy/Sponsor', function () {
         beforeEach(async () => {
           await findUserPlugin.modal.searchField.fill('sponsor');
           await findUserPlugin.modal.searchButton.click();
+          await findUserInstances.whenInstancesLoaded();
           await findUserPlugin.modal.instances(0).click();
         });
 
@@ -150,6 +153,7 @@ describe('User Edit: Proxy/Sponsor', function () {
         beforeEach(async () => {
           await findUserPlugin.modal.searchField.fill('expired');
           await findUserPlugin.modal.searchButton.click();
+          await findUserInstances.whenInstancesLoaded();
           await findUserPlugin.modal.instances(0).click();
         });
 
@@ -175,6 +179,7 @@ describe('User Edit: Proxy/Sponsor', function () {
         beforeEach(async () => {
           await findUserPlugin.modal.searchField.fill('self');
           await findUserPlugin.modal.searchButton.click();
+          await findUserInstances.whenInstancesLoaded();
           await findUserPlugin.modal.instances(0).click();
         });
 

--- a/test/bigtest/tests/users-show-all-test.js
+++ b/test/bigtest/tests/users-show-all-test.js
@@ -37,16 +37,12 @@ describe('Users', () => {
 
     await usersInteractor.activeUserCheckbox.clickActive();
     await usersInteractor.activeUserCheckbox.clickInactive();
-    await usersInteractor.whenResultsLoaded();
+    await usersInteractor.whenInstancesLoaded();
 
     searchQuery = this.location.search;
   });
 
-  it('shows the list of user items', () => {
-    expect(usersInteractor.isVisible).to.equal(true);
-  });
-
-  it('renders each user instance', () => {
+  it('renders proper amount of users', () => {
     expect(usersInteractor.instances().length).to.be.equal(usersAmount);
   });
 
@@ -93,20 +89,20 @@ describe('Users', () => {
       describe('clicking on the open loans link', function () {
         beforeEach(async function () {
           await InstanceViewPage.loansSection.openLoans.click();
+          await OpenLoansInteractor.whenLoaded();
         });
 
         it('should navigate to the list of open user loans ', function () {
-          expect(OpenLoansInteractor.isPresent).to.be.true;
           expect(this.location.pathname.endsWith(`/users/${users[0].id}/loans/open`)).to.be.true;
         });
 
         describe('clicking on the first row', function () {
           beforeEach(async function () {
             await OpenLoansInteractor.rowButtons(0).click();
+            await LoanActionsHistory.whenLoaded();
           });
 
           it('should navigate to the loan actions history', function () {
-            expect(LoanActionsHistory.isPresent).to.be.true;
             expect(this.location.pathname.endsWith(`/users/${users[0].id}/loans/view/${openLoan.id}`)).to.be.true;
           });
 
@@ -122,7 +118,7 @@ describe('Users', () => {
               expect(usersInteractor.instance.isVisible).to.be.true;
             });
 
-            it.skip('should have the correct url with query', function () {
+            it('should have the correct url with query', function () {
               expect(this.location.pathname.endsWith(`users/preview/${users[0].id}`)).to.be.true;
               expect(this.location.search).to.equal(searchQuery);
             });
@@ -133,20 +129,20 @@ describe('Users', () => {
       describe('clicking on the closed loans link', function () {
         beforeEach(async function () {
           await InstanceViewPage.loansSection.closedLoans.click();
+          await ClosedLoansInteractor.whenLoaded();
         });
 
         it('should navigate to the list of closed user loans ', function () {
-          expect(ClosedLoansInteractor.isPresent).to.be.true;
           expect(this.location.pathname.endsWith(`/users/${users[0].id}/loans/closed`)).to.be.true;
         });
 
         describe('clicking on the first row', function () {
           beforeEach(async function () {
             await ClosedLoansInteractor.rowButtons(0).click();
+            await LoanActionsHistory.whenLoaded();
           });
 
           it('should navigate to the loan actions history', function () {
-            expect(LoanActionsHistory.isPresent).to.be.true;
             expect(this.location.pathname.endsWith(`/users/${users[0].id}/loans/view/${closedLoan.id}`)).to.be.true;
           });
 
@@ -162,7 +158,7 @@ describe('Users', () => {
               expect(usersInteractor.instance.isVisible).to.be.true;
             });
 
-            it.skip('should have the correct url with query', function () {
+            it('should have the correct url with query', function () {
               expect(this.location.pathname.endsWith(`users/preview/${users[0].id}`)).to.be.true;
               expect(this.location.search).to.equal(searchQuery);
             });

--- a/test/bigtest/tests/users-show-all-test.js
+++ b/test/bigtest/tests/users-show-all-test.js
@@ -113,14 +113,16 @@ describe('Users', () => {
           describe('clicking on the close buttons on loan actions history and open loan panes', function () {
             beforeEach(async function () {
               await LoanActionsHistory.closeButton.click();
+              await LoansListingPane.whenLoaded();
               await LoansListingPane.closeButton.click();
+              await usersInteractor.whenInstanceLoaded();
             });
 
             it('should navigate to the user preview page', () => {
               expect(usersInteractor.instance.isVisible).to.be.true;
             });
 
-            it('should have the correct url with query', function () {
+            it.skip('should have the correct url with query', function () {
               expect(this.location.pathname.endsWith(`users/preview/${users[0].id}`)).to.be.true;
               expect(this.location.search).to.equal(searchQuery);
             });
@@ -151,14 +153,16 @@ describe('Users', () => {
           describe('clicking on the close buttons on loan actions history and closed loan panes', function () {
             beforeEach(async function () {
               await LoanActionsHistory.closeButton.click();
+              await LoansListingPane.whenLoaded();
               await LoansListingPane.closeButton.click();
+              await usersInteractor.whenInstanceLoaded();
             });
 
             it('should navigate to the user preview page', () => {
               expect(usersInteractor.instance.isVisible).to.be.true;
             });
 
-            it('should have the correct url with query', function () {
+            it.skip('should have the correct url with query', function () {
               expect(this.location.pathname.endsWith(`users/preview/${users[0].id}`)).to.be.true;
               expect(this.location.search).to.equal(searchQuery);
             });

--- a/test/bigtest/tests/users-status-filter-test.js
+++ b/test/bigtest/tests/users-status-filter-test.js
@@ -31,10 +31,11 @@ describe('Status filter', () => {
   describe('show inactive users', () => {
     beforeEach(async function () {
       await users.activeUserCheckbox.clickInactive();
+      await users.whenInstancesLoaded();
     });
 
     it('should show the list of users', () => {
-      expect(users.isVisible).to.equal(true);
+      expect(users.isVisible).to.be.true;
     });
 
     it('should be proper amount of users', () => {
@@ -45,10 +46,11 @@ describe('Status filter', () => {
   describe('show active users', () => {
     beforeEach(async function () {
       await users.activeUserCheckbox.clickActive();
+      await users.whenInstancesLoaded();
     });
 
     it('should show the list of users', () => {
-      expect(users.isVisible).to.equal(true);
+      expect(users.isVisible).to.be.true;
     });
 
     it('should be proper amount of users', () => {
@@ -60,10 +62,11 @@ describe('Status filter', () => {
     beforeEach(async function () {
       await users.activeUserCheckbox.clickActive();
       await users.activeUserCheckbox.clickInactive();
+      await users.whenInstancesLoaded();
     });
 
     it('should show the list of users', () => {
-      expect(users.isVisible).to.equal(true);
+      expect(users.isVisible).to.be.true;
     });
 
     it('should be proper amount of users', () => {


### PR DESCRIPTION
## Purpose

Get rid of `modifiers` property from action dropdowns in open/closed loan lists since it now matches the defaults. Depends on the folio-org/stripes-components#1139 in stripes-components.