### PR TITLE
UIU-1202: Add UI to mark items Declared lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Refactor open and closed loans lists to use <Dropdown /> from stripes-components
 * Omit 'notify' field upon creating fee/fine in order to prevent backend error. Fixes UIU-1438.
 * Refresh list of loans after anonymization. Fixes UIU-1046.
+* Add UI to mark items Declared lost. Refs UIU-1202.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/package.json
+++ b/package.json
@@ -593,6 +593,7 @@
           "ui-users.loans.view",
           "ui-users.loans.edit",
           "ui-users.loans.renew",
+          "circulation.loans.declare-item-lost.post",
           "ui-users.loans.renew-override",
           "ui-users.settings.feefines",
           "circulation.loans.item.put",

--- a/src/components/DeclareLostDialog/DeclareLostDialog.css
+++ b/src/components/DeclareLostDialog/DeclareLostDialog.css
@@ -1,0 +1,3 @@
+.additionalInformation {
+  margin-top: 10px;
+}

--- a/src/components/DeclareLostDialog/DeclareLostDialog.js
+++ b/src/components/DeclareLostDialog/DeclareLostDialog.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { Modal } from '@folio/stripes/components';
+
+import DeclareLostInfo from './DeclareLostInfo';
+
+class DeclareLostDialog extends React.Component {
+  static propTypes = {
+    onClose: PropTypes.func.isRequired,
+    open: PropTypes.bool.isRequired,
+    loan: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const {
+      onClose,
+      open,
+      loan,
+    } = this.props;
+
+    if (!loan) return null;
+
+    const modalLabel = <FormattedMessage id="ui-users.loans.confirmLostState" />;
+
+    return (
+      <Modal
+        id="declare-lost-modal"
+        size="small"
+        dismissible
+        closeOnBackgroundClick
+        open={open}
+        label={modalLabel}
+        onClose={onClose}
+      >
+        <DeclareLostInfo
+          loan={loan}
+          onClose={onClose}
+        />
+      </Modal>
+    );
+  }
+}
+
+export default DeclareLostDialog;

--- a/src/components/DeclareLostDialog/DeclareLostInfo.js
+++ b/src/components/DeclareLostDialog/DeclareLostInfo.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { get } from 'lodash';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Button,
+  Layout,
+  TextArea,
+  Row,
+  Col,
+} from '@folio/stripes/components';
+import { stripesConnect } from '@folio/stripes/core';
+
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
+
+import css from './DeclareLostDialog.css';
+
+class DeclareLostInfo extends React.Component {
+  static manifest = Object.freeze({
+    declareLost: {
+      type: 'okapi',
+      fetch: false,
+      POST: {
+        path: 'circulation/loans/!{loan.id}/declare-item-lost',
+      },
+    },
+  });
+
+  static propTypes = {
+    mutator: PropTypes.shape({
+      declareLost: PropTypes.shape({
+        POST: PropTypes.func.isRequired,
+      }).isRequired,
+    }).isRequired,
+    loan: PropTypes.object.isRequired,
+    onClose: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      additionalInfo: '',
+    };
+  }
+
+  handleAdditionalInfoChange = (event) => {
+    this.setState({ additionalInfo: event.target.value });
+  };
+
+  submitDeclareLost = async () => {
+    const { additionalInfo } = this.state;
+
+    const {
+      mutator: {
+        declareLost: {
+          POST,
+        }
+      },
+      onClose,
+    } = this.props;
+
+    await POST({ comment: additionalInfo });
+
+    onClose();
+  };
+
+  render() {
+    const {
+      loan,
+      onClose,
+    } = this.props;
+    const { additionalInfo } = this.state;
+
+    return (
+      <div>
+        <Layout className="flex">
+          <Layout className="flex">
+            <SafeHTMLMessage
+              id="ui-users.loans.declareLostDialogBody"
+              values={{
+                title: get(loan, 'item.title'),
+                materialType: get(loan, 'item.materialType.name'),
+                barcode: get(loan, 'item.barcode'),
+              }}
+            />
+          </Layout>
+        </Layout>
+        <Row>
+          <Col sm={12} className={css.additionalInformation}>
+            <FormattedMessage id="ui-users.loans.declareLost.additionalInfoPlaceholder">
+              {placeholder => (
+                <TextArea
+                  data-test-declare-lost-additional-info-textarea
+                  label={<FormattedMessage id="ui-users.additionalInfo.label" />}
+                  placeholder={placeholder}
+                  required
+                  onChange={this.handleAdditionalInfoChange}
+                />
+              )}
+            </FormattedMessage>
+          </Col>
+        </Row>
+        <Layout className="textRight">
+          <Button
+            data-test-declare-lost-dialog-cancel-button
+            onClick={onClose}
+          >
+            <FormattedMessage id="ui-users.cancel" />
+          </Button>
+          <Button
+            data-test-declare-lost-dialog-confirm-button
+            buttonStyle="primary"
+            disabled={!additionalInfo}
+            onClick={this.submitDeclareLost}
+          >
+            <FormattedMessage id="ui-users.confirm" />
+          </Button>
+        </Layout>
+      </div>
+    );
+  }
+}
+
+export default stripesConnect(DeclareLostInfo);

