### PR TITLE
Improve tests

### DIFF
--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -44,6 +44,7 @@ class UserEdit extends React.Component {
     stripes: PropTypes.object,
     resources: PropTypes.object,
     history: PropTypes.object,
+    location: PropTypes.object,
     match: PropTypes.object,
     updateProxies: PropTypes.func,
     updateSponsors: PropTypes.func,
@@ -198,6 +199,8 @@ class UserEdit extends React.Component {
       mutator,
       history,
       resources,
+      match: { params },
+      location: { state },
       stripes,
     } = this.props;
 
@@ -232,7 +235,10 @@ class UserEdit extends React.Component {
     data.active = (moment(user.expirationDate).endOf('day').isSameOrAfter(today));
 
     mutator.selUser.PUT(data).then(() => {
-      history.goBack();
+      history.push({
+        pathname: params.id ? `/users/preview/${params.id}` : '/users',
+        state,
+      });
     });
   }
 
@@ -249,6 +255,7 @@ class UserEdit extends React.Component {
     const {
       history,
       resources,
+      location: { state },
       match: { params }
     } = this.props;
 
@@ -258,7 +265,6 @@ class UserEdit extends React.Component {
 
     // data is information that the form needs, mostly to populate options lists
     const formData = this.getUserFormData();
-
     const onSubmit = params.id ? (record) => this.update(record) : (record) => this.create(record);
 
     return (
@@ -266,7 +272,12 @@ class UserEdit extends React.Component {
         formData={formData}
         initialValues={this.getUserFormValues()} // values are strictly values...if we're editing (id param present) pull in existing values.
         onSubmit={onSubmit}
-        onCancel={() => history.goBack()}
+        onCancel={() => {
+          history.push({
+            pathname: params.id ? `/users/preview/${params.id}` : '/users',
+            state,
+          });
+        }}
         uniquenessValidator={this.props.mutator.uniquenessValidator}
       />
     );

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -403,6 +403,7 @@ class UserForm extends React.Component {
       formData,
       change, // from redux-form...
       servicePoints,
+      onCancel,
     } = this.props;
 
     const { sections } = this.state;
@@ -432,6 +433,7 @@ class UserForm extends React.Component {
                   {paneTitle}
                 </span>
               }
+              onClose={onCancel}
             >
               <div className={css.UserFormContent}>
                 <Headline

--- a/test/bigtest/interactors/users.js
+++ b/test/bigtest/interactors/users.js
@@ -28,7 +28,7 @@ export default @interactor class UsersInteractor {
   headerDropdownMenu = new HeaderDropdownMenu();
   searchFocused = isPresent('[data-test-user-search-input]:focus');
   patronGroupsPresent = isPresent('#clickable-filter-pg-faculty');
-  instancePresent = isPresent('[data-test-user-instances] [data-test-instance-details]');
+  instancePresent = isPresent('[data-test-instance-details]');
   instancesPresent = isPresent('[role=group] [role=row]');
   headerDropdown = new HeaderDropdown('[class*=paneHeaderCenterInner---] [class*=dropdown---]');
   clickFacultyCheckbox = clickable('#clickable-filter-pg-faculty');

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -17,156 +17,143 @@ describe('User Edit Page', () => {
 
   setupApplication();
 
-  describe('visit users-details', () => {
+  beforeEach(async function () {
+    user1 = this.server.create('user');
+    user2 = this.server.create('user');
+    this.server.create('requestPreference', {
+      userId: user1.id,
+      delivery: true,
+      defaultServicePointId: 'servicepointId1',
+      defaultDeliveryAddressTypeId: 'Type1',
+      fulfillment: 'Delivery',
+    });
+
+    this.visit(`/users/${user1.id}/edit`);
+    await UserFormPage.whenLoaded();
+  });
+
+  it('displays the title in the pane header', () => {
+    expect(UserFormPage.title).to.equal(user1.username);
+  });
+
+  describe('validating user barcode', () => {
     beforeEach(async function () {
-      user1 = this.server.create('user');
-      user2 = this.server.create('user');
-      this.server.create('requestPreference', {
-        userId: user1.id,
-        delivery: true,
-        defaultServicePointId: 'servicepointId1',
-        defaultDeliveryAddressTypeId: 'Type1',
-        fulfillment: 'Delivery',
-      });
-
-      this.visit(`/users/preview/${user1.id}`);
-      await InstanceViewPage.whenLoaded();
+      await UserFormPage.barcodeField.fillAndBlur(user2.barcode);
+      await UserFormPage.submitButton.click();
     });
 
-    it('edit button is present', () => {
-      expect(InstanceViewPage.editButtonPresent).to.be.true;
+    it('should display validation error', () => {
+      expect(UserFormPage.feedbackError).to.equal('This barcode has already been taken');
+    });
+  });
+
+  describe('validating empty user barcode', () => {
+    beforeEach(async function () {
+      await UserFormPage.barcodeField.fillAndBlur('');
+      await UserFormPage.submitButton.click();
     });
 
-    describe('visiting the edit user page', () => {
-      beforeEach(async function () {
-        await InstanceViewPage.clickEditButton();
-        await UserFormPage.whenLoaded();
+    it('should show user detail view', () => {
+      expect(InstanceViewPage.isVisible).to.equal(true);
+    });
+  });
+
+  describe('validating username', () => {
+    beforeEach(async function () {
+      await UserFormPage.usernameField.fillAndBlur(user2.username);
+      await UserFormPage.submitButton.click();
+    });
+
+    it('should display validation error', () => {
+      expect(UserFormPage.feedbackError).to.equal('This username already exists');
+    });
+  });
+
+  describe('pane header menu', () => {
+    beforeEach(async () => {
+      await UserFormPage.cancelButton.click();
+    });
+
+    it('should redirect to view users page after click', () => {
+      expect(users.$root).to.exist;
+    });
+  });
+
+  describe('request preferences', () => {
+    it('should display "hold shelf" checkbox as checked', () => {
+      expect(UserFormPage.holdShelfCheckboxIsChecked).to.be.true;
+    });
+
+    it('should display "hold shelf" checkbox as disabled', () => {
+      expect(UserFormPage.holdShelfCheckboxIsDisabled).to.be.true;
+    });
+
+    describe('when delivery is activated', () => {
+      it('should display "delivery" checkbox as checked', () => {
+        expect(UserFormPage.deliveryCheckboxIsChecked).to.be.true;
       });
 
-      it('displays the title in the pane header', () => {
-        expect(UserFormPage.title).to.equal(user1.username);
+      it('should display selected "Fulfillment preference"', () => {
+        expect(UserFormPage.fulfillmentPreference.value).to.equal('Delivery');
       });
 
-      describe('validating user barcode', () => {
-        beforeEach(async function () {
-          await UserFormPage.barcodeField.fillAndBlur(user2.barcode);
-          await UserFormPage.submitButton.click();
-        });
-
-        it('should display validation error', () => {
-          expect(UserFormPage.feedbackError).to.equal('This barcode has already been taken');
-        });
+      it('should display selected default address type', () => {
+        const CLAIM_ADDRESS_TYPE_VALUE = 'Type1';
+        expect(UserFormPage.defaultAddressTypeField.value).to.equal(CLAIM_ADDRESS_TYPE_VALUE);
       });
 
-      describe('validating empty user barcode', () => {
-        beforeEach(async function () {
-          await UserFormPage.barcodeField.fillAndBlur('');
-          await UserFormPage.submitButton.click();
-        });
-
-        it('should show user detail view', () => {
-          expect(InstanceViewPage.isVisible).to.equal(true);
-        });
-      });
-
-      describe('validating username', () => {
-        beforeEach(async function () {
-          await UserFormPage.usernameField.fillAndBlur(user2.username);
-          await UserFormPage.submitButton.click();
-        });
-
-        it('should display validation error', () => {
-          expect(UserFormPage.feedbackError).to.equal('This username already exists');
-        });
-      });
-
-      describe('pane header menu', () => {
+      describe('and selected default address type was changed', () => {
         beforeEach(async () => {
-          await UserFormPage.cancelButton.click();
+          await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
+          await UserFormPage.defaultAddressTypeField.selectAndBlur('Home');
+          await UserFormPage.firstAddressTypeField.selectAndBlur('Order');
         });
 
-        it('should redirect to view users page after click', () => {
-          expect(users.$root).to.exist;
+        it('should reset default address type to empty value', () => {
+          expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
+        });
+
+        it('should display validation message of "Default delivery address field"', () => {
+          expect(UserFormPage.defaultAddressTypeValidationMessage).to.equal('Please fill this in to continue');
         });
       });
 
-      describe('request preferences', () => {
-        it('should display "hold shelf" checkbox as checked', () => {
-          expect(UserFormPage.holdShelfCheckboxIsChecked).to.be.true;
+      describe('and selected default address type was deleted', () => {
+        beforeEach(async () => {
+          await UserFormPage.clickAddAddressButton();
+          await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
+          await UserFormPage.defaultAddressTypeField.selectAndBlur('Home');
+          await UserFormPage.deleteAddressType();
         });
 
-        it('should display "hold shelf" checkbox as disabled', () => {
-          expect(UserFormPage.holdShelfCheckboxIsDisabled).to.be.true;
+        it('should reset default address type to empty value', () => {
+          expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
         });
 
-        describe('when delivery is activated', () => {
-          it('should display "delivery" checkbox as checked', () => {
-            expect(UserFormPage.deliveryCheckboxIsChecked).to.be.true;
-          });
+        it('should display validation message of "Default delivery address field"', () => {
+          expect(UserFormPage.defaultAddressTypeValidationMessage)
+            .to.equal('Please, add at least one address inside "Addresses" section');
+        });
+      });
 
-          it('should display selected "Fulfillment preference"', () => {
-            expect(UserFormPage.fulfillmentPreference.value).to.equal('Delivery');
-          });
+      describe('and all address types were deleted', () => {
+        beforeEach(async () => {
+          await UserFormPage.clickAddAddressButton();
+          await UserFormPage.clickAddAddressButton();
+          await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
+          await UserFormPage.secondAddressTypeField.selectAndBlur('Order');
+          await UserFormPage.defaultAddressTypeField.selectAndBlur('Order');
+          await UserFormPage.deleteAddressType();
+          await UserFormPage.deleteAddressType();
+        });
 
-          it('should display selected default address type', () => {
-            const CLAIM_ADDRESS_TYPE_VALUE = 'Type1';
-            expect(UserFormPage.defaultAddressTypeField.value).to.equal(CLAIM_ADDRESS_TYPE_VALUE);
-          });
+        it('should reset default address type to empty value', () => {
+          expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
+        });
 
-          describe('and selected default address type was changed', () => {
-            beforeEach(async () => {
-              await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
-              await UserFormPage.defaultAddressTypeField.selectAndBlur('Home');
-              await UserFormPage.firstAddressTypeField.selectAndBlur('Order');
-            });
-
-            it('should reset default address type to empty value', () => {
-              expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
-            });
-
-            it('should display validation message of "Default delivery address field"', () => {
-              expect(UserFormPage.defaultAddressTypeValidationMessage).to.equal('Please fill this in to continue');
-            });
-          });
-
-          describe('and selected default address type was deleted', () => {
-            beforeEach(async () => {
-              await UserFormPage.clickAddAddressButton();
-              await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
-              await UserFormPage.defaultAddressTypeField.selectAndBlur('Home');
-              await UserFormPage.deleteAddressType();
-            });
-
-            it('should reset default address type to empty value', () => {
-              expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
-            });
-
-            it('should display validation message of "Default delivery address field"', () => {
-              expect(UserFormPage.defaultAddressTypeValidationMessage)
-                .to.equal('Please, add at least one address inside "Addresses" section');
-            });
-          });
-
-          describe('and all address types were deleted', () => {
-            beforeEach(async () => {
-              await UserFormPage.clickAddAddressButton();
-              await UserFormPage.clickAddAddressButton();
-              await UserFormPage.firstAddressTypeField.selectAndBlur('Home');
-              await UserFormPage.secondAddressTypeField.selectAndBlur('Order');
-              await UserFormPage.defaultAddressTypeField.selectAndBlur('Order');
-              await UserFormPage.deleteAddressType();
-              await UserFormPage.deleteAddressType();
-            });
-
-            it('should reset default address type to empty value', () => {
-              expect(UserFormPage.defaultAddressTypeField.value).to.equal('');
-            });
-
-            it('should display validation message of "Default delivery address field"', () => {
-              expect(UserFormPage.defaultAddressTypeValidationMessage)
-                .to.equal('Please, add at least one address inside "Addresses" section');
-            });
-          });
+        it('should display validation message of "Default delivery address field"', () => {
+          expect(UserFormPage.defaultAddressTypeValidationMessage)
+            .to.equal('Please, add at least one address inside "Addresses" section');
         });
       });
     });

--- a/test/bigtest/tests/user-proxy-edit-test.js
+++ b/test/bigtest/tests/user-proxy-edit-test.js
@@ -11,7 +11,6 @@ import FindUserInteractor from '@folio/plugin-find-user/test/bigtest/interactors
 
 import setupApplication from '../helpers/setup-application';
 import UserFormPage from '../interactors/user-form-page';
-import InstanceViewPage from '../interactors/user-view-page';
 import UsersInteractor from '../interactors/users';
 import FindUserInstancesInteractor from '../interactors/FindUserInstances';
 
@@ -39,176 +38,122 @@ describe('User Edit: Proxy/Sponsor', function () {
   const findUserPlugin = new FindUserInteractor({ timeout: 5000 });
   const findUserInstances = new FindUserInstancesInteractor({ timeout: 5000 });
 
-  describe('visiting user details', () => {
-    beforeEach(async function () {
-      this.visit('/users/preview/test-user-proxy-unique-id');
-      await InstanceViewPage.whenLoaded();
+  beforeEach(async function () {
+    this.visit('/users/test-user-proxy-unique-id/edit');
+    await UserFormPage.whenLoaded();
+  });
+
+  it('displays the title in the pane header', () => {
+    expect(UserFormPage.title).to.not.equal('Edit User');
+  });
+
+  describe('Add sponsor', () => {
+    beforeEach(async () => {
+      await UserFormPage.when(() => UserFormPage.proxySection.isPresent);
+      await findUserPlugin.when(() => findUserPlugin.button.isPresent);
+      await findUserPlugin.button.click();
     });
 
-    it('edit button is present', () => {
-      expect(InstanceViewPage.editButtonPresent).to.be.true;
+    it('should display the sponsor modal', () => {
+      expect(findUserPlugin.modal.isPresent).to.be.true;
     });
 
-    describe('visiting the edit user page', () => {
-      beforeEach(async function () {
-        await InstanceViewPage.clickEditButton();
-        await UserFormPage.whenLoaded();
+    describe('Find a valid sponsor', () => {
+      beforeEach(async () => {
+        await findUserPlugin.modal.searchField.fill('sponsor');
+        await findUserPlugin.modal.searchButton.click();
+        await findUserInstances.whenInstancesLoaded();
+        await findUserPlugin.modal.instances(0).click();
       });
 
-      it('displays the title in the pane header', () => {
-        expect(UserFormPage.title).to.not.equal('Edit User');
+      it('form should list a selected sponsor', () => {
+        expect(UserFormPage.proxySection.sponsorCount).to.equal(1);
       });
 
-      describe('Add sponsor', () => {
+      it('sponsor status should have two options', () => {
+        expect(UserFormPage.proxySection.statusCount).to.equal(2);
+      });
+
+      describe('Expire the relationship', () => {
         beforeEach(async () => {
-          await UserFormPage.when(() => UserFormPage.proxySection.isPresent);
-          await findUserPlugin.when(() => findUserPlugin.button.isPresent);
-          await findUserPlugin.button.click();
+          await UserFormPage.proxySection.expirationDate.fillAndBlur(faker.date.past(1).toJSON().substring(0, 10));
         });
 
-        it('should display the sponsor modal', () => {
-          expect(findUserPlugin.modal.isPresent).to.be.true;
+        it('relationship statuses should be correct', () => {
+          expect(UserFormPage.proxySection.statusCount).to.equal(1);
+          expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
+          expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
         });
 
-        describe('Find a valid sponsor', () => {
-          beforeEach(async () => {
-            await findUserPlugin.modal.searchField.fill('sponsor');
-            await findUserPlugin.modal.searchButton.click();
-            await findUserInstances.whenInstancesLoaded();
-            await findUserPlugin.modal.instances(0).click();
-          });
-
-          it('form should list a selected sponsor', () => {
-            expect(UserFormPage.proxySection.sponsorCount).to.equal(1);
-          });
-
-          it('sponsor status should have two options', () => {
-            expect(UserFormPage.proxySection.statusCount).to.equal(2);
-          });
-
-          describe('Expire the relationship', () => {
-            beforeEach(async () => {
-              await UserFormPage.proxySection.expirationDate.fillAndBlur(faker.date.past(1).toJSON().substring(0, 10));
-            });
-
-            it('relationship status should be be restricted', () => {
-              expect(UserFormPage.proxySection.statusCount).to.equal(1);
-            });
-
-            it('relationship status should be inactive', () => {
-              expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
-            });
-
-            it('relationship status should show a warning', () => {
-              expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
-              expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.proxyrelationship.expired']);
-            });
-          });
-
-          describe('Expire the user', () => {
-            beforeEach(async () => {
-              await UserFormPage.expirationDate.fillAndBlur('2019-01-01');
-            });
-
-            it('relationship status should be be restricted', () => {
-              expect(UserFormPage.proxySection.statusCount).to.equal(1);
-            });
-
-            it('relationship status should be inactive', () => {
-              expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
-            });
-
-            it('relationship status should show a warning', () => {
-              expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
-              expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.currentUser.expired']);
-            });
-          });
-          // describe('Saving a sponsor', () => {
-          //   beforeEach(async () => {
-          //     await UserFormPage.submitButton.click();
-          //     await InstanceViewPage.whenLoaded();
-          //   });
-
-          //   it('should navigate to the detail view', () => {
-          //     expect(users.$root).to.exist;
-          //   });
-
-          //   it('should display proxies in detail view', () => {
-          //     expect(InstanceViewPage.proxySection.sponsorCount).to.equal(1);
-          //   });
-
-          //   describe('Back to edit view', () => {
-          //     beforeEach(async () => {
-          //       await InstanceViewPage.clickEditButton();
-          //       await UserFormPage.whenLoaded();
-          //     });
-
-          //     it('should navigate to the edit view', () => {
-          //       expect(UserFormPage.title).to.not.equal('Edit User');
-          //     });
-          //   });
-          // });
-        });
-
-        describe('Find an expired sponsor', () => {
-          beforeEach(async () => {
-            await findUserPlugin.modal.searchField.fill('expired');
-            await findUserPlugin.modal.searchButton.click();
-            await findUserInstances.whenInstancesLoaded();
-            await findUserPlugin.modal.instances(0).click();
-          });
-
-          it('form should list a selected sponsor', () => {
-            expect(UserFormPage.proxySection.sponsorCount).to.equal(1);
-          });
-
-          it('relationship status should be be restricted', () => {
-            expect(UserFormPage.proxySection.statusCount).to.equal(1);
-          });
-
-          it('relationship status should be inactive', () => {
-            expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
-          });
-
-          it('relationship status should show a warning', () => {
-            expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
-            expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.sponsors.expired']);
-          });
-        });
-
-        describe('Adding user as own sponsor should fail', () => {
-          beforeEach(async () => {
-            await findUserPlugin.modal.searchField.fill('self');
-            await findUserPlugin.modal.searchButton.click();
-            await findUserInstances.whenInstancesLoaded();
-            await findUserPlugin.modal.instances(0).click();
-          });
-
-          it('sponsor list should be empty', () => {
-            expect(UserFormPage.proxySection.sponsorCount).to.equal(0);
-          });
-
-          it('error modal should be present', () => {
-            expect(UserFormPage.errorModal.isPresent).to.be.true;
-            expect(UserFormPage.errorModal.label).to.equal(translations['errors.sponsors.invalidUserLabel']);
-            expect(UserFormPage.errorModal.text).to.include(translations['errors.sponsors.invalidUserMessage']);
-          });
-
-          it('Malkovich?');
-          it('Malkovich! Malkovich Malkovich');
+        it('should be the correct warning', () => {
+          expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.proxyrelationship.expired']);
         });
       });
 
-      describe('pane header menu', () => {
+      describe('Expire the user', () => {
         beforeEach(async () => {
-          await UserFormPage.cancelButton.click();
-          await users.whenLoaded();
+          await UserFormPage.expirationDate.fillAndBlur('2019-01-01');
         });
 
-        it('should redirect to view users page after click', () => {
-          expect(users.$root).to.exist;
+        it('relationship statuses should be correct', () => {
+          expect(UserFormPage.proxySection.statusCount).to.equal(1);
+          expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
+          expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
+        });
+
+        it('should be the correct warning', () => {
+          expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.currentUser.expired']);
         });
       });
+    });
+
+    describe('Find an expired sponsor', () => {
+      beforeEach(async () => {
+        await findUserPlugin.modal.searchField.fill('expired');
+        await findUserPlugin.modal.searchButton.click();
+        await findUserInstances.whenInstancesLoaded();
+        await findUserPlugin.modal.instances(0).click();
+      });
+
+      it('relationship statuses should be correct', () => {
+        expect(UserFormPage.proxySection.sponsorCount).to.equal(1);
+        expect(UserFormPage.proxySection.statusCount).to.equal(1);
+        expect(UserFormPage.proxySection.relationshipStatus.val).to.equal('inactive');
+        expect(UserFormPage.proxySection.relationshipStatus.hasWarningStyle).to.be.true;
+      });
+
+      it('should be the correct warning', () => {
+        expect(UserFormPage.proxySection.relationshipStatus.warningText).to.equal(translations['errors.sponsors.expired']);
+      });
+    });
+
+    describe('Adding user as own sponsor should fail', () => {
+      beforeEach(async () => {
+        await findUserPlugin.modal.searchField.fill('self');
+        await findUserPlugin.modal.searchButton.click();
+        await findUserInstances.whenInstancesLoaded();
+        await findUserPlugin.modal.instances(0).click();
+      });
+
+      it('sponsor list should be empty', () => {
+        expect(UserFormPage.proxySection.sponsorCount).to.equal(0);
+      });
+
+      it('error modal should be present', () => {
+        expect(UserFormPage.errorModal.isPresent).to.be.true;
+        expect(UserFormPage.errorModal.label).to.equal(translations['errors.sponsors.invalidUserLabel']);
+        expect(UserFormPage.errorModal.text).to.include(translations['errors.sponsors.invalidUserMessage']);
+      });
+    });
+  });
+
+  describe('pane header menu', () => {
+    beforeEach(async () => {
+      await UserFormPage.cancelButton.click();
+    });
+
+    it('should redirect to view users page after click', () => {
+      expect(users.$root).to.exist;
     });
   });
 });

--- a/test/bigtest/tests/users-show-all-test.js
+++ b/test/bigtest/tests/users-show-all-test.js
@@ -65,17 +65,12 @@ describe('Users', () => {
         await InstanceViewPage.whenLoaded();
       });
 
-      it('should load the user instance details', () => {
-        expect(usersInteractor.instance.isVisible).to.be.true;
-      });
-
       it('should display the loans section', () => {
         expect(InstanceViewPage.loansSection.isPresent).to.be.true;
       });
 
       describe('clicking on the accordion of the loans section', function () {
         beforeEach(async function () {
-          await InstanceViewPage.whenLoaded();
           await InstanceViewPage.loansSection.accordionButton.click();
         });
 
@@ -112,10 +107,6 @@ describe('Users', () => {
                 await usersInteractor.whenInstanceLoaded();
               });
 
-              it('should navigate to the user preview page', () => {
-                expect(usersInteractor.instance.isVisible).to.be.true;
-              });
-
               it('should have the correct url with query', function () {
                 expect(this.location.pathname.endsWith(`users/preview/${users[0].id}`)).to.be.true;
                 expect(this.location.search).to.equal(searchQuery);
@@ -150,10 +141,6 @@ describe('Users', () => {
                 await LoansListingPane.whenLoaded();
                 await LoansListingPane.closeButton.click();
                 await usersInteractor.whenInstanceLoaded();
-              });
-
-              it('should navigate to the user preview page', () => {
-                expect(usersInteractor.instance.isVisible).to.be.true;
               });
 
               it('should have the correct url with query', function () {


### PR DESCRIPTION
## Purpose
Improve the situation with BigTest tests which are unstable recently. This is the analog of #1129 but without `React.lazy` which requires additional testing per @mkuklis and @aditya-matukumalli. They are going to test it on one route for the beginning.

## Approach
- reduced the flow to get to the test (basically reducing the nested describes). For example, the need to test the edit user form. Instead of navigating to /users and then by clicking on the edit button to the edit form, -navigate straight away to edit route;
- grouped some unstable tests. For example, the tests which test for existing properties after the heavy beforeEach has done;

Additionally, the navigation was handled [here](https://github.com/folio-org/ui-users/pull/1129/commits/b4185107e43328f41852cfd2e0d7e86ee1a05906#diff-e74dacc8738c898345810bad610956a4R275) and [here](https://github.com/folio-org/ui-users/pull/1129/commits/b4185107e43328f41852cfd2e0d7e86ee1a05906#diff-e74dacc8738c898345810bad610956a4R238). Since it affected tests, these changed should be made. The motivation for it is that when the user navigates to the edit page straight away and user has not the previous history (imagine user navigates for the first time), clicking on the close button will throw user to the empty tab (like new tab view in the browser), instead of navigating to the users page with the preserved search query.