### PR TITLE
UIU-1406 correctly sort "Active" column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Don't update state in `withRenew` when unmounted. Fixes UIU-1450.
 * Update circulation okapiInterface to version `9.0`. Part of UIU-1440.
 * Disable `autoComplete` in user's search box. Refs UIU-1426.
+* Correctly sort "Active" column. Refs UIU-1406.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -65,7 +65,7 @@ class UserSearch extends React.Component {
 
   static defaultProps = {
     idPrefix: 'users-',
-    visibleColumns: ['status', 'name', 'barcode', 'patronGroup', 'username', 'email'],
+    visibleColumns: ['active', 'name', 'barcode', 'patronGroup', 'username', 'email'],
   };
 
   constructor(props) {
@@ -273,7 +273,7 @@ class UserSearch extends React.Component {
     }
 
     const resultsFormatter = {
-      status: user => (
+      active: user => (
         <AppIcon app="users" size="small" className={user.active ? undefined : css.inactiveAppIcon}>
           {user.active ? <FormattedMessage id="ui-users.active" /> : <FormattedMessage id="ui-users.inactive" />}
         </AppIcon>
@@ -379,7 +379,7 @@ class UserSearch extends React.Component {
                           contentData={users}
                           totalCount={count}
                           columnMapping={{
-                            status: intl.formatMessage({ id: 'ui-users.active' }),
+                            active: intl.formatMessage({ id: 'ui-users.active' }),
                             name: intl.formatMessage({ id: 'ui-users.information.name' }),
                             barcode: intl.formatMessage({ id: 'ui-users.information.barcode' }),
                             patronGroup: intl.formatMessage({ id: 'ui-users.information.patronGroup' }),


### PR DESCRIPTION
The first column in the search results had the name `status` but the
field-name on the object is `active`. I think we have gone around and
around on how to properly display this field. In any case, the problem
here is that there is no `status` field to sort by, so of course trying
to use that does not work.

Fixes [UIU-1406](https://issues.folio.org/browse/UIU-1406)