--- a/src/components/DeclareLostDialog/index.js
+++ b/src/components/DeclareLostDialog/index.js
@@ -1,0 +1,1 @@
+export { default } from './DeclareLostDialog';

--- a/src/components/Loans/OpenLoans/OpenLoansControl.js
+++ b/src/components/Loans/OpenLoans/OpenLoansControl.js
@@ -11,7 +11,10 @@ import {
 import { stripesShape } from '@folio/stripes/core';
 
 import { nav } from '../../util';
-import { withRenew } from '../../Wrappers';
+import {
+  withRenew,
+  withDeclareLost,
+} from '../../Wrappers';
 import TableModel from './components/OpenLoansWithStaticData';
 
 class OpenLoansControl extends React.Component {
@@ -48,6 +51,7 @@ class OpenLoansControl extends React.Component {
     loans: PropTypes.arrayOf(PropTypes.object).isRequired,
     patronBlocks: PropTypes.arrayOf(PropTypes.object).isRequired,
     renew: PropTypes.func.isRequired,
+    declareLost: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -223,6 +227,8 @@ class OpenLoansControl extends React.Component {
     });
   };
 
+  declareLost = loan => { this.props.declareLost(loan); };
+
   feefineDetails = (loan, e) => {
     const {
       resources,
@@ -337,4 +343,4 @@ class OpenLoansControl extends React.Component {
   }
 }
 
-export default withRenew(OpenLoansControl);
+export default withDeclareLost(withRenew(OpenLoansControl));

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -77,6 +77,18 @@ class ActionsDropdown extends React.Component {
             <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
           </Button>
         </IfPermission>
+        { get(loan, ['item', 'status', 'name']) !== 'Declared lost' &&
+          <Button
+            buttonStyle="dropdownItem"
+            data-test-dropdown-content-declare-lost-button
+            onClick={(e) => {
+              handleOptionsChange({ loan, action:'declareLost' });
+              onToggle(e);
+            }}
+          >
+            <FormattedMessage id="ui-users.loans.declareLost" />
+          </Button>
+        }
         <IfPermission perm="circulation-storage.loan-policies.item.get">
           <Button
             buttonStyle="dropdownItem"

--- a/src/components/Wrappers/index.js
+++ b/src/components/Wrappers/index.js
@@ -1,3 +1,4 @@
 export { default as withRenew } from './withRenew';
 export { default as withServicePoints } from './withServicePoints';
 export { default as withProxy } from './withProxy';
+export { default as withDeclareLost } from './withDeclareLost';

--- a/src/components/Wrappers/withDeclareLost.js
+++ b/src/components/Wrappers/withDeclareLost.js
@@ -1,0 +1,50 @@
+import React, { Fragment } from 'react';
+
+import DeclareLostDialog from '../DeclareLostDialog';
+
+const withDeclareLost = WrappedComponent => class WithDeclareLost extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      declareLostDialogOpen: false,
+      loan: null,
+    };
+  }
+
+  declareLost = loan => {
+    this.setState({
+      loan,
+      declareLostDialogOpen: true,
+    });
+  }
+
+  hideDeclareLostDialog = () => {
+    this.setState({ declareLostDialogOpen: false });
+  }
+
+  render() {
+    const {
+      declareLostDialogOpen,
+      loan,
+    } = this.state;
+
+    return (
+      <Fragment>
+        <WrappedComponent
+          declareLost={this.declareLost}
+          {...this.props}
+        />
+        { loan &&
+          <DeclareLostDialog
+            loan={loan}
+            open={declareLostDialogOpen}
+            onClose={this.hideDeclareLostDialog}
+          />
+        }
+      </Fragment>
+    );
+  }
+};
+
+export default withDeclareLost;

