### PR TITLE
UIU-1483: Send notify patron value in the Confirm fee/fine cancellation modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Mark fields as required when filling in the username or password. Fixes UIU-1350.
 * Enable override for renewal of declared lost items. Refs UIU-1208.
 * Show edit button only if user has "Can edit user profile" permission. Fixes UIU-1435.
+* Send `Notify Patron` checkbox value to backend in the Confirm fee/fine cancellation modal. Refs UIU-1483. 
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/Accounts/Actions/Actions.js
+++ b/src/components/Accounts/Actions/Actions.js
@@ -181,8 +181,14 @@ class Actions extends React.Component {
     });
   }
 
-  newAction = (action, id, typeAction, amount, comment, balance, transaction, createAt) => {
-    const notify = this.state.notify;
+  newAction = (action, id, typeAction, amount, comment, balance, transaction, createAt, values) => {
+    let notify;
+    if (values) {
+      notify = _.isUndefined(values.notify) ? true : values.notify;
+    } else {
+      notify = this.state.notify;
+    }
+
     const newAction = {
       typeAction,
       source: `${this.props.okapi.currentUser.lastName}, ${this.props.okapi.currentUser.firstName}`,
@@ -231,7 +237,7 @@ class Actions extends React.Component {
     const type = this.props.accounts[0] || {};
     delete type.rowIndex;
     this.props.mutator.activeRecord.update({ id: type.id });
-    this.newAction({}, type.id, canceled, type.amount, this.assembleTagInfo(values), 0, 0, type.feeFineOwner);
+    this.newAction({}, type.id, canceled, type.amount, this.assembleTagInfo(values), 0, 0, type.feeFineOwner, values);
     this.editAccount(type, canceled, 'Closed', 0.00)
       .then(() => this.props.handleEdit(1))
       .then(() => this.showCalloutMessage(type))
@@ -509,6 +515,7 @@ class Actions extends React.Component {
           )}
         </FormattedMessage>
         <CancellationModal
+          form="error-modal"
           open={actions.cancellation}
           onClose={this.onCloseCancellation}
           user={this.props.user}


### PR DESCRIPTION
# Description
Send `Notify Patron` checkbox value to backend in the Confirm fee/fine cancellation modal
# Issue
https://issues.folio.org/browse/UIU-1483
# Screenshots
![Annotation 2020-02-18 184107](https://user-images.githubusercontent.com/55694637/74757940-58102a00-527f-11ea-9615-e365e4a3b377.png)
![Annotation 2020-02-18 184145](https://user-images.githubusercontent.com/55694637/74757944-5b0b1a80-527f-11ea-9d47-5419adfbb630.png)
