### PR TITLE
Improve tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,22 +13,23 @@ import * as Routes from './routes';
 import pkg from '../package';
 import Settings from './settings';
 import commands from './commands';
-import PermissionSets from './settings/permissions/PermissionSets';
-import PatronGroupsSettings from './settings/PatronGroupsSettings';
-import AddressTypesSettings from './settings/AddressTypesSettings';
-import ProfilePictureSettings from './settings/ProfilePictureSettings';
-import OwnerSettings from './settings/OwnerSettings';
-import FeeFineSettings from './settings/FeeFineSettings';
-import WaiveSettings from './settings/WaiveSettings';
-import PaymentSettings from './settings/PaymentSettings';
-import CommentRequiredSettings from './settings/CommentRequiredSettings';
-import RefundReasonsSettings from './settings/RefundReasonsSettings';
-import TransferAccountsSettings from './settings/TransferAccountsSettings';
 import {
   NoteCreatePage,
   NoteViewPage,
   NoteEditPage
 } from './views';
+
+const PermissionSets = React.lazy(() => import('./settings/permissions/PermissionSets'));
+const PatronGroupsSettings = React.lazy(() => import('./settings/PatronGroupsSettings'));
+const AddressTypesSettings = React.lazy(() => import('./settings/AddressTypesSettings'));
+const ProfilePictureSettings = React.lazy(() => import('./settings/ProfilePictureSettings'));
+const OwnerSettings = React.lazy(() => import('./settings/OwnerSettings'));
+const FeeFineSettings = React.lazy(() => import('./settings/FeeFineSettings'));
+const WaiveSettings = React.lazy(() => import('./settings/WaiveSettings'));
+const PaymentSettings = React.lazy(() => import('./settings/PaymentSettings'));
+const CommentRequiredSettings = React.lazy(() => import('./settings/CommentRequiredSettings'));
+const RefundReasonsSettings = React.lazy(() => import('./settings/RefundReasonsSettings'));
+const TransferAccountsSettings = React.lazy(() => import('./settings/TransferAccountsSettings'));
 
 const settingsGeneral = [
   {
@@ -209,12 +210,14 @@ class UsersRouting extends React.Component {
     if (showSettings) {
       return (
         <Route path={path} component={Settings}>
-          <Switch>
-            {[].concat(...settingsSections.map(section => section.pages))
-              .filter(setting => !setting.perm || stripes.hasPerm(setting.perm))
-              .map(setting => <Route path={`${path}/${setting.route}`} key={setting.route} component={setting.component} />)
-            }
-          </Switch>
+          <React.Suspense fallback={<div>Loading...</div>}>
+            <Switch>
+              {[].concat(...settingsSections.map(section => section.pages))
+                .filter(setting => !setting.perm || stripes.hasPerm(setting.perm))
+                .map(setting => <Route path={`${path}/${setting.route}`} key={setting.route} component={setting.component} />)
+              }
+            </Switch>
+          </React.Suspense>
         </Route>
       );
     }
@@ -226,64 +229,66 @@ class UsersRouting extends React.Component {
           isWithinScope={this.checkScope}
           scope={this.shortcutScope}
         >
-          <Switch>
-            <Route
-              path={`${base}/:id/loans/view/:loanid`}
-              render={(props) => (
-                <IfPermission perm="ui-users.loans.view">
-                  <Routes.LoanDetailContainer {...props} />
-                </IfPermission>
-              )}
-            />
-            <Route
-              path={`${base}/:id/loans/:loanstatus`}
-              render={(props) => (
-                <IfPermission perm="ui-users.loans.view">
-                  <Routes.LoansListingContainer {...props} />
-                </IfPermission>
-              )}
-            />
-            <Route
-              path={`${base}/:id/accounts/:accountstatus/charge`}
-              exact
-              render={(props) => (
-                <IfPermission perm="ui-users.feesfines.actions.all">
-                  <Routes.FeesFinesContainer {...props} />
-                </IfPermission>
-              )}
-            />
-            <Route
-              path={`${base}/:id/accounts/view/:accountid`}
-              render={(props) => (
-                <IfPermission perm="ui-users.feesfines.actions.all">
-                  <Routes.AccountDetailsContainer {...props} />
-                </IfPermission>
-              )}
-            />
-            <Route
-              path={`${base}/:id/accounts/:accountstatus`}
-              exact
-              component={Routes.AccountsListingContainer}
-              render={(props) => (
-                <IfPermission perm="ui-users.feesfines.actions.all">
-                  <Routes.AccountsListingContainer {...props} />
-                </IfPermission>
-              )}
-            />
-            <Route path={`${base}/:id/charge/:loanid?`} component={Routes.ChargeFeesFinesContainer} />
-            <Route path={`${base}/:id/patronblocks/edit/:patronblockid`} component={Routes.PatronBlockContainer} />
-            <Route path={`${base}/:id/patronblocks/create`} component={Routes.PatronBlockContainer} />
-            <Route path={`${base}/create`} component={Routes.UserEditContainer} />
-            <Route path={`${base}/:id/edit`} component={Routes.UserEditContainer} />
-            <Route path={`${base}/view/:id`} component={Routes.UserDetailFullscreenContainer} />
-            <Route path={`${base}/notes/new`} exact component={NoteCreatePage} />
-            <Route path={`${base}/notes/:id`} exact component={NoteViewPage} />
-            <Route path={`${base}/notes/:id/edit`} exact component={NoteEditPage} />
-            <Route path={base} component={Routes.UserSearchContainer}>
-              <Route path={`${base}/preview/:id`} component={Routes.UserDetailContainer} />
-            </Route>
-            <Route render={this.noMatch} />
-          </Switch>
+          <React.Suspense fallback={<div>Loading...</div>}>
+            <Switch>
+              <Route
+                path={`${base}/:id/loans/view/:loanid`}
+                render={(props) => (
+                  <IfPermission perm="ui-users.loans.view">
+                    <Routes.LoanDetailContainer {...props} />
+                  </IfPermission>
+                )}
+              />
+              <Route
+                path={`${base}/:id/loans/:loanstatus`}
+                render={(props) => (
+                  <IfPermission perm="ui-users.loans.view">
+                    <Routes.LoansListingContainer {...props} />
+                  </IfPermission>
+                )}
+              />
+              <Route
+                path={`${base}/:id/accounts/:accountstatus/charge`}
+                exact
+                render={(props) => (
+                  <IfPermission perm="ui-users.feesfines.actions.all">
+                    <Routes.FeesFinesContainer {...props} />
+                  </IfPermission>
+                )}
+              />
+              <Route
+                path={`${base}/:id/accounts/view/:accountid`}
+                render={(props) => (
+                  <IfPermission perm="ui-users.feesfines.actions.all">
+                    <Routes.AccountDetailsContainer {...props} />
+                  </IfPermission>
+                )}
+              />
+              <Route
+                path={`${base}/:id/accounts/:accountstatus`}
+                exact
+                component={Routes.AccountsListingContainer}
+                render={(props) => (
+                  <IfPermission perm="ui-users.feesfines.actions.all">
+                    <Routes.AccountsListingContainer {...props} />
+                  </IfPermission>
+                )}
+              />
+              <Route path={`${base}/:id/charge/:loanid?`} component={Routes.ChargeFeesFinesContainer} />
+              <Route path={`${base}/:id/patronblocks/edit/:patronblockid`} component={Routes.PatronBlockContainer} />
+              <Route path={`${base}/:id/patronblocks/create`} component={Routes.PatronBlockContainer} />
+              <Route path={`${base}/create`} component={Routes.UserEditContainer} />
+              <Route path={`${base}/:id/edit`} component={Routes.UserEditContainer} />
+              <Route path={`${base}/view/:id`} component={Routes.UserDetailFullscreenContainer} />
+              <Route path={`${base}/notes/new`} exact component={NoteCreatePage} />
+              <Route path={`${base}/notes/:id`} exact component={NoteViewPage} />
+              <Route path={`${base}/notes/:id/edit`} exact component={NoteEditPage} />
+              <Route path={base} component={Routes.UserSearchContainer}>
+                <Route path={`${base}/preview/:id`} component={Routes.UserDetailContainer} />
+              </Route>
+              <Route render={this.noMatch} />
+            </Switch>
+          </React.Suspense>
         </HasCommand>
       </CommandList>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -8,16 +8,9 @@ import _ from 'lodash';
 import { Route, Switch, IfPermission } from '@folio/stripes/core';
 import { CommandList, HasCommand } from '@folio/stripes/components';
 
-import * as Routes from './routes';
-
 import pkg from '../package';
 import Settings from './settings';
 import commands from './commands';
-import {
-  NoteCreatePage,
-  NoteViewPage,
-  NoteEditPage
-} from './views';
 
 const PermissionSets = React.lazy(() => import('./settings/permissions/PermissionSets'));
 const PatronGroupsSettings = React.lazy(() => import('./settings/PatronGroupsSettings'));
@@ -30,6 +23,21 @@ const PaymentSettings = React.lazy(() => import('./settings/PaymentSettings'));
 const CommentRequiredSettings = React.lazy(() => import('./settings/CommentRequiredSettings'));
 const RefundReasonsSettings = React.lazy(() => import('./settings/RefundReasonsSettings'));
 const TransferAccountsSettings = React.lazy(() => import('./settings/TransferAccountsSettings'));
+
+const NoteCreatePage = React.lazy(() => import('./views/Notes/NoteCreatePage'));
+const NoteEditPage = React.lazy(() => import('./views/Notes/NoteEditPage'));
+const NoteViewPage = React.lazy(() => import('./views/Notes/NoteViewPage'));
+
+const UserSearchContainer = React.lazy(() => import('./routes/UserSearchContainer'));
+const UserDetailContainer = React.lazy(() => import('./routes/UserDetailContainer'));
+const UserDetailFullscreenContainer = React.lazy(() => import('./routes/UserDetailFullscreenContainer'));
+const UserEditContainer = React.lazy(() => import('./routes/UserEditContainer'));
+const PatronBlockContainer = React.lazy(() => import('./routes/PatronBlockContainer'));
+const ChargeFeesFinesContainer = React.lazy(() => import('./routes/ChargeFeesFinesContainer'));
+const AccountsListingContainer = React.lazy(() => import('./routes/AccountsListingContainer'));
+const LoansListingContainer = React.lazy(() => import('./routes/LoansListingContainer'));
+const LoanDetailContainer = React.lazy(() => import('./routes/LoanDetailContainer'));
+const AccountDetailsContainer = React.lazy(() => import('./routes/AccountDetailsContainer'));
 
 const settingsGeneral = [
   {
@@ -235,7 +243,7 @@ class UsersRouting extends React.Component {
                 path={`${base}/:id/loans/view/:loanid`}
                 render={(props) => (
                   <IfPermission perm="ui-users.loans.view">
-                    <Routes.LoanDetailContainer {...props} />
+                    <LoanDetailContainer {...props} />
                   </IfPermission>
                 )}
               />
@@ -243,7 +251,7 @@ class UsersRouting extends React.Component {
                 path={`${base}/:id/loans/:loanstatus`}
                 render={(props) => (
                   <IfPermission perm="ui-users.loans.view">
-                    <Routes.LoansListingContainer {...props} />
+                    <LoansListingContainer {...props} />
                   </IfPermission>
                 )}
               />
@@ -252,7 +260,7 @@ class UsersRouting extends React.Component {
                 exact
                 render={(props) => (
                   <IfPermission perm="ui-users.feesfines.actions.all">
-                    <Routes.FeesFinesContainer {...props} />
+                    <ChargeFeesFinesContainer {...props} />
                   </IfPermission>
                 )}
               />
@@ -260,31 +268,30 @@ class UsersRouting extends React.Component {
                 path={`${base}/:id/accounts/view/:accountid`}
                 render={(props) => (
                   <IfPermission perm="ui-users.feesfines.actions.all">
-                    <Routes.AccountDetailsContainer {...props} />
+                    <AccountDetailsContainer {...props} />
                   </IfPermission>
                 )}
               />
               <Route
                 path={`${base}/:id/accounts/:accountstatus`}
                 exact
-                component={Routes.AccountsListingContainer}
                 render={(props) => (
                   <IfPermission perm="ui-users.feesfines.actions.all">
-                    <Routes.AccountsListingContainer {...props} />
+                    <AccountsListingContainer {...props} />
                   </IfPermission>
                 )}
               />
-              <Route path={`${base}/:id/charge/:loanid?`} component={Routes.ChargeFeesFinesContainer} />
-              <Route path={`${base}/:id/patronblocks/edit/:patronblockid`} component={Routes.PatronBlockContainer} />
-              <Route path={`${base}/:id/patronblocks/create`} component={Routes.PatronBlockContainer} />
-              <Route path={`${base}/create`} component={Routes.UserEditContainer} />
-              <Route path={`${base}/:id/edit`} component={Routes.UserEditContainer} />
-              <Route path={`${base}/view/:id`} component={Routes.UserDetailFullscreenContainer} />
+              <Route path={`${base}/:id/charge/:loanid?`} component={ChargeFeesFinesContainer} />
+              <Route path={`${base}/:id/patronblocks/edit/:patronblockid`} component={PatronBlockContainer} />
+              <Route path={`${base}/:id/patronblocks/create`} component={PatronBlockContainer} />
+              <Route path={`${base}/create`} component={UserEditContainer} />
+              <Route path={`${base}/:id/edit`} component={UserEditContainer} />
+              <Route path={`${base}/view/:id`} component={UserDetailFullscreenContainer} />
               <Route path={`${base}/notes/new`} exact component={NoteCreatePage} />
               <Route path={`${base}/notes/:id`} exact component={NoteViewPage} />
               <Route path={`${base}/notes/:id/edit`} exact component={NoteEditPage} />
-              <Route path={base} component={Routes.UserSearchContainer}>
-                <Route path={`${base}/preview/:id`} component={Routes.UserDetailContainer} />
+              <Route path={base} component={UserSearchContainer}>
+                <Route path={`${base}/preview/:id`} component={UserDetailContainer} />
               </Route>
               <Route render={this.noMatch} />
             </Switch>

--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,7 @@ class UsersRouting extends React.Component {
     if (showSettings) {
       return (
         <Route path={path} component={Settings}>
-          <React.Suspense fallback={<div>Loading...</div>}>
+          <React.Suspense fallback={null}>
             <Switch>
               {[].concat(...settingsSections.map(section => section.pages))
                 .filter(setting => !setting.perm || stripes.hasPerm(setting.perm))
@@ -237,7 +237,7 @@ class UsersRouting extends React.Component {
           isWithinScope={this.checkScope}
           scope={this.shortcutScope}
         >
-          <React.Suspense fallback={<div>Loading...</div>}>
+          <React.Suspense fallback={null}>
             <Switch>
               <Route
                 path={`${base}/:id/loans/view/:loanid`}

--- a/src/routes/UserDetailContainer.js
+++ b/src/routes/UserDetailContainer.js
@@ -1,15 +1,12 @@
 import React from 'react';
-import UserRecordContainer from './UserRecordContainer';
-import { UserDetail, UserDetailFullscreen } from '../views';
 
-export const UserDetailContainer = ({ children, ...rest }) => (
+import UserRecordContainer from './UserRecordContainer';
+import { UserDetail } from '../views';
+
+const UserDetailContainer = ({ children, ...rest }) => (
   <UserRecordContainer {...rest}>
     { payload => <UserDetail {...payload} paneWidth="44%">{children}</UserDetail> }
   </UserRecordContainer>
 );
 
-export const UserDetailFullscreenContainer = ({ children, ...rest }) => (
-  <UserRecordContainer {...rest}>
-    { payload => <UserDetailFullscreen {...payload}>{children}</UserDetailFullscreen> }
-  </UserRecordContainer>
-);
+export default UserDetailContainer;

--- a/src/routes/UserDetailFullscreenContainer.js
+++ b/src/routes/UserDetailFullscreenContainer.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import UserRecordContainer from './UserRecordContainer';
+import { UserDetailFullscreen } from '../views';
+
+const UserDetailFullscreenContainer = ({ children, ...rest }) => (
+  <UserRecordContainer {...rest}>
+    { payload => <UserDetailFullscreen {...payload}>{children}</UserDetailFullscreen> }
+  </UserRecordContainer>
+);
+
+export default UserDetailFullscreenContainer;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,4 +1,3 @@
-export { default as UserRecordContainer } from './UserRecordContainer';
 export { default as UserSearchContainer } from './UserSearchContainer';
 export { UserDetailContainer, UserDetailFullscreenContainer } from './UserDetailContainer';
 export { default as UserEditContainer } from './UserEditContainer';

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,9 +1,0 @@
-export { default as UserSearchContainer } from './UserSearchContainer';
-export { UserDetailContainer, UserDetailFullscreenContainer } from './UserDetailContainer';
-export { default as UserEditContainer } from './UserEditContainer';
-export { default as PatronBlockContainer } from './PatronBlockContainer';
-export { default as ChargeFeesFinesContainer } from './ChargeFeesFinesContainer';
-export { default as AccountsListingContainer } from './AccountsListingContainer';
-export { default as LoansListingContainer } from './LoansListingContainer';
-export { default as LoanDetailContainer } from './LoanDetailContainer';
-export { default as AccountDetailsContainer } from './AccountDetailsContainer';

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -44,6 +44,7 @@ class UserEdit extends React.Component {
     stripes: PropTypes.object,
     resources: PropTypes.object,
     history: PropTypes.object,
+    location: PropTypes.object,
     match: PropTypes.object,
     updateProxies: PropTypes.func,
     updateSponsors: PropTypes.func,
@@ -198,6 +199,8 @@ class UserEdit extends React.Component {
       mutator,
       history,
       resources,
+      match: { params },
+      location: { state },
       stripes,
     } = this.props;
 
@@ -232,7 +235,10 @@ class UserEdit extends React.Component {
     data.active = (moment(user.expirationDate).endOf('day').isSameOrAfter(today));
 
     mutator.selUser.PUT(data).then(() => {
-      history.goBack();
+      history.push({
+        pathname: params.id ? `/users/preview/${params.id}` : '/users',
+        state,
+      });
     });
   }
 
@@ -249,6 +255,7 @@ class UserEdit extends React.Component {
     const {
       history,
       resources,
+      location: { state },
       match: { params }
     } = this.props;
 
@@ -258,7 +265,6 @@ class UserEdit extends React.Component {
 
     // data is information that the form needs, mostly to populate options lists
     const formData = this.getUserFormData();
-
     const onSubmit = params.id ? (record) => this.update(record) : (record) => this.create(record);
 
     return (
@@ -266,7 +272,12 @@ class UserEdit extends React.Component {
         formData={formData}
         initialValues={this.getUserFormValues()} // values are strictly values...if we're editing (id param present) pull in existing values.
         onSubmit={onSubmit}
-        onCancel={() => history.goBack()}
+        onCancel={() => {
+          history.push({
+            pathname: params.id ? `/users/preview/${params.id}` : '/users',
+            state,
+          });
+        }}
         uniquenessValidator={this.props.mutator.uniquenessValidator}
       />
     );

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -403,6 +403,7 @@ class UserForm extends React.Component {
       formData,
       change, // from redux-form...
       servicePoints,
+      onCancel,
     } = this.props;
 
     const { sections } = this.state;
@@ -432,6 +433,7 @@ class UserForm extends React.Component {
                   {paneTitle}
                 </span>
               }
+              onClose={onCancel}
             >
               <div className={css.UserFormContent}>
                 <Headline

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -6,6 +6,4 @@ export { default as LoanDetails } from './LoanDetails/LoanDetails';
 export { default as LoansListing } from './LoansListing/LoansListing';
 export { default as AccountDetails } from './AccountDetails/AccountDetails';
 export { default as AccountsListing } from './AccountsListing/AccountsListing';
-export { default as NoteCreatePage } from './Notes/NoteCreatePage';
-export { default as NoteEditPage } from './Notes/NoteEditPage';
-export { default as NoteViewPage } from './Notes/NoteViewPage';
+

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -6,4 +6,3 @@ export { default as LoanDetails } from './LoanDetails/LoanDetails';
 export { default as LoansListing } from './LoansListing/LoansListing';
 export { default as AccountDetails } from './AccountDetails/AccountDetails';
 export { default as AccountsListing } from './AccountsListing/AccountsListing';
-

--- a/test/bigtest/interactors/users.js
+++ b/test/bigtest/interactors/users.js
@@ -28,7 +28,7 @@ export default @interactor class UsersInteractor {
   headerDropdownMenu = new HeaderDropdownMenu();
   searchFocused = isPresent('[data-test-user-search-input]:focus');
   patronGroupsPresent = isPresent('#clickable-filter-pg-faculty');
-  instancePresent = isPresent('[data-test-user-instances] [data-test-instance-details]');
+  instancePresent = isPresent('[data-test-instance-details]');
   instancesPresent = isPresent('[role=group] [role=row]');
   headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   clickFacultyCheckbox = clickable('#clickable-filter-pg-faculty');

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -17,156 +17,143 @@ describe('User Edit Page', () => {
 
   setupApplication();
 
-  describe('visit users-details', () => {
+  beforeEach(async function () {
+    user1 = this.server.create('user');
+    user2 = this.server.create('user');
+    this.server.create('requestPreference', {
+      userId: user1.id,
+      delivery: true,
+      defaultServicePointId: 'servicepointId1',
+      defaultDeliveryAddressTypeId: 'Type1',
+      fulfillment: 'Delivery',
+    });
+
+    this.visit(`/users/${user1.id}/edit`);
+    await UserFormPage.whenLoaded();
+  });
+
+  it('displays the title in the pane header', () => {
+    expect(UserFormPage.title).to.equal(user1.username);
+  });
+
+  describe('validating user barcode', () => {
     beforeEach(async function () {
-      user1 = this.server.create('user');
-      user2 = this.server.create('user');
-      this.server.create('requestPreference', {
-        userId: user1.id,
-        delivery: true,
-        defaultServicePointId: 'servicepointId1',
-        defaultDeliveryAddressTypeId: 'Type1',
-        fulfillment: 'Delivery',
-      });
-
-      this.visit(`/users/preview/${user1.id}`);
-      await InstanceViewPage.whenLoaded();
+      await UserFormPage.barcodeField.fillAndBlur(user2.barcode);
+      await UserFormPage.submitButton.click();
     });
 
-    it('edit button is present', () => {
-      expect(InstanceViewPage.editButtonPresent).to.be.true;
+    it('should display validation error', () => {
+      expect(UserFormPage.feedbackError).to.equal('This barcode has already been taken');
+    });
+  });
+
+  describe('validating empty user barcode', () => {
+    beforeEach(async function () {
+      await UserFormPage.barcodeField.fillAndBlur('');
+      await UserFormPage.submitButton.click();
     });
 
-    describe('visiting the edit user page', () => {
-      beforeEach(async function () {
-        await InstanceViewPage.clickEditButton();
-        await UserFormPage.whenLoaded();
+    it('should show user detail view', () => {
+      expect(InstanceViewPage.isVisible).to.equal(true);
+    });
+  });
+
+  describe('validating username', () => {
+    beforeEach(async function () {
+      await UserFormPage.usernameField.fillAndBlur(user2.username);
+      await UserFormPage.submitButton.click();
+    });
+
+    it('should display validation error', () => {
+      expect(UserFormPage.feedbackError).to.equal('This username already exists');
+    });
+  });
+
+  describe('pane header menu', () => {
+    beforeEach(async () => {
+      await UserFormPage.cancelButton.click();
+    });
+
+    it('should redirect to view users page after click', () => {
+      expect(users.$root).to.exist;
+    });
+  });
+
+  describe('request preferences', () => {
+    it('should display "hold shelf" checkbox as checked', () => {
+      expect(UserFormPage.holdShelfCheckboxIsChecked).to.be.true;
+    });
+
+    it('should display "hold shelf" checkbox as disabled', () => {
+      expect(UserFormPage.holdShelfCheckboxIsDisabled).to.be.true;
+    });
+
+    describe('when delivery is activated', () => {
+      it('should display "delivery" checkbox as checked', () => {
+        expect(UserFormPage.deliveryCheckboxIsChecked).to.be.true;
       });
 
-      it('displays the title in the pane header', () => {
-        expect(UserFormPage.title).to.equal(user1.username);
+      it('should display selected "Fulfillment preference"', () => {
+        expect(UserFormPage.fulfillmentPreference.value).to.equal('Delivery');
       });
 
-      describe('validating user barcode', () => {
-        beforeEach(async function () {
-          await UserFormPage.barcodeField.fillAndBlur(user2.barcode);
-          await UserFormPage.submitButton.click();
-        });
-
-        it('should display validation error', () => {
-          expect(UserFormPage.feedbackError).to.equal('This barcode has already been taken');
-        });
+      it('should display selected default address type', () => {
+        const CLAIM_ADDRESS_TYPE_VALUE = 'Type1';
+        expect(UserFormPage.defaultAddressTypeField.value).to.equal(CLAIM_ADDRESS_TYPE_VALUE);
       });
 
-      describe('validating empty user barcode', () => {
-        beforeEach(async function () {
-          await UserFormPage.barcodeField.fillAndBlur('');
-          await UserFormPage.submitButton.click();
-        });
-
-        it('should show user detail view', () => {
-          expect(InstanceViewPage.isVisible).to.equal(true);
-        });
-      });
-
-      describe('validating username', () => {
-        beforeEach(async function () {
-          await UserFormPage.usernameField.fillAndBlur(user2.username);
-          await UserFormPage.submitButton.click();
-        });
-
-        it('should display validation error', () => {
-          expect(UserFormPage.feedbackError).to.equal('This username already exists');
-        });
-      });
-
-      describe('pane header menu', () => {
+      describe('and selected default address type was changed', () => {
         beforeEach(async () => {
-          await UserFormPage.cancelButton.click();
+          await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
+          await UserFormPage.defaultAddressTypeField.selectAndBlur('Home');
+          await UserFormPage.firstAddressTypeField.selectAndBlur('Order');
         });
 
-        it('should redirect to view users page after click', () => {
-          expect(users.$root).to.exist;
+        it('should reset default address type to empty value', () => {
+          expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
+        });
+
+        it('should display validation message of "Default delivery address field"', () => {
+          expect(UserFormPage.defaultAddressTypeValidationMessage).to.equal('Please fill this in to continue');
         });
       });
 
-      describe('request preferences', () => {
-        it('should display "hold shelf" checkbox as checked', () => {
-          expect(UserFormPage.holdShelfCheckboxIsChecked).to.be.true;
+      describe('and selected default address type was deleted', () => {
+        beforeEach(async () => {
+          await UserFormPage.clickAddAddressButton();
+          await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
+          await UserFormPage.defaultAddressTypeField.selectAndBlur('Home');
+          await UserFormPage.deleteAddressType();
         });
 
-        it('should display "hold shelf" checkbox as disabled', () => {
-          expect(UserFormPage.holdShelfCheckboxIsDisabled).to.be.true;
+        it('should reset default address type to empty value', () => {
+          expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
         });
 
-        describe('when delivery is activated', () => {
-          it('should display "delivery" checkbox as checked', () => {
-            expect(UserFormPage.deliveryCheckboxIsChecked).to.be.true;
-          });
+        it('should display validation message of "Default delivery address field"', () => {
+          expect(UserFormPage.defaultAddressTypeValidationMessage)
+            .to.equal('Please, add at least one address inside "Addresses" section');
+        });
+      });
 
-          it('should display selected "Fulfillment preference"', () => {
-            expect(UserFormPage.fulfillmentPreference.value).to.equal('Delivery');
-          });
+      describe('and all address types were deleted', () => {
+        beforeEach(async () => {
+          await UserFormPage.clickAddAddressButton();
+          await UserFormPage.clickAddAddressButton();
+          await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
+          await UserFormPage.secondAddressTypeField.selectAndBlur('Order');
+          await UserFormPage.defaultAddressTypeField.selectAndBlur('Order');
+          await UserFormPage.deleteAddressType();
+          await UserFormPage.deleteAddressType();
+        });
 
-          it('should display selected default address type', () => {
-            const CLAIM_ADDRESS_TYPE_VALUE = 'Type1';
-            expect(UserFormPage.defaultAddressTypeField.value).to.equal(CLAIM_ADDRESS_TYPE_VALUE);
-          });
+        it('should reset default address type to empty value', () => {
+          expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
+        });
 
-          describe('and selected default address type was changed', () => {
-            beforeEach(async () => {
-              await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
-              await UserFormPage.defaultAddressTypeField.selectAndBlur('Home');
-              await UserFormPage.firstAddressTypeField.selectAndBlur('Order');
-            });
-
-            it('should reset default address type to empty value', () => {
-              expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
-            });
-
-            it('should display validation message of "Default delivery address field"', () => {
-              expect(UserFormPage.defaultAddressTypeValidationMessage).to.equal('Please fill this in to continue');
-            });
-          });
-
-          describe('and selected default address type was deleted', () => {
-            beforeEach(async () => {
-              await UserFormPage.clickAddAddressButton();
-              await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
-              await UserFormPage.defaultAddressTypeField.selectAndBlur('Home');
-              await UserFormPage.deleteAddressType();
-            });
-
-            it('should reset default address type to empty value', () => {
-              expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
-            });
-
-            it('should display validation message of "Default delivery address field"', () => {
-              expect(UserFormPage.defaultAddressTypeValidationMessage)
-                .to.equal('Please, add at least one address inside "Addresses" section');
-            });
-          });
-
-          describe('and all address types were deleted', () => {
-            beforeEach(async () => {
-              await UserFormPage.clickAddAddressButton();
-              await UserFormPage.clickAddAddressButton();
-              await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
-              await UserFormPage.secondAddressTypeField.selectAndBlur('Order');
-              await UserFormPage.defaultAddressTypeField.selectAndBlur('Order');
-              await UserFormPage.deleteAddressType();
-              await UserFormPage.deleteAddressType();
-            });
-
-            it('should reset default address type to empty value', () => {
-              expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
-            });
-
-            it('should display validation message of "Default delivery address field"', () => {
-              expect(UserFormPage.defaultAddressTypeValidationMessage)
-                .to.equal('Please, add at least one address inside "Addresses" section');
-            });
-          });
+        it('should display validation message of "Default delivery address field"', () => {
+          expect(UserFormPage.defaultAddressTypeValidationMessage)
+            .to.equal('Please, add at least one address inside "Addresses" section');
         });
       });
     });

--- a/test/bigtest/tests/user-proxy-edit-test.js
+++ b/test/bigtest/tests/user-proxy-edit-test.js
@@ -11,7 +11,6 @@ import FindUserInteractor from '@folio/plugin-find-user/test/bigtest/interactors
 
 import setupApplication from '../helpers/setup-application';
 import UserFormPage from '../interactors/user-form-page';
-import InstanceViewPage from '../interactors/user-view-page';
 import UsersInteractor from '../interactors/users';
 import FindUserInstancesInteractor from '../interactors/FindUserInstances';
 
@@ -39,176 +38,162 @@ describe('User Edit: Proxy/Sponsor', function () {
   const findUserPlugin = new FindUserInteractor({ timeout: 5000 });
   const findUserInstances = new FindUserInstancesInteractor({ timeout: 5000 });
 
-  describe('visiting user details', () => {
-    beforeEach(async function () {
-      this.visit('/users/preview/test-user-proxy-unique-id');
-      await InstanceViewPage.whenLoaded();
+  beforeEach(async function () {
+    this.visit('/users/test-user-proxy-unique-id/edit');
+    await UserFormPage.whenLoaded();
+  });
+
+  it('displays the title in the pane header', () => {
+    expect(UserFormPage.title).to.not.equal('Edit User');
+  });
+
+  describe('Add sponsor', () => {
+    beforeEach(async () => {
+      await UserFormPage.when(() => UserFormPage.proxySection.isPresent);
+      await findUserPlugin.when(() => findUserPlugin.button.isPresent);
+      await findUserPlugin.button.click();
     });
 
-    it('edit button is present', () => {
-      expect(InstanceViewPage.editButtonPresent).to.be.true;
+    it('should display the sponsor modal', () => {
+      expect(findUserPlugin.modal.isPresent).to.be.true;
     });
 
-    describe('visiting the edit user page', () => {
-      beforeEach(async function () {
-        await InstanceViewPage.clickEditButton();
-        await UserFormPage.whenLoaded();
+    describe('Find a valid sponsor', () => {
+      beforeEach(async () => {
+        await findUserPlugin.modal.searchField.fill('sponsor');
+        await findUserPlugin.modal.searchButton.click();
+        await findUserInstances.whenInstancesLoaded();
+        await findUserPlugin.modal.instances(0).click();
       });
 
-      it('displays the title in the pane header', () => {
-        expect(UserFormPage.title).to.not.equal('Edit User');
+      it('form should list a selected sponsor', () => {
+        expect(UserFormPage.proxySection.sponsorCount).to.equal(1);
       });
 
-      describe('Add sponsor', () => {
+      it('sponsor status should have two options', () => {
+        expect(UserFormPage.proxySection.statusCount).to.equal(2);
+      });
+
+      describe('Expire the relationship', () => {
         beforeEach(async () => {
-          await UserFormPage.when(() => UserFormPage.proxySection.isPresent);
-          await findUserPlugin.when(() => findUserPlugin.button.isPresent);
-          await findUserPlugin.button.click();
+          await UserFormPage.proxySection.expirationDate.fillAndBlur(faker.date.past(1).toJSON().substring(0, 10));
         });
 
-        it('should display the sponsor modal', () => {
-          expect(findUserPlugin.modal.isPresent).to.be.true;
+        it('relationship status should be be restricted', () => {
+          expect(UserFormPage.proxySection.statusCount).to.equal(1);
         });
 
-        describe('Find a valid sponsor', () => {
-          beforeEach(async () => {
-            await findUserPlugin.modal.searchField.fill('sponsor');
-            await findUserPlugin.modal.searchButton.click();
-            await findUserInstances.whenInstancesLoaded();
-            await findUserPlugin.modal.instances(0).click();
-          });
-
-          it('form should list a selected sponsor', () => {
-            expect(UserFormPage.proxySection.sponsorCount).to.equal(1);
-          });
-
-          it('sponsor status should have two options', () => {
-            expect(UserFormPage.proxySection.statusCount).to.equal(2);
-          });
-
-          describe('Expire the relationship', () => {
-            beforeEach(async () => {
-              await UserFormPage.proxySection.expirationDate.fillAndBlur(faker.date.past(1).toJSON().substring(0, 10));
-            });
-
-            it('relationship status should be be restricted', () => {
-              expect(UserFormPage.proxySection.statusCount).to.equal(1);
-            });
-
-            it('relationship status should be inactive', () => {
-              expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
-            });
-
-            it('relationship status should show a warning', () => {
-              expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
-              expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.proxyrelationship.expired']);
-            });
-          });
-
-          describe('Expire the user', () => {
-            beforeEach(async () => {
-              await UserFormPage.expirationDate.fillAndBlur('2019-01-01');
-            });
-
-            it('relationship status should be be restricted', () => {
-              expect(UserFormPage.proxySection.statusCount).to.equal(1);
-            });
-
-            it('relationship status should be inactive', () => {
-              expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
-            });
-
-            it('relationship status should show a warning', () => {
-              expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
-              expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.currentUser.expired']);
-            });
-          });
-          // describe('Saving a sponsor', () => {
-          //   beforeEach(async () => {
-          //     await UserFormPage.submitButton.click();
-          //     await InstanceViewPage.whenLoaded();
-          //   });
-
-          //   it('should navigate to the detail view', () => {
-          //     expect(users.$root).to.exist;
-          //   });
-
-          //   it('should display proxies in detail view', () => {
-          //     expect(InstanceViewPage.proxySection.sponsorCount).to.equal(1);
-          //   });
-
-          //   describe('Back to edit view', () => {
-          //     beforeEach(async () => {
-          //       await InstanceViewPage.clickEditButton();
-          //       await UserFormPage.whenLoaded();
-          //     });
-
-          //     it('should navigate to the edit view', () => {
-          //       expect(UserFormPage.title).to.not.equal('Edit User');
-          //     });
-          //   });
-          // });
+        it('relationship status should be inactive', () => {
+          expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
         });
 
-        describe('Find an expired sponsor', () => {
-          beforeEach(async () => {
-            await findUserPlugin.modal.searchField.fill('expired');
-            await findUserPlugin.modal.searchButton.click();
-            await findUserInstances.whenInstancesLoaded();
-            await findUserPlugin.modal.instances(0).click();
-          });
-
-          it('form should list a selected sponsor', () => {
-            expect(UserFormPage.proxySection.sponsorCount).to.equal(1);
-          });
-
-          it('relationship status should be be restricted', () => {
-            expect(UserFormPage.proxySection.statusCount).to.equal(1);
-          });
-
-          it('relationship status should be inactive', () => {
-            expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
-          });
-
-          it('relationship status should show a warning', () => {
-            expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
-            expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.sponsors.expired']);
-          });
-        });
-
-        describe('Adding user as own sponsor should fail', () => {
-          beforeEach(async () => {
-            await findUserPlugin.modal.searchField.fill('self');
-            await findUserPlugin.modal.searchButton.click();
-            await findUserInstances.whenInstancesLoaded();
-            await findUserPlugin.modal.instances(0).click();
-          });
-
-          it('sponsor list should be empty', () => {
-            expect(UserFormPage.proxySection.sponsorCount).to.equal(0);
-          });
-
-          it('error modal should be present', () => {
-            expect(UserFormPage.errorModal.isPresent).to.be.true;
-            expect(UserFormPage.errorModal.label).to.equal(translations['errors.sponsors.invalidUserLabel']);
-            expect(UserFormPage.errorModal.text).to.include(translations['errors.sponsors.invalidUserMessage']);
-          });
-
-          it('Malkovich?');
-          it('Malkovich! Malkovich Malkovich');
+        it('relationship status should show a warning', () => {
+          expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
+          expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.proxyrelationship.expired']);
         });
       });
 
-      describe('pane header menu', () => {
+      describe('Expire the user', () => {
         beforeEach(async () => {
-          await UserFormPage.cancelButton.click();
-          await users.whenLoaded();
+          await UserFormPage.expirationDate.fillAndBlur('2019-01-01');
         });
 
-        it('should redirect to view users page after click', () => {
-          expect(users.$root).to.exist;
+        it('relationship status should be be restricted', () => {
+          expect(UserFormPage.proxySection.statusCount).to.equal(1);
+        });
+
+        it('relationship status should be inactive', () => {
+          expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
+        });
+
+        it('relationship status should show a warning', () => {
+          expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
+          expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.currentUser.expired']);
         });
       });
+      // describe('Saving a sponsor', () => {
+      //   beforeEach(async () => {
+      //     await UserFormPage.submitButton.click();
+      //     await InstanceViewPage.whenLoaded();
+      //   });
+
+      //   it('should navigate to the detail view', () => {
+      //     expect(users.$root).to.exist;
+      //   });
+
+      //   it('should display proxies in detail view', () => {
+      //     expect(InstanceViewPage.proxySection.sponsorCount).to.equal(1);
+      //   });
+
+      //   describe('Back to edit view', () => {
+      //     beforeEach(async () => {
+      //       await InstanceViewPage.clickEditButton();
+      //       await UserFormPage.whenLoaded();
+      //     });
+
+      //     it('should navigate to the edit view', () => {
+      //       expect(UserFormPage.title).to.not.equal('Edit User');
+      //     });
+      //   });
+      // });
+    });
+
+    describe('Find an expired sponsor', () => {
+      beforeEach(async () => {
+        await findUserPlugin.modal.searchField.fill('expired');
+        await findUserPlugin.modal.searchButton.click();
+        await findUserInstances.whenInstancesLoaded();
+        await findUserPlugin.modal.instances(0).click();
+      });
+
+      it('form should list a selected sponsor', () => {
+        expect(UserFormPage.proxySection.sponsorCount).to.equal(1);
+      });
+
+      it('relationship status should be be restricted', () => {
+        expect(UserFormPage.proxySection.statusCount).to.equal(1);
+      });
+
+      it('relationship status should be inactive', () => {
+        expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
+      });
+
+      it('relationship status should show a warning', () => {
+        expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
+        expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.sponsors.expired']);
+      });
+    });
+
+    describe('Adding user as own sponsor should fail', () => {
+      beforeEach(async () => {
+        await findUserPlugin.modal.searchField.fill('self');
+        await findUserPlugin.modal.searchButton.click();
+        await findUserInstances.whenInstancesLoaded();
+        await findUserPlugin.modal.instances(0).click();
+      });
+
+      it('sponsor list should be empty', () => {
+        expect(UserFormPage.proxySection.sponsorCount).to.equal(0);
+      });
+
+      it('error modal should be present', () => {
+        expect(UserFormPage.errorModal.isPresent).to.be.true;
+        expect(UserFormPage.errorModal.label).to.equal(translations['errors.sponsors.invalidUserLabel']);
+        expect(UserFormPage.errorModal.text).to.include(translations['errors.sponsors.invalidUserMessage']);
+      });
+
+      it('Malkovich?');
+      it('Malkovich! Malkovich Malkovich');
+    });
+  });
+
+  describe('pane header menu', () => {
+    beforeEach(async () => {
+      await UserFormPage.cancelButton.click();
+    });
+
+    it('should redirect to view users page after click', () => {
+      expect(users.$root).to.exist;
     });
   });
 });

--- a/test/bigtest/tests/user-proxy-edit-test.js
+++ b/test/bigtest/tests/user-proxy-edit-test.js
@@ -79,16 +79,13 @@ describe('User Edit: Proxy/Sponsor', function () {
           await UserFormPage.proxySection.expirationDate.fillAndBlur(faker.date.past(1).toJSON().substring(0, 10));
         });
 
-        it('relationship status should be be restricted', () => {
+        it('relationship statuses should be correct', () => {
           expect(UserFormPage.proxySection.statusCount).to.equal(1);
-        });
-
-        it('relationship status should be inactive', () => {
           expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
+          expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
         });
 
-        it('relationship status should show a warning', () => {
-          expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
+        it('should be the correct warning', () => {
           expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.proxyrelationship.expired']);
         });
       });
@@ -98,44 +95,16 @@ describe('User Edit: Proxy/Sponsor', function () {
           await UserFormPage.expirationDate.fillAndBlur('2019-01-01');
         });
 
-        it('relationship status should be be restricted', () => {
+        it('relationship statuses should be correct', () => {
           expect(UserFormPage.proxySection.statusCount).to.equal(1);
-        });
-
-        it('relationship status should be inactive', () => {
           expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
+          expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
         });
 
-        it('relationship status should show a warning', () => {
-          expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
+        it('should be the correct warning', () => {
           expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.currentUser.expired']);
         });
       });
-      // describe('Saving a sponsor', () => {
-      //   beforeEach(async () => {
-      //     await UserFormPage.submitButton.click();
-      //     await InstanceViewPage.whenLoaded();
-      //   });
-
-      //   it('should navigate to the detail view', () => {
-      //     expect(users.$root).to.exist;
-      //   });
-
-      //   it('should display proxies in detail view', () => {
-      //     expect(InstanceViewPage.proxySection.sponsorCount).to.equal(1);
-      //   });
-
-      //   describe('Back to edit view', () => {
-      //     beforeEach(async () => {
-      //       await InstanceViewPage.clickEditButton();
-      //       await UserFormPage.whenLoaded();
-      //     });
-
-      //     it('should navigate to the edit view', () => {
-      //       expect(UserFormPage.title).to.not.equal('Edit User');
-      //     });
-      //   });
-      // });
     });
 
     describe('Find an expired sponsor', () => {
@@ -146,20 +115,14 @@ describe('User Edit: Proxy/Sponsor', function () {
         await findUserPlugin.modal.instances(0).click();
       });
 
-      it('form should list a selected sponsor', () => {
+      it('relationship statuses should be correct', () => {
         expect(UserFormPage.proxySection.sponsorCount).to.equal(1);
-      });
-
-      it('relationship status should be be restricted', () => {
         expect(UserFormPage.proxySection.statusCount).to.equal(1);
-      });
-
-      it('relationship status should be inactive', () => {
         expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
+        expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
       });
 
-      it('relationship status should show a warning', () => {
-        expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
+      it('should be the correct warning', () => {
         expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.sponsors.expired']);
       });
     });
@@ -181,9 +144,6 @@ describe('User Edit: Proxy/Sponsor', function () {
         expect(UserFormPage.errorModal.label).to.equal(translations['errors.sponsors.invalidUserLabel']);
         expect(UserFormPage.errorModal.text).to.include(translations['errors.sponsors.invalidUserMessage']);
       });
-
-      it('Malkovich?');
-      it('Malkovich! Malkovich Malkovich');
     });
   });
 

--- a/test/bigtest/tests/users-show-all-test.js
+++ b/test/bigtest/tests/users-show-all-test.js
@@ -65,17 +65,12 @@ describe('Users', () => {
         await InstanceViewPage.whenLoaded();
       });
 
-      it('should load the user instance details', () => {
-        expect(usersInteractor.instance.isVisible).to.be.true;
-      });
-
       it('should display the loans section', () => {
         expect(InstanceViewPage.loansSection.isPresent).to.be.true;
       });
 
       describe('clicking on the accordion of the loans section', function () {
         beforeEach(async function () {
-          await InstanceViewPage.whenLoaded();
           await InstanceViewPage.loansSection.accordionButton.click();
         });
 
@@ -112,10 +107,6 @@ describe('Users', () => {
                 await usersInteractor.whenInstanceLoaded();
               });
 
-              it('should navigate to the user preview page', () => {
-                expect(usersInteractor.instance.isVisible).to.be.true;
-              });
-
               it('should have the correct url with query', function () {
                 expect(this.location.pathname.endsWith(`users/preview/${users[0].id}`)).to.be.true;
                 expect(this.location.search).to.equal(searchQuery);
@@ -150,10 +141,6 @@ describe('Users', () => {
                 await LoansListingPane.whenLoaded();
                 await LoansListingPane.closeButton.click();
                 await usersInteractor.whenInstanceLoaded();
-              });
-
-              it('should navigate to the user preview page', () => {
-                expect(usersInteractor.instance.isVisible).to.be.true;
               });
 
               it('should have the correct url with query', function () {


### PR DESCRIPTION
## Purpose
Improve the situation with BigTest tests which are unstable recently.

## Approach

- used React.lazy to not load all stuff (seems like now it is possible). I think it would be great to use it from now on in other modules;
- reduced the flow to get to the test (basically reducing the nested describes). For example, the need to test the edit user form. Instead of navigating to /users and then by clicking on the edit button to the edit form, -navigate straight away to edit route;
- grouped some unstable tests. For example, the tests which test for existing properties after the heavy beforeEach has done;

Additionally, the navigation was handled [here](https://github.com/folio-org/ui-users/pull/1129/commits/b4185107e43328f41852cfd2e0d7e86ee1a05906#diff-e74dacc8738c898345810bad610956a4R275) and [here](https://github.com/folio-org/ui-users/pull/1129/commits/b4185107e43328f41852cfd2e0d7e86ee1a05906#diff-e74dacc8738c898345810bad610956a4R238). Since it affected tests, these changed should be made. The motivation for it is that when the user navigates to the edit page straight away and user has not the previous history (imagine user navigates for the first time), clicking on the close button will throw user to the empty tab (like new tab view in the browser), instead of navigating to the users page with the preserved search query.