--- a/src/routes/LoanDetailContainer.js
+++ b/src/routes/LoanDetailContainer.js
@@ -58,12 +58,11 @@ class LoanDetailContainer extends React.Component {
       path: 'loan-storage/loan-history?query=(loan.id=:{loanid})&limit=100',
       records: 'loansHistory',
       resourceShouldRefresh: true,
-      shouldRefresh: (props, nextProps) => {
-        return (
-          (props.resources.modified.time !== nextProps.resources.modified.time) ||
-          (props.resources.renew.succesfulMutations.length !== nextProps.resources.renew.successfulMutations.length)
-        );
-      }
+      shouldRefresh: (resource, action, refresh) => {
+        const { path } = action.meta;
+
+        return refresh || (path && path.match(/circulation/));
+      },
     },
     loanAccountsActions: {
       type: 'okapi',

--- a/test/bigtest/interactors/declare-lost-dialog.js
+++ b/test/bigtest/interactors/declare-lost-dialog.js
@@ -1,0 +1,18 @@
+import {
+  interactor,
+  Interactor,
+  property
+} from '@bigtest/interactor';
+
+import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor'; // eslint-disable-line
+
+@interactor class DeclareLostDialog {
+  static defaultScope = '#declare-lost-modal';
+
+  additionalInfoTextArea = new Interactor('[data-test-declare-lost-additional-info-textarea]');
+  confirmButton = new ButtonInteractor('[data-test-declare-lost-dialog-confirm-button]');
+  cancelButton = new ButtonInteractor('[data-test-declare-lost-dialog-cancel-button]');
+  isConfirmButtonDisabled = property('[data-test-declare-lost-dialog-confirm-button]', 'disabled');
+}
+
+export default DeclareLostDialog;

--- a/test/bigtest/interactors/loan-actions-history.js
+++ b/test/bigtest/interactors/loan-actions-history.js
@@ -2,6 +2,7 @@ import {
   interactor,
   scoped,
   ButtonInteractor,
+  property
 } from '@bigtest/interactor';
 
 import KeyValue from './KeyValue';
@@ -10,8 +11,12 @@ import KeyValue from './KeyValue';
   static defaultScope = '[data-test-loan-actions-history]';
 
   requests = scoped('[data-test-loan-actions-history-requests] div', KeyValue);
+  lostDate = scoped('[data-test-loan-actions-history-lost] div', KeyValue);
+  itemStatus = scoped('[data-test-loan-actions-history-item-status] div', KeyValue);
   feeFines = scoped('[data-test-loan-fees-fines] [data-test-kv-value]', KeyValue);
   closeButton = scoped('button[icon=times]', ButtonInteractor);
+  declareLostButton = scoped('[data-test-declare-lost-button]', ButtonInteractor);
+  isDeclareLostButtonDisabled = property('[data-test-declare-lost-button]', 'disabled');
 }
 
 export default new LoanActionsHistory();

--- a/test/bigtest/interactors/open-loans.js
+++ b/test/bigtest/interactors/open-loans.js
@@ -11,6 +11,8 @@ import moment from 'moment';
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor'; // eslint-disable-line
 import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/interactor'; // eslint-disable-line
 
