### PR TITLE
UIU-1450 XHRs musn't leak memory after component unmounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Refresh list of loans after anonymization. Fixes UIU-1046.
 * Add UI to mark items Declared lost. Refs UIU-1202.
 * Omit `comments`, `patronInfo` fields, when fee/fine is paying, to prevent backend error. Fixes UIU-1413.
+* Don't update state in `withRenew` when unmounted. Fixes UIU-1450.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)


### PR DESCRIPTION
Renew: Does not check its lifecycle
Sets the state, leaks out memory
Promise completes alone
When it resolves, component heaves, detached from the DOM
The console begins to moan

Memory, all alone without GC
It is leaking out two ways
From this component when:
It remembers loan policy and count-request too
Stop the memory leak again!

Refs [UIU-1450](https://issues.folio.org/browse/UIU-1450)