### PR TITLE
FOLIO-2097 comment CommandList and HasCommand

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import { hot } from 'react-hot-loader';
 import _ from 'lodash';
 
 import { Route, Switch, IfPermission } from '@folio/stripes/core';
-import { CommandList, HasCommand } from '@folio/stripes/components';
+// import { CommandList, HasCommand } from '@folio/stripes/components';
 
 import * as Routes from './routes';
 
@@ -220,12 +220,14 @@ class UsersRouting extends React.Component {
     }
 
     return (
+      {/*
       <CommandList commands={commands}>
         <HasCommand
           commands={this.shortcuts}
           isWithinScope={this.checkScope}
           scope={this.shortcutScope}
         >
+      */}
           <Switch>
             <Route
               path={`${base}/:id/loans/view/:loanid`}
@@ -284,8 +286,10 @@ class UsersRouting extends React.Component {
             </Route>
             <Route render={this.noMatch} />
           </Switch>
+        {/*
         </HasCommand>
       </CommandList>
+      */}
     );
   }
 }

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -25,7 +25,7 @@ import {
   Col,
   Headline,
   AccordionSet,
-  HasCommand,
+  // HasCommand,
 } from '@folio/stripes/components';
 
 import {
@@ -403,181 +403,185 @@ class UserDetail extends React.Component {
     } else {
       return (
         <React.Fragment>
+          {/*
           <HasCommand
             commands={this.shortcuts}
             isWithinScope={this.checkScope}
             scope={document.body}
           >
-            <Pane
-              data-test-instance-details
-              id="pane-userdetails"
-              appIcon={<AppIcon app="users" appIconKey="users" />}
-              defaultWidth={paneWidth}
-              paneTitle={
-                <span data-test-header-title>
-                  {getFullName(user)}
-                </span>
-              }
-              lastMenu={this.renderDetailMenu(user)}
-              dismissible
-              onClose={this.onClose}
-              actionMenu={this.getActionMenu}
-            >
-              <TitleManager record={getFullName(user)} />
-              <Headline
-                size="xx-large"
-                tag="h2"
-              >
+          */}
+          <Pane
+            data-test-instance-details
+            id="pane-userdetails"
+            appIcon={<AppIcon app="users" appIconKey="users" />}
+            defaultWidth={paneWidth}
+            paneTitle={
+              <span data-test-header-title>
                 {getFullName(user)}
-              </Headline>
-              <Row>
-                <Col xs={10}>
-                  {(hasPatronBlocks === 1 && totalPatronBlocks > 0)
-                    ? <PatronBlockMessage />
-                    : ''}
-                </Col>
-                <Col xs={2}>
-                  <ExpandAllButton
-                    accordionStatus={sections}
-                    onToggle={this.handleExpandAll}
-                  />
-                </Col>
-              </Row>
-              <AccordionSet>
-                <UserInfo
-                  accordionId="userInformationSection"
-                  user={user}
-                  patronGroup={patronGroup}
-                  settings={settings}
-                  stripes={stripes}
-                  expanded={sections.userInformationSection}
-                  onToggle={this.handleSectionToggle}
+              </span>
+            }
+            lastMenu={this.renderDetailMenu(user)}
+            dismissible
+            onClose={this.onClose}
+            actionMenu={this.getActionMenu}
+          >
+            <TitleManager record={getFullName(user)} />
+            <Headline
+              size="xx-large"
+              tag="h2"
+            >
+              {getFullName(user)}
+            </Headline>
+            <Row>
+              <Col xs={10}>
+                {(hasPatronBlocks === 1 && totalPatronBlocks > 0)
+                  ? <PatronBlockMessage />
+                  : ''}
+              </Col>
+              <Col xs={2}>
+                <ExpandAllButton
+                  accordionStatus={sections}
+                  onToggle={this.handleExpandAll}
                 />
-                <IfPermission perm="manualblocks.collection.get">
-                  <PatronBlock
-                    accordionId="patronBlocksSection"
-                    user={user}
-                    hasPatronBlocks={(hasPatronBlocks === 1 && totalPatronBlocks > 0)}
-                    patronBlocks={patronBlocks}
-                    expanded={sections.patronBlocksSection}
+              </Col>
+            </Row>
+            <AccordionSet>
+              <UserInfo
+                accordionId="userInformationSection"
+                user={user}
+                patronGroup={patronGroup}
+                settings={settings}
+                stripes={stripes}
+                expanded={sections.userInformationSection}
+                onToggle={this.handleSectionToggle}
+              />
+              <IfPermission perm="manualblocks.collection.get">
+                <PatronBlock
+                  accordionId="patronBlocksSection"
+                  user={user}
+                  hasPatronBlocks={(hasPatronBlocks === 1 && totalPatronBlocks > 0)}
+                  patronBlocks={patronBlocks}
+                  expanded={sections.patronBlocksSection}
+                  onToggle={this.handleSectionToggle}
+                  onClickViewPatronBlock={this.onClickViewPatronBlock}
+                  addRecord={this.state.addRecord}
+                  {...this.props}
+                />
+              </IfPermission>
+              <ExtendedInfo
+                accordionId="extendedInfoSection"
+                user={user}
+                expanded={sections.extendedInfoSection}
+                requestPreferences={requestPreferences}
+                defaultServicePointName={defaultServicePointName}
+                defaultDeliveryAddressTypeName={defaultDeliveryAddressTypeName}
+                onToggle={this.handleSectionToggle}
+              />
+              <ContactInfo
+                accordionId="contactInfoSection"
+                stripes={stripes}
+                user={user}
+                addresses={addressesList}
+                addressTypes={addressTypes}
+                expanded={sections.contactInfoSection}
+                onToggle={this.handleSectionToggle}
+              />
+              <IfPermission perm="proxiesfor.collection.get">
+                <ProxyPermissions
+                  user={user}
+                  accordionId="proxySection"
+                  onToggle={this.handleSectionToggle}
+                  proxies={proxies}
+                  sponsors={sponsors}
+                  expanded={sections.proxySection}
+                  {...this.props}
+                />
+              </IfPermission>
+              <IfPermission perm="ui-users.feesfines.actions.all">
+                <UserAccounts
+                  expanded={sections.accountsSection}
+                  onToggle={this.handleSectionToggle}
+                  accordionId="accountsSection"
+                  addRecord={addRecord}
+                  location={location}
+                  match={match}
+                />
+              </IfPermission>
+
+              <IfPermission perm="ui-users.loans.view">
+                <IfInterface name="loan-policy-storage">
+                  { /* Check without version, so can support either of multiple versions.
+            Replace with specific check when facility for providing
+            multiple versions is available */ }
+                  <IfInterface name="circulation">
+                    <UserLoans
+                      onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
+                      onClickViewOpenLoans={this.onClickViewOpenLoans}
+                      onClickViewClosedLoans={this.onClickViewClosedLoans}
+                      expanded={sections.loansSection}
+                      onToggle={this.handleSectionToggle}
+                      accordionId="loansSection"
+                      {...this.props}
+                    />
+                  </IfInterface>
+                </IfInterface>
+              </IfPermission>
+
+              <IfPermission perm="ui-users.requests.all">
+                <IfInterface name="request-storage" version="2.5 3.0">
+                  <UserRequests
+                    expanded={sections.requestsSection}
                     onToggle={this.handleSectionToggle}
-                    onClickViewPatronBlock={this.onClickViewPatronBlock}
-                    addRecord={this.state.addRecord}
+                    accordionId="requestsSection"
+                    user={user}
                     {...this.props}
                   />
-                </IfPermission>
-                <ExtendedInfo
-                  accordionId="extendedInfoSection"
-                  user={user}
-                  expanded={sections.extendedInfoSection}
-                  requestPreferences={requestPreferences}
-                  defaultServicePointName={defaultServicePointName}
-                  defaultDeliveryAddressTypeName={defaultDeliveryAddressTypeName}
-                  onToggle={this.handleSectionToggle}
-                />
-                <ContactInfo
-                  accordionId="contactInfoSection"
-                  stripes={stripes}
-                  user={user}
-                  addresses={addressesList}
-                  addressTypes={addressTypes}
-                  expanded={sections.contactInfoSection}
-                  onToggle={this.handleSectionToggle}
-                />
-                <IfPermission perm="proxiesfor.collection.get">
-                  <ProxyPermissions
-                    user={user}
-                    accordionId="proxySection"
+                </IfInterface>
+              </IfPermission>
+
+              <IfPermission perm="perms.users.get">
+                <IfInterface name="permissions" version="5.0">
+                  <UserPermissions
+                    expanded={sections.permissionsSection}
                     onToggle={this.handleSectionToggle}
-                    proxies={proxies}
-                    sponsors={sponsors}
-                    expanded={sections.proxySection}
+                    userPermissions={permissions}
+                    accordionId="permissionsSection"
                     {...this.props}
                   />
-                </IfPermission>
-                <IfPermission perm="ui-users.feesfines.actions.all">
-                  <UserAccounts
-                    expanded={sections.accountsSection}
+                </IfInterface>
+              </IfPermission>
+
+              <IfPermission perm="inventory-storage.service-points.collection.get,inventory-storage.service-points-users.collection.get">
+                <IfInterface name="service-points-users" version="1.0">
+                  <UserServicePoints
+                    expanded={sections.servicePointsSection}
                     onToggle={this.handleSectionToggle}
-                    accordionId="accountsSection"
-                    addRecord={addRecord}
-                    location={location}
-                    match={match}
+                    accordionId="servicePointsSection"
+                    servicePoints={servicePoints}
+                    preferredServicePoint={preferredServicePoint}
+                    {...this.props}
                   />
-                </IfPermission>
-
-                <IfPermission perm="ui-users.loans.view">
-                  <IfInterface name="loan-policy-storage">
-                    { /* Check without version, so can support either of multiple versions.
-              Replace with specific check when facility for providing
-              multiple versions is available */ }
-                    <IfInterface name="circulation">
-                      <UserLoans
-                        onClickViewLoanActionsHistory={this.onClickViewLoanActionsHistory}
-                        onClickViewOpenLoans={this.onClickViewOpenLoans}
-                        onClickViewClosedLoans={this.onClickViewClosedLoans}
-                        expanded={sections.loansSection}
-                        onToggle={this.handleSectionToggle}
-                        accordionId="loansSection"
-                        {...this.props}
-                      />
-                    </IfInterface>
-                  </IfInterface>
-                </IfPermission>
-
-                <IfPermission perm="ui-users.requests.all">
-                  <IfInterface name="request-storage" version="2.5 3.0">
-                    <UserRequests
-                      expanded={sections.requestsSection}
-                      onToggle={this.handleSectionToggle}
-                      accordionId="requestsSection"
-                      user={user}
-                      {...this.props}
-                    />
-                  </IfInterface>
-                </IfPermission>
-
-                <IfPermission perm="perms.users.get">
-                  <IfInterface name="permissions" version="5.0">
-                    <UserPermissions
-                      expanded={sections.permissionsSection}
-                      onToggle={this.handleSectionToggle}
-                      userPermissions={permissions}
-                      accordionId="permissionsSection"
-                      {...this.props}
-                    />
-                  </IfInterface>
-                </IfPermission>
-
-                <IfPermission perm="inventory-storage.service-points.collection.get,inventory-storage.service-points-users.collection.get">
-                  <IfInterface name="service-points-users" version="1.0">
-                    <UserServicePoints
-                      expanded={sections.servicePointsSection}
-                      onToggle={this.handleSectionToggle}
-                      accordionId="servicePointsSection"
-                      servicePoints={servicePoints}
-                      preferredServicePoint={preferredServicePoint}
-                      {...this.props}
-                    />
-                  </IfInterface>
-                </IfPermission>
-                <IfPermission perm="ui-notes.item.view">
-                  <NotesSmartAccordion
-                    domainName="users"
-                    entityId={match.params.id}
-                    entityName={getFullName(user)}
-                    open={this.state.sections.notesAccordion}
-                    onToggle={this.handleSectionToggle}
-                    id="notesAccordion"
-                    entityType="user"
-                    pathToNoteCreate="/users/notes/new"
-                    pathToNoteDetails="/users/notes"
-                    hideAssignButton
-                  />
-                </IfPermission>
-              </AccordionSet>
-            </Pane>
+                </IfInterface>
+              </IfPermission>
+              <IfPermission perm="ui-notes.item.view">
+                <NotesSmartAccordion
+                  domainName="users"
+                  entityId={match.params.id}
+                  entityName={getFullName(user)}
+                  open={this.state.sections.notesAccordion}
+                  onToggle={this.handleSectionToggle}
+                  id="notesAccordion"
+                  entityType="user"
+                  pathToNoteCreate="/users/notes/new"
+                  pathToNoteDetails="/users/notes"
+                  hideAssignButton
+                />
+              </IfPermission>
+            </AccordionSet>
+          </Pane>
+          {/*
           </HasCommand>
+          */}
           { helperApp && <HelperApp appName={helperApp} onClose={this.closeHelperApp} /> }
         </React.Fragment>
       );

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -18,7 +18,7 @@ import {
   Row,
   Col,
   Headline,
-  HasCommand,
+  // HasCommand,
   AccordionSet,
 } from '@folio/stripes/components';
 import stripesForm from '@folio/stripes/form';
@@ -414,114 +414,118 @@ class UserForm extends React.Component {
       : <FormattedMessage id="ui-users.crud.createUser" />;
 
     return (
+      {/*
       <HasCommand commands={this.keyboardCommands}>
-        <form
-          data-test-form-page
-          className={css.UserFormRoot}
-          id="form-user"
-          onSubmit={handleSubmit}
-        >
-          <Paneset>
-            <Pane
-              defaultWidth="100%"
-              firstMenu={firstMenu}
-              footer={footer}
-              appIcon={<AppIcon app="users" appIconKey="users" />}
-              paneTitle={
-                <span data-test-header-title>
-                  {paneTitle}
-                </span>
-              }
-            >
-              <div className={css.UserFormContent}>
-                <Headline
-                  size="xx-large"
-                  tag="h2"
-                  data-test-header-title
-                >
-                  {fullName}
-                </Headline>
-                <Row end="xs">
-                  <Col xs>
-                    <ExpandAllButton
-                      accordionStatus={sections}
-                      onToggle={this.handleExpandAll}
+      */}
+      <form
+        data-test-form-page
+        className={css.UserFormRoot}
+        id="form-user"
+        onSubmit={handleSubmit}
+      >
+        <Paneset>
+          <Pane
+            defaultWidth="100%"
+            firstMenu={firstMenu}
+            footer={footer}
+            appIcon={<AppIcon app="users" appIconKey="users" />}
+            paneTitle={
+              <span data-test-header-title>
+                {paneTitle}
+              </span>
+            }
+          >
+            <div className={css.UserFormContent}>
+              <Headline
+                size="xx-large"
+                tag="h2"
+                data-test-header-title
+              >
+                {fullName}
+              </Headline>
+              <Row end="xs">
+                <Col xs>
+                  <ExpandAllButton
+                    accordionStatus={sections}
+                    onToggle={this.handleExpandAll}
+                  />
+                </Col>
+              </Row>
+              <AccordionSet>
+                <EditUserInfo
+                  accordionId="editUserInfo"
+                  expanded={sections.editUserInfo}
+                  onToggle={this.handleSectionToggle}
+                  initialValues={initialValues}
+                  patronGroups={formData.patronGroups}
+                />
+                <EditExtendedInfo
+                  accordionId="extendedInfo"
+                  expanded={sections.extendedInfo}
+                  onToggle={this.handleSectionToggle}
+                  userId={initialValues.id}
+                  userFirstName={initialValues.personal.firstName}
+                  userEmail={initialValues.personal.email}
+                  servicePoints={servicePoints}
+                  addressTypes={formData.addressTypes}
+                />
+                <EditContactInfo
+                  accordionId="contactInfo"
+                  expanded={sections.contactInfo}
+                  onToggle={this.handleSectionToggle}
+                  addressTypes={formData.addressTypes}
+                  preferredContactTypeId={initialValues.preferredContactTypeId}
+                />
+                {initialValues.id &&
+                  <div>
+                    <EditProxy
+                      accordionId="proxyAccordion"
+                      expanded={sections.proxy}
+                      onToggle={this.handleSectionToggle}
+                      sponsors={initialValues.sponsors}
+                      proxies={initialValues.proxies}
+                      fullName={fullName}
+                      change={change}
+                      initialValues={initialValues}
+                      getWarning={getProxySponsorWarning}
                     />
-                  </Col>
-                </Row>
-                <AccordionSet>
-                  <EditUserInfo
-                    accordionId="editUserInfo"
-                    expanded={sections.editUserInfo}
-                    onToggle={this.handleSectionToggle}
-                    initialValues={initialValues}
-                    patronGroups={formData.patronGroups}
-                  />
-                  <EditExtendedInfo
-                    accordionId="extendedInfo"
-                    expanded={sections.extendedInfo}
-                    onToggle={this.handleSectionToggle}
-                    userId={initialValues.id}
-                    userFirstName={initialValues.personal.firstName}
-                    userEmail={initialValues.personal.email}
-                    servicePoints={servicePoints}
-                    addressTypes={formData.addressTypes}
-                  />
-                  <EditContactInfo
-                    accordionId="contactInfo"
-                    expanded={sections.contactInfo}
-                    onToggle={this.handleSectionToggle}
-                    addressTypes={formData.addressTypes}
-                    preferredContactTypeId={initialValues.preferredContactTypeId}
-                  />
-                  {initialValues.id &&
-                    <div>
-                      <EditProxy
-                        accordionId="proxyAccordion"
-                        expanded={sections.proxy}
-                        onToggle={this.handleSectionToggle}
-                        sponsors={initialValues.sponsors}
-                        proxies={initialValues.proxies}
-                        fullName={fullName}
-                        change={change}
-                        initialValues={initialValues}
-                        getWarning={getProxySponsorWarning}
-                      />
-                      <PermissionsAccordion
-                        filtersConfig={[
-                          permissionTypeFilterConfig,
-                          statusFilterConfig,
-                        ]}
-                        visibleColumns={[
-                          'selected',
-                          'permissionName',
-                          'type',
-                          'status',
-                        ]}
-                        accordionId="permissions"
-                        expanded={sections.permissions}
-                        onToggle={this.handleSectionToggle}
-                        headlineContent={<FormattedMessage id="ui-users.permissions.userPermissions" />}
-                        permToRead="perms.permissions.get"
-                        permToDelete="perms.permissions.item.delete"
-                        permToModify="perms.permissions.item.put"
-                        formName="userForm"
-                        permissionsField="permissions"
-                      />
-                      <EditServicePoints
-                        accordionId="servicePoints"
-                        expanded={sections.servicePoints}
-                        onToggle={this.handleSectionToggle}
-                        {...this.props}
-                      />
-                    </div>
-                  }
-                </AccordionSet>
-              </div>
-            </Pane>
-          </Paneset>
-        </form>
+                    <PermissionsAccordion
+                      filtersConfig={[
+                        permissionTypeFilterConfig,
+                        statusFilterConfig,
+                      ]}
+                      visibleColumns={[
+                        'selected',
+                        'permissionName',
+                        'type',
+                        'status',
+                      ]}
+                      accordionId="permissions"
+                      expanded={sections.permissions}
+                      onToggle={this.handleSectionToggle}
+                      headlineContent={<FormattedMessage id="ui-users.permissions.userPermissions" />}
+                      permToRead="perms.permissions.get"
+                      permToDelete="perms.permissions.item.delete"
+                      permToModify="perms.permissions.item.put"
+                      formName="userForm"
+                      permissionsField="permissions"
+                    />
+                    <EditServicePoints
+                      accordionId="servicePoints"
+                      expanded={sections.servicePoints}
+                      onToggle={this.handleSectionToggle}
+                      {...this.props}
+                    />
+                  </div>
+                }
+              </AccordionSet>
+            </div>
+          </Pane>
+        </Paneset>
+      </form>
+      {/*
       </HasCommand>
+      */}
     );
   }
 }

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -17,7 +17,7 @@ import {
   Icon,
   Button,
   PaneMenu,
-  HasCommand,
+  // HasCommand,
 } from '@folio/stripes/components';
 
 import {
@@ -304,125 +304,130 @@ class UserSearch extends React.Component {
     };
 
     return (
+      {/*
       <HasCommand commands={this.shortcuts}>
-        <div data-test-user-instances ref={contentRef}>
-          <SearchAndSortQuery
-            querySetter={querySetter}
-            queryGetter={queryGetter}
-            onComponentWillUnmount={onComponentWillUnmount}
-            initialSearch={initialSearch}
-            initialSearchState={{ qindex: '', query: '' }}
-          >
-            {
-              ({
-                searchValue,
-                getSearchHandlers,
-                onSubmitSearch,
-                onSort,
-                getFilterHandlers,
-                activeFilters,
-                filterChanged,
-                searchChanged,
-                resetAll,
-              }) => {
-                return (
-                  <IntlConsumer>
-                    {intl => (
-                      <Paneset id={`${idPrefix}-paneset`}>
-                        {this.state.filterPaneIsVisible &&
-                          <Pane defaultWidth="22%" paneTitle="User search">
-                            <form onSubmit={onSubmitSearch}>
-                              <div className={css.searchGroupWrap}>
-                                <SearchField
-                                  aria-label="user search"
-                                  name="query"
-                                  id="input-user-search"
-                                  className={css.searchField}
-                                  onChange={getSearchHandlers().query}
-                                  value={searchValue.query}
-                                  marginBottom0
-                                  inputRef={this.searchField}
-                                  data-test-user-search-input
-                                />
-                                <Button
-                                  id="submit-user-search"
-                                  type="submit"
-                                  buttonStyle="primary"
-                                  fullWidth
-                                  marginBottom0
-                                  disabled={(!searchValue.query || searchValue.query === '')}
-                                  data-test-user-search-submit
-                                >
-                                  Search
-                                </Button>
-                              </div>
-                              <div className={css.resetButtonWrap}>
-                                <Button
-                                  buttonStyle="none"
-                                  id="clickable-reset-all"
-                                  disabled={!(filterChanged || searchChanged)}
-                                  fullWidth
-                                  onClick={resetAll}
-                                >
-                                  <Icon icon="times-circle-solid">
-                                    <FormattedMessage id="stripes-smart-components.resetAll" />
-                                  </Icon>
-                                </Button>
-                              </div>
-                              <Filters
-                                onChangeHandlers={getFilterHandlers()}
-                                activeFilters={activeFilters}
-                                config={filterConfig}
+      */}
+      <div data-test-user-instances ref={contentRef}>
+        <SearchAndSortQuery
+          querySetter={querySetter}
+          queryGetter={queryGetter}
+          onComponentWillUnmount={onComponentWillUnmount}
+          initialSearch={initialSearch}
+          initialSearchState={{ qindex: '', query: '' }}
+        >
+          {
+            ({
+              searchValue,
+              getSearchHandlers,
+              onSubmitSearch,
+              onSort,
+              getFilterHandlers,
+              activeFilters,
+              filterChanged,
+              searchChanged,
+              resetAll,
+            }) => {
+              return (
+                <IntlConsumer>
+                  {intl => (
+                    <Paneset id={`${idPrefix}-paneset`}>
+                      {this.state.filterPaneIsVisible &&
+                        <Pane defaultWidth="22%" paneTitle="User search">
+                          <form onSubmit={onSubmitSearch}>
+                            <div className={css.searchGroupWrap}>
+                              <SearchField
+                                aria-label="user search"
+                                name="query"
+                                id="input-user-search"
+                                className={css.searchField}
+                                onChange={getSearchHandlers().query}
+                                value={searchValue.query}
+                                marginBottom0
+                                inputRef={this.searchField}
+                                data-test-user-search-input
                               />
-                            </form>
-                          </Pane>
-                        }
-                        <Pane
-                          firstMenu={this.renderResultsFirstMenu(activeFilters)}
-                          lastMenu={this.renderNewRecordBtn()}
-                          paneTitle={resultsHeader}
-                          paneSub={resultPaneSub}
-                          defaultWidth="fill"
-                          actionMenu={this.getActionMenu}
-                          padContent={false}
-                          noOverflow
-                        >
-                          <MultiColumnList
-                            id="list-users"
-                            visibleColumns={visibleColumns}
-                            rowUpdater={this.rowUpdater}
-                            contentData={users}
-                            totalCount={count}
-                            columnMapping={{
-                              status: intl.formatMessage({ id: 'ui-users.active' }),
-                              name: intl.formatMessage({ id: 'ui-users.information.name' }),
-                              barcode: intl.formatMessage({ id: 'ui-users.information.barcode' }),
-                              patronGroup: intl.formatMessage({ id: 'ui-users.information.patronGroup' }),
-                              username: intl.formatMessage({ id: 'ui-users.information.username' }),
-                              email: intl.formatMessage({ id: 'ui-users.contact.email' }),
-                            }}
-                            formatter={resultsFormatter}
-                            rowFormatter={this.anchoredRowFormatter}
-                            onNeedMoreData={onNeedMoreData}
-                            onHeaderClick={onSort}
-                            sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
-                            sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
-                            isEmptyMessage={resultsStatusMessage}
-                            isSelected={this.isSelected}
-                            autosize
-                            virtualize
-                          />
-
+                              <Button
+                                id="submit-user-search"
+                                type="submit"
+                                buttonStyle="primary"
+                                fullWidth
+                                marginBottom0
+                                disabled={(!searchValue.query || searchValue.query === '')}
+                                data-test-user-search-submit
+                              >
+                                Search
+                              </Button>
+                            </div>
+                            <div className={css.resetButtonWrap}>
+                              <Button
+                                buttonStyle="none"
+                                id="clickable-reset-all"
+                                disabled={!(filterChanged || searchChanged)}
+                                fullWidth
+                                onClick={resetAll}
+                              >
+                                <Icon icon="times-circle-solid">
+                                  <FormattedMessage id="stripes-smart-components.resetAll" />
+                                </Icon>
+                              </Button>
+                            </div>
+                            <Filters
+                              onChangeHandlers={getFilterHandlers()}
+                              activeFilters={activeFilters}
+                              config={filterConfig}
+                            />
+                          </form>
                         </Pane>
-                        { this.props.children }
-                      </Paneset>
-                    )}
-                  </IntlConsumer>
-                );
-              }}
-          </SearchAndSortQuery>
-        </div>
-      </HasCommand>);
+                      }
+                      <Pane
+                        firstMenu={this.renderResultsFirstMenu(activeFilters)}
+                        lastMenu={this.renderNewRecordBtn()}
+                        paneTitle={resultsHeader}
+                        paneSub={resultPaneSub}
+                        defaultWidth="fill"
+                        actionMenu={this.getActionMenu}
+                        padContent={false}
+                        noOverflow
+                      >
+                        <MultiColumnList
+                          id="list-users"
+                          visibleColumns={visibleColumns}
+                          rowUpdater={this.rowUpdater}
+                          contentData={users}
+                          totalCount={count}
+                          columnMapping={{
+                            status: intl.formatMessage({ id: 'ui-users.active' }),
+                            name: intl.formatMessage({ id: 'ui-users.information.name' }),
+                            barcode: intl.formatMessage({ id: 'ui-users.information.barcode' }),
+                            patronGroup: intl.formatMessage({ id: 'ui-users.information.patronGroup' }),
+                            username: intl.formatMessage({ id: 'ui-users.information.username' }),
+                            email: intl.formatMessage({ id: 'ui-users.contact.email' }),
+                          }}
+                          formatter={resultsFormatter}
+                          rowFormatter={this.anchoredRowFormatter}
+                          onNeedMoreData={onNeedMoreData}
+                          onHeaderClick={onSort}
+                          sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
+                          sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
+                          isEmptyMessage={resultsStatusMessage}
+                          isSelected={this.isSelected}
+                          autosize
+                          virtualize
+                        />
+
+                      </Pane>
+                      { this.props.children }
+                    </Paneset>
+                  )}
+                </IntlConsumer>
+              );
+            }}
+        </SearchAndSortQuery>
+      </div>
+      {/*
+        </HasCommand>
+        */}
+    );
   }
 }
 


### PR DESCRIPTION
We have a theory that a memory leak in a transitive dependency of
`<CommandList>` and `<HasCommand>` is behind the failing unit tests. The
problem may be that event listeners are not properly detached and
recycled.

This is an alternative to #1139, commenting out those components instead
of removing them, which may be easier to revert.

Refs [FOLIO-2097](https://issues.folio.org/browse/FOLIO-2097)