### PR TITLE
FOLIO-2440 remove extraneous wait clause

### DIFF
--- a/test/ui-testing/new-permission-set.js
+++ b/test/ui-testing/new-permission-set.js
@@ -117,7 +117,6 @@ module.exports.test = function foo(uiTestCtx) {
             return true;
           }, uuid)
           .wait(parseInt(process.env.FOLIO_UI_DEBUG, 10) ? parseInt(config.debug_sleep, 10) : 555) // debugging
-          .wait(30000)
           .then(() => { done(); })
           .catch(done);
       });


### PR DESCRIPTION
A `wait(30000)` clause useful for debugging was inadvertently committed.

Refs [FOLIO-2440](https://issues.folio.org/browse/FOLIO-2440)