### PR TITLE
UIU-1476: Fixed missing sort indicators

### DIFF
--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -169,6 +169,7 @@ class UserSearchContainer extends React.Component {
         source={this.source}
         initialSearch="?sort=name"
         onNeedMoreData={this.onNeedMoreData}
+        queryGetter={this.queryGetter}
         {...this.props}
       >
         { this.props.children }


### PR DESCRIPTION
**Ticket:** https://issues.folio.org/browse/UIU-1476

Passing down`queryGetter` to `<UserSearch>` to enable retrieving the current sort value which re-enables the sort indicator icons.