### PR TITLE
UIU-1412 show user details when closing modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 2.26.2 (IN PROGRESS)
+
+* Go back to user's accounts when clicking on cancel or `x` from fee/fine form. Fixes UIU-1412.
+
 ## [2.26.1](https://github.com/folio-org/ui-users/tree/v2.26.1) (2020-01-06)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v2.26.1)
 
@@ -9,7 +13,6 @@
 * Display correct user block on the edit form. Fixes UIU-1397 (and UIU-1393).
 * Clear previous item data when open a new fee/fine form page. Fixes UIU-1410.
 * Add record last updated and created back to manual patron block. Fixes UIU-1420.
-* Go back to user's accounts when clicking on cancel or `x` from fee/fine form. Fixes UIU-1412.
 * Reset patronBlocks before refetching. Fixes UIU-1430 and UIU-1431.
 * Fix bug with wrong displaying of address type. Refs UIU-1404
 * Correctly handle checkboxes in fees/fines MCLs. Refs UIU-1407, UIU-1408.

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -87,6 +87,7 @@ class ChargeForm extends React.Component {
     history: PropTypes.object,
     initialValues: PropTypes.object,
     dispatch: PropTypes.func,
+    match: PropTypes.object,
   }
 
   constructor(props) {
@@ -161,9 +162,19 @@ class ChargeForm extends React.Component {
     }));
   }
 
-  render() {
+  goToAccounts = () => {
     const {
       history,
+      match: {
+        params: { id },
+      },
+    } = this.props;
+
+    history.push(`/users/${id}/accounts/open`);
+  }
+
+  render() {
+    const {
       user,
       dispatch,
       initialValues,
@@ -201,7 +212,7 @@ class ChargeForm extends React.Component {
 
     const lastMenu = (
       <PaneMenu>
-        <Button id="cancelCharge" onClick={() => { this.props.history.goBack(); }} style={mg}><FormattedMessage id="ui-users.feefines.modal.cancel" /></Button>
+        <Button id="cancelCharge" onClick={this.goToAccounts} style={mg}><FormattedMessage id="ui-users.feefines.modal.cancel" /></Button>
         <Button
           id="chargeAndPay"
           disabled={this.props.pristine || this.props.submitting || this.props.invalid}
@@ -225,7 +236,7 @@ class ChargeForm extends React.Component {
         <Pane
           defaultWidth="100%"
           dismissible
-          onClose={() => { history.goBack(); }}
+          onClose={this.goToAccounts}
           paneTitle={(
             <FormattedMessage id="ui-users.charge.title" />
           )}

--- a/src/views/AccountsListing/AccountsListing.js
+++ b/src/views/AccountsListing/AccountsListing.js
@@ -483,7 +483,7 @@ class AccountsHistory extends React.Component {
           defaultWidth="100%"
           dismissible
           padContent={false}
-          onClose={() => { history.goBack(); }}
+          onClose={() => { history.push(`/users/preview/${params.id}`); }}
           paneTitle={(
             <FormattedMessage id="ui-users.accounts.title">
               {(title) => (

--- a/test/bigtest/tests/charge-fee-fine-test.js
+++ b/test/bigtest/tests/charge-fee-fine-test.js
@@ -79,7 +79,7 @@ describe('Charge fee/fine', () => {
             });
 
             it('navigate to previous page', function () {
-              expect(this.location.pathname).to.equal(`/users/preview/${loan.userId}`);
+              expect(this.location.pathname).to.equal(`/users/${loan.userId}/accounts/open`);
             });
           });
 


### PR DESCRIPTION
When closing an account listing or fee-fine form, return to the user-details pane. Previously, the close-handler used `history.goBack()`, which could cause a navigation loop in some circumstances. 

Refs [UIU-1412](https://issues.folio.org/browse/UIU-1412)