+import DeclareLostDialog from './declare-lost-dialog';
+
 @interactor class BulkOverrideModal {
   static defaultScope = '#bulk-override-modal';
 
@@ -45,10 +47,12 @@ import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/inter
   actionDropdownRequestQueue = new Interactor('[data-test-dropdown-content-request-queue]');
   actionDropdownRenewButton = new Interactor('[data-test-dropdown-content-renew-button]');
   actionDropdownChangeDueDateButton = new Interactor('[data-test-dropdown-content-change-due-date-button]');
+  actionDropdownDeclareLostButton = new Interactor('[data-test-dropdown-content-declare-lost-button]');
   requestsCount = count('[data-test-list-requests]');
   bulkRenewalModal = new BulkRenewalModal();
   bulkOverrideModal = new BulkOverrideModal();
   changeDueDateOverlay = new ChangeDueDateOverlay();
+  declareLostDialog = new DeclareLostDialog();
   dueDateCalendarCellButton = new ButtonInteractor(`[data-test-date="${moment().format('MM/DD/YYYY')}"]`);
   rowButtons = collection('[data-test-open-loans-list] button[role="row"]', ButtonInteractor);
 

--- a/test/bigtest/tests/declare-lost-test.js
+++ b/test/bigtest/tests/declare-lost-test.js
@@ -1,0 +1,210 @@
+import {
+  before,
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+import { Response } from '@bigtest/mirage';
+
+import setupApplication from '../helpers/setup-application';
+import OpenLoansInteractor from '../interactors/open-loans';
+import LoanActionsHistory from '../interactors/loan-actions-history';
+
+describe('Declare Lost', () => {
+  before(function () {
+    setupApplication({
+      permissions: {
+        'manualblocks.collection.get': true,
+        'circulation.loans.collection.get': true,
+      },
+    });
+  });
+
+  describe('Visiting open loans list page with not declared lost item', () => {
+    let loan;
+
+    beforeEach(async function () {
+      loan = this.server.create('loan', { status: { name: 'Open' } });
+
+      this.visit(`/users/${loan.userId}/loans/open`);
+
+      await OpenLoansInteractor.whenLoaded();
+    });
+
+    it('should display open loans list', () => {
+      expect(OpenLoansInteractor.isPresent).to.be.true;
+    });
+
+    it('icon button should be presented', () => {
+      expect(OpenLoansInteractor.actionDropdowns(0).isPresent).to.be.true;
+    });
+
+    describe('opening dropdown for not declared lost item', () => {
+      beforeEach(async () => {
+        await OpenLoansInteractor.actionDropdowns(0).click('button');
+      });
+
+      it('should display declare lost button', () => {
+        expect(OpenLoansInteractor.actionDropdownDeclareLostButton.isPresent).to.be.true;
+      });
+
+      describe('clicking declare lost button', () => {
+        beforeEach(async () => {
+          await OpenLoansInteractor.actionDropdownDeclareLostButton.click();
+        });
+
+        it('should display declare lost dialog', () => {
+          expect(OpenLoansInteractor.declareLostDialog.isVisible).to.be.true;
+        });
+
+        it('should display disabled confirm button', () => {
+          expect(OpenLoansInteractor.declareLostDialog.confirmButton.isPresent).to.be.true;
+          expect(OpenLoansInteractor.declareLostDialog.isConfirmButtonDisabled).to.be.true;
+        });
+
+        it('should display cancel button', () => {
+          expect(OpenLoansInteractor.declareLostDialog.cancelButton.isPresent).to.be.true;
+        });
+
+        it('should display additional information textarea', () => {
+          expect(OpenLoansInteractor.declareLostDialog.additionalInfoTextArea.isPresent).to.be.true;
+        });
+
+        describe('clicking cancel button', () => {
+          beforeEach(async () => {
+            await OpenLoansInteractor.declareLostDialog.cancelButton.click();
+          });
+
+          it('should hide declare lost dialog', () => {
+            expect(OpenLoansInteractor.declareLostDialog.isPresent).to.be.false;
+          });
+        });
+
+        describe('filling additional information textarea', () => {
+          const additionalInfoText = 'text';
+
+          beforeEach(async () => {
+            await OpenLoansInteractor.declareLostDialog.additionalInfoTextArea.focus();
+            await OpenLoansInteractor.declareLostDialog.additionalInfoTextArea.fill(additionalInfoText);
+          });
+
+          it('should enable confirm button', () => {
+            expect(OpenLoansInteractor.declareLostDialog.isConfirmButtonDisabled).to.be.false;
+          });
+
+          describe('clicking confirm button', () => {
+            let parsedRequestBody;
+
+            beforeEach(async function () {
+              this.server.post(`/circulation/loans/${loan.id}/declare-item-lost`, (_, request) => {
+                parsedRequestBody = JSON.parse(request.requestBody);
+
+                return new Response(204, {});
+              });
+
+              await OpenLoansInteractor.declareLostDialog.confirmButton.click();
+            });
+
+            it('should send correct request body', () => {
+              expect(parsedRequestBody.comment).to.equal(additionalInfoText);
+            });
+
+            it('should hide declare lost dialog', () => {
+              expect(OpenLoansInteractor.declareLostDialog.isPresent).to.be.false;
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('Visiting open loans list page with declared lost item', () => {
+    beforeEach(async function () {
+      const loan = this.server.create('loan', {
+        status: { name: 'Open' },
+        item: { status: { name: 'Declared lost' } },
+      });
+
+      this.visit(`/users/${loan.userId}/loans/open`);
+
+      await OpenLoansInteractor.whenLoaded();
+    });
+
+    describe('opening dropdown for declared lost item', () => {
+      beforeEach(async () => {
+        await OpenLoansInteractor.actionDropdowns(0).click('button');
+      });
+
+      it('should not display declare lost button', () => {
+        expect(OpenLoansInteractor.actionDropdownDeclareLostButton.isPresent).to.be.false;
+      });
+    });
+  });
+
+  describe('Visiting loan details  page with not declared lost item', () => {
+    beforeEach(async function () {
+      const loan = this.server.create('loan', {
+        status: { name: 'Open' },
+        loanPolicyId: 'test'
+      });
+
+      this.visit(`/users/${loan.userId}/loans/view/${loan.id}`);
+    });
+
+    it('should display enabled declare lost button', () => {
+      expect(LoanActionsHistory.declareLostButton.isPresent).to.be.true;
+      expect(LoanActionsHistory.isDeclareLostButtonDisabled).to.be.false;
+    });
+
+    it('should display dash in lost field', () => {
+      expect(LoanActionsHistory.lostDate.value.text).to.equal('-');
+    });
+
+    describe('clicking on declare lost button', () => {
+      beforeEach(async function () {
+        await LoanActionsHistory.declareLostButton.click();
+      });
+
+      it('should display declare lost dialog', () => {
+        expect(OpenLoansInteractor.declareLostDialog.isVisible).to.be.true;
+      });
+    });
+  });
+
+  describe('Visiting loan details page with declared lost item', () => {
+    beforeEach(async function () {
+      const loan = this.server.create('loan', {
+        status: { name: 'Open' },
+        loanPolicyId: 'test',
+        action: 'declaredLost',
+        actionComment: 'D',
+        item: { status: { name: 'Declared lost' } },
+      });
+
+      this.server.create('user', { id: loan.userId });
+
+      this.server.create('loanactions', {
+        loan: {
+          ...loan.attrs,
+        },
+        operation : 'U',
+        action: 'declaredLost',
+        actionComment: 'D',
+        itemStatus: 'Declared lost',
+      });
+
+      this.visit(`/users/${loan.userId}/loans/view/${loan.id}`);
+    });
+
+
+    it('should display disabled declare lost button', () => {
+      expect(LoanActionsHistory.declareLostButton.isPresent).to.be.true;
+      expect(LoanActionsHistory.isDeclareLostButtonDisabled).to.be.true;
+    }).timeout(5000);
+
+    it('should display the lost date in lost field', () => {
+      expect(LoanActionsHistory.lostDate.value.text).to.not.equal('-');
+    });
+  });
+});

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -6,6 +6,7 @@
   "loading": "Loading...",
   "search": "Search",
   "expandAll": "Expand all",
+  "confirm": "Confirm",
   "collapseAll": "Collapse all",
   "resultCount": "{count, number} {count, plural, one {Record found} other {Records found}}",
   "closedLoansCount": "{count, number} {count, plural, one {closed loan} other {closed loans}}",
@@ -306,6 +307,10 @@
   "loans.numOpenLoans": "{count, number} {count, plural, one {open loan} other {open loans}}",
   "loans.numClosedLoans": "{count, number} {count, plural, one {closed loan} other {closed loans}}",
   "loans.loanDetails": "Loan details",
+  "loans.declareLost": "Declare lost",
+  "loans.declareLostDialogBody": "<strong>{title} {materialType}</strong> (Barcode: {barcode}) will be <strong>declared lost</strong>",
+  "loans.confirmLostState": "Confirm lost state",
+  "loans.declareLost.additionalInfoPlaceholder": "Enter more information about the lost item (required)",
   "loans.newFeeFine": "New fee/fine",
   "loans.feeFineDetails": "Fee/fine details",
 


### PR DESCRIPTION
## Purposes

Add ability to mark items "Declared lost" on UI. The detailed information about the supported scenarios can be found by [link](https://issues.folio.org/browse/UIU-1202).

## Screenshots

![declared_lost_in_dropdown](https://user-images.githubusercontent.com/50317804/72154303-fbd10500-33b8-11ea-8ff7-e254dbfc9e49.png)

![declared_lost_hidden_for_declared_lost_items](https://user-images.githubusercontent.com/50317804/72154305-fbd10500-33b8-11ea-9271-2fcaea6096e3.png)

![declared_lost_button_is_enabled](https://user-images.githubusercontent.com/50317804/72154306-fbd10500-33b8-11ea-9198-5e1a4725e28a.png)

![declared_lost_button_is_disabled_for_declared_lost_item](https://user-images.githubusercontent.com/50317804/72154307-fc699b80-33b8-11ea-9994-067962e15d18.png)
