### PR TITLE
UIU-1413: Omit useless fields, when fee/fine is paying, to prevent backend error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Omit 'notify' field upon creating fee/fine in order to prevent backend error. Fixes UIU-1438.
 * Refresh list of loans after anonymization. Fixes UIU-1046.
 * Add UI to mark items Declared lost. Refs UIU-1202.
+* Omit `comments`, `patronInfo` fields, when fee/fine is paying, to prevent backend error. Fixes UIU-1413.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -164,7 +164,6 @@ class ChargeFeeFine extends React.Component {
         amountAction: parseFloat(amount || 0).toFixed(2),
         balance: parseFloat(balance || 0).toFixed(2),
         transactionInformation: transaction || '-',
-        comments: comment,
         notify,
       };
       this.props.mutator.feefineactions.POST(Object.assign(action, newAction));
@@ -286,7 +285,7 @@ class ChargeFeeFine extends React.Component {
       this.type.paymentStatus.name = paymentStatus;
       this.props.mutator.activeRecord.update({ id: this.type.id });
 
-      return this.props.mutator.accounts.PUT(_.omit(this.type, ['notify']));
+      return this.props.mutator.accounts.PUT(_.omit(this.type, ['comments', 'patronInfo', 'notify']));
     })
       .then(() => this.newAction({ paymentMethod: values.method }, this.type.id,
         this.type.paymentStatus.name, values.amount,


### PR DESCRIPTION
# Description 
Omit `comments` and `patronInfo` fields, when fee/fine and charge is paying, to prevent backend error
# Issue
https://issues.folio.org/browse/UIU-1413
# Screenshot
![image](https://user-images.githubusercontent.com/55694637/72257883-62525f00-3615-11ea-8e4e-63cef3aa6bb8.png)
