### PR TITLE
UIU-1213: Add UI to mark items Claim returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Enable override for renewal of declared lost items. Refs UIU-1208.
 * Show edit button only if user has "Can edit user profile" permission. Fixes UIU-1435.
 * Send `Notify Patron` checkbox value to backend in the Confirm fee/fine cancellation modal. Refs UIU-1483. 
+* Add UI to mark items Claim returned. Refs UIU-1213.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/ClaimReturnedDialog/ClaimReturnedDialog.css
+++ b/src/components/ClaimReturnedDialog/ClaimReturnedDialog.css
@@ -1,0 +1,3 @@
+.additionalInformation {
+  margin-top: 10px;
+}

--- a/src/components/ClaimReturnedDialog/ClaimReturnedDialog.js
+++ b/src/components/ClaimReturnedDialog/ClaimReturnedDialog.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { Modal } from '@folio/stripes/components';
+
+import ClaimReturnedInfo from './ClaimReturnedInfo';
+
+class ClaimReturnedDialog extends React.Component {
+  static propTypes = {
+    onClose: PropTypes.func.isRequired,
+    open: PropTypes.bool.isRequired,
+    loan: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const {
+      onClose,
+      open,
+      loan,
+    } = this.props;
+
+    if (!loan) return null;
+
+    const modalLabel = <FormattedMessage id="ui-users.loans.confirmClaimReturned" />;
+
+    return (
+      <Modal
+        id="claim-returned-modal"
+        size="small"
+        dismissible
+        closeOnBackgroundClick
+        open={open}
+        label={modalLabel}
+        onClose={onClose}
+      >
+        <ClaimReturnedInfo
+          loan={loan}
+          onClose={onClose}
+        />
+      </Modal>
+    );
+  }
+}
+
+export default ClaimReturnedDialog;

--- a/src/components/ClaimReturnedDialog/ClaimReturnedInfo.js
+++ b/src/components/ClaimReturnedDialog/ClaimReturnedInfo.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Button,
+  Layout,
+  TextArea,
+  Row,
+  Col,
+} from '@folio/stripes/components';
+import { stripesConnect } from '@folio/stripes/core';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
+
+import css from './ClaimReturnedDialog.css';
+
+class ClaimReturnedInfo extends React.Component {
+  static manifest = Object.freeze({
+    claimReturned: {
+      type: 'okapi',
+      fetch: false,
+      POST: {
+        path: 'circulation/loans/!{loan.id}/claim-item-returned',
+      },
+    },
+  });
+
+  static propTypes = {
+    mutator: PropTypes.shape({
+      claimReturned: PropTypes.shape({
+        POST: PropTypes.func.isRequired,
+      }).isRequired,
+    }).isRequired,
+    loan: PropTypes.object.isRequired,
+    onClose: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      additionalInfo: '',
+    };
+  }
+
+  handleAdditionalInfoChange = event => {
+    this.setState({ additionalInfo: event.target.value });
+  };
+
+  submitClaimReturned = async () => {
+    const { additionalInfo } = this.state;
+
+    const {
+      mutator: {
+        claimReturned: {
+          POST,
+        }
+      },
+      onClose,
+    } = this.props;
+
+    await POST({
+      itemClaimedReturnedDateTime: new Date().toISOString(),
+      comment: additionalInfo,
+    });
+
+    onClose();
+  };
+
+  render() {
+    const {
+      loan,
+      onClose,
+    } = this.props;
+
+    const { additionalInfo } = this.state;
+
+    return (
+      <div>
+        <Layout className="flex">
+          <Layout className="flex">
+            <SafeHTMLMessage
+              id="ui-users.loans.claimReturnedDialogBody"
+              values={{
+                title: loan?.item?.title,
+                materialType: loan?.item?.materialType?.name,
+                barcode: loan?.item?.barcode,
+              }}
+            />
+          </Layout>
+        </Layout>
+        <Row>
+          <Col sm={12} className={css.additionalInformation}>
+            <TextArea
+              data-test-claim-returned-additional-info-textarea
+              label={<FormattedMessage id="ui-users.additionalInfo.label" />}
+              required
+              onChange={this.handleAdditionalInfoChange}
+            />
+          </Col>
+        </Row>
+        <Layout className="textRight">
+          <Button
+            data-test-claim-returned-dialog-cancel-button
+            onClick={onClose}
+          >
+            <FormattedMessage id="ui-users.cancel" />
+          </Button>
+          <Button
+            data-test-claim-returned-dialog-confirm-button
+            buttonStyle="primary"
+            disabled={!additionalInfo}
+            onClick={this.submitClaimReturned}
+          >
+            <FormattedMessage id="ui-users.confirm" />
+          </Button>
+        </Layout>
+      </div>
+    );
+  }
+}
+
+export default stripesConnect(ClaimReturnedInfo);

--- a/src/components/ClaimReturnedDialog/index.js
+++ b/src/components/ClaimReturnedDialog/index.js
@@ -1,0 +1,1 @@
+export { default } from './ClaimReturnedDialog';

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { withRouter } from 'react-router-dom';
-import { get } from 'lodash';
 
 import {
   Button,
@@ -57,7 +56,7 @@ class ActionsDropdown extends React.Component {
           <Button
             buttonStyle="dropdownItem"
             data-test-dropdown-content-renew-button
-            onClick={(e) => {
+            onClick={e => {
               handleOptionsChange({ loan, action: 'renew' });
               onToggle(e);
             }}
@@ -65,11 +64,23 @@ class ActionsDropdown extends React.Component {
             <FormattedMessage id="ui-users.renew" />
           </Button>
         </IfPermission>
+        { loan?.item?.status?.name !== 'Claimed returned' &&
+          <Button
+            buttonStyle="dropdownItem"
+            data-test-dropdown-content-claim-returned-button
+            onClick={e => {
+              handleOptionsChange({ loan, action:'claimReturned' });
+              onToggle(e);
+            }}
+          >
+            <FormattedMessage id="ui-users.loans.claimReturned" />
+          </Button>
+        }
         <IfPermission perm="ui-users.loans.edit">
           <Button
             buttonStyle="dropdownItem"
             data-test-dropdown-content-change-due-date-button
-            onClick={(e) => {
+            onClick={e => {
               handleOptionsChange({ loan, action:'changeDueDate' });
               onToggle(e);
             }}
@@ -77,11 +88,11 @@ class ActionsDropdown extends React.Component {
             <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
           </Button>
         </IfPermission>
-        { get(loan, ['item', 'status', 'name']) !== 'Declared lost' &&
+        { loan?.item?.status?.name !== 'Declared lost' &&
           <Button
             buttonStyle="dropdownItem"
             data-test-dropdown-content-declare-lost-button
-            onClick={(e) => {
+            onClick={e => {
               handleOptionsChange({ loan, action:'declareLost' });
               onToggle(e);
             }}
@@ -117,7 +128,7 @@ class ActionsDropdown extends React.Component {
           <Button
             buttonStyle="dropdownItem"
             data-test-dropdown-content-request-queue
-            to={getOpenRequestsPath(get(loan, ['item', 'barcode']))}
+            to={getOpenRequestsPath(loan?.item?.barcode)}
           >
             <FormattedMessage id="ui-users.loans.details.requestQueue" />
           </Button>

--- a/src/components/Wrappers/index.js
+++ b/src/components/Wrappers/index.js
@@ -2,3 +2,4 @@ export { default as withRenew } from './withRenew';
 export { default as withServicePoints } from './withServicePoints';
 export { default as withProxy } from './withProxy';
 export { default as withDeclareLost } from './withDeclareLost';
+export { default as withClaimReturned } from './withClaimReturned';

--- a/src/components/Wrappers/withClaimReturned.js
+++ b/src/components/Wrappers/withClaimReturned.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import ClaimReturnedDialog from '../ClaimReturnedDialog';
+
+const withClaimReturned = WrappedComponent => class withClaimReturnedComponent extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      claimReturnedDialogOpen: false,
+      loan: null,
+    };
+  }
+
+  openClaimReturnedDialog = loan => {
+    this.setState({
+      loan,
+      claimReturnedDialogOpen: true,
+    });
+  }
+
+  hideClaimReturnedDialog = () => {
+    this.setState({ claimReturnedDialogOpen: false });
+  }
+
+  render() {
+    const {
+      claimReturnedDialogOpen,
+      loan,
+    } = this.state;
+
+    return (
+      <>
+        <WrappedComponent
+          claimReturned={this.openClaimReturnedDialog}
+          {...this.props}
+        />
+        { loan &&
+          <ClaimReturnedDialog
+            loan={loan}
+            open={claimReturnedDialogOpen}
+            onClose={this.hideClaimReturnedDialog}
+          />
+        }
+      </>
+    );
+  }
+};
+
+export default withClaimReturned;

--- a/src/components/data/static/loanActionMap.js
+++ b/src/components/data/static/loanActionMap.js
@@ -2,6 +2,7 @@ export default {
   'checkedout': 'ui-users.data.loanActionMap.checkedOut',
   'checkedin': 'ui-users.data.loanActionMap.checkedIn',
   'declaredLost': 'ui-users.data.loanActionMap.declaredLost',
+  'claimedReturned': 'ui-users.data.loanActionMap.claimedReturned',
   'renewed': 'ui-users.data.loanActionMap.renewed',
   'Operator': 'ui-users.data.loanActionMap.source',
   'holdrequested': 'ui-users.data.loanActionMap.holdRequested',

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -38,6 +38,7 @@ import {
 import {
   withRenew,
   withDeclareLost,
+  withClaimReturned,
 } from '../../components/Wrappers';
 import loanActionMap from '../../components/data/static/loanActionMap';
 import LoanProxyDetails from './LoanProxyDetails';
@@ -71,6 +72,7 @@ class LoanDetails extends React.Component {
     requestCounts: PropTypes.object,
     renew: PropTypes.func,
     declareLost: PropTypes.func,
+    claimReturned: PropTypes.func,
     patronBlocks: PropTypes.arrayOf(PropTypes.object),
     intl: intlShape.isRequired,
     match: PropTypes.object.isRequired,
@@ -286,6 +288,7 @@ class LoanDetails extends React.Component {
       loanPolicies,
       requestCounts,
       declareLost,
+      claimReturned,
     } = this.props;
 
     const {
@@ -331,6 +334,7 @@ class LoanDetails extends React.Component {
     const overduePolicyName = get(loan, ['overdueFinePolicy', 'name'], '-');
     const lostItemPolicyName = get(loan, ['lostItemPolicy', 'name'], '-');
     const itemStatus = get(loan, ['item', 'status', 'name'], '-');
+    const claimedReturnedDate = itemStatus === 'Claimed returned' && loan.claimedReturnedDate;
     const isDeclaredLostItem = itemStatus === 'Declared lost';
     let lostDate;
     const declaredLostActions = loanActionsWithUser.filter(currentAction => get(currentAction, ['action'], '') === 'declaredLost');
@@ -381,6 +385,14 @@ class LoanDetails extends React.Component {
                     <FormattedMessage id="ui-users.renew" />
                   </Button>
                 </IfPermission>
+                <Button
+                  data-test-claim-returned-button
+                  disabled={buttonDisabled || itemStatus === 'Claimed returned'}
+                  buttonStyle="primary"
+                  onClick={() => claimReturned(loan)}
+                >
+                  <FormattedMessage id="ui-users.loans.claimReturned" />
+                </Button>
                 <IfPermission perm="ui-users.loans.edit">
                   <Button
                     disabled={buttonDisabled}
@@ -473,10 +485,16 @@ class LoanDetails extends React.Component {
                   value={get(loan, ['renewalCount'], '-')}
                 />
               </Col>
-              <Col xs={2}>
+              <Col
+                data-test-loan-claimed-returned
+                xs={2}
+              >
                 <KeyValue
                   label={<FormattedMessage id="ui-users.loans.details.claimedReturned" />}
-                  value="TODO"
+                  value={claimedReturnedDate ?
+                    (<FormattedTime value={claimedReturnedDate} day="numeric" month="numeric" year="numeric" />) :
+                    (<NoValue />)
+                  }
                 />
               </Col>
               <Col xs={2}>
@@ -577,4 +595,5 @@ export default compose(
   injectIntl,
   withRenew,
   withDeclareLost,
+  withClaimReturned,
 )(LoanDetails);

--- a/test/bigtest/interactors/claim-returned-dialog.js
+++ b/test/bigtest/interactors/claim-returned-dialog.js
@@ -1,0 +1,18 @@
+import {
+  interactor,
+  Interactor,
+  property
+} from '@bigtest/interactor';
+
+import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor'; // eslint-disable-line
+
+@interactor class ClaimReturnedDialog {
+  static defaultScope = '#claim-returned-modal';
+
+  additionalInfoTextArea = new Interactor('[data-test-claim-returned-additional-info-textarea]');
+  confirmButton = new ButtonInteractor('[data-test-claim-returned-dialog-confirm-button]');
+  cancelButton = new ButtonInteractor('[data-test-claim-returned-dialog-cancel-button]');
+  isConfirmButtonDisabled = property('[data-test-claim-returned-dialog-confirm-button]', 'disabled');
+}
+
+export default ClaimReturnedDialog;

--- a/test/bigtest/interactors/loan-actions-history.js
+++ b/test/bigtest/interactors/loan-actions-history.js
@@ -11,6 +11,7 @@ import KeyValue from './KeyValue';
 @interactor class LoanActionsHistory {
   static defaultScope = '[data-test-loan-actions-history]';
 
+  claimedReturnedDate = scoped('[data-test-loan-claimed-returned] div', KeyValue);
   requests = scoped('[data-test-loan-actions-history-requests] div', KeyValue);
   lostDate = scoped('[data-test-loan-actions-history-lost] div', KeyValue);
   itemStatus = scoped('[data-test-loan-actions-history-item-status] div', KeyValue);
@@ -22,6 +23,8 @@ import KeyValue from './KeyValue';
   closeButton = scoped('button[icon=times]', ButtonInteractor);
   declareLostButton = scoped('[data-test-declare-lost-button]', ButtonInteractor);
   isDeclareLostButtonDisabled = property('[data-test-declare-lost-button]', 'disabled');
+  claimReturnedButton = scoped('[data-test-claim-returned-button]', ButtonInteractor);
+  isClaimReturnedButtonDisabled = property('[data-test-claim-returned-button]', 'disabled');
 
   whenLoaded() {
     return this.when(() => this.isPresent).timeout(5000);

--- a/test/bigtest/interactors/open-loans.js
+++ b/test/bigtest/interactors/open-loans.js
@@ -12,6 +12,7 @@ import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interac
 import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/interactor'; // eslint-disable-line
 
 import DeclareLostDialog from './declare-lost-dialog';
+import ClaimReturnedDialog from './claim-returned-dialog';
 
 @interactor class BulkOverrideModal {
   static defaultScope = '#bulk-override-modal';
@@ -48,11 +49,13 @@ import DeclareLostDialog from './declare-lost-dialog';
   actionDropdownRenewButton = new Interactor('[data-test-dropdown-content-renew-button]');
   actionDropdownChangeDueDateButton = new Interactor('[data-test-dropdown-content-change-due-date-button]');
   actionDropdownDeclareLostButton = new Interactor('[data-test-dropdown-content-declare-lost-button]');
+  actionDropdownClaimReturnedButton = new Interactor('[data-test-dropdown-content-claim-returned-button]');
   requestsCount = count('[data-test-list-requests]');
   bulkRenewalModal = new BulkRenewalModal();
   bulkOverrideModal = new BulkOverrideModal();
   changeDueDateOverlay = new ChangeDueDateOverlay();
   declareLostDialog = new DeclareLostDialog();
+  claimReturnedDialog = new ClaimReturnedDialog();
   dueDateCalendarCellButton = new ButtonInteractor(`[data-test-date="${moment().format('MM/DD/YYYY')}"]`);
   rowButtons = collection('[data-test-open-loans-list] button[role="row"]', ButtonInteractor);
 

--- a/test/bigtest/tests/claim-returned-test.js
+++ b/test/bigtest/tests/claim-returned-test.js
@@ -1,0 +1,205 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+import { Response } from 'miragejs';
+
+import setupApplication from '../helpers/setup-application';
+import OpenLoansInteractor from '../interactors/open-loans';
+import LoanActionsHistory from '../interactors/loan-actions-history';
+
+describe('Claim returned', () => {
+  setupApplication({
+    permissions: {
+      'manualblocks.collection.get': true,
+      'circulation.loans.collection.get': true,
+    },
+  });
+
+  describe('Visiting open loans list page with not claimed returned item', () => {
+    let loan;
+
+    beforeEach(async function () {
+      loan = this.server.create('loan', { status: { name: 'Open' } });
+
+      this.visit(`/users/${loan.userId}/loans/open`);
+
+      await OpenLoansInteractor.whenLoaded();
+    });
+
+    it('should display open loans list', () => {
+      expect(OpenLoansInteractor.isPresent).to.be.true;
+    });
+
+    it('icon button should be presented', () => {
+      expect(OpenLoansInteractor.actionDropdowns(0).isPresent).to.be.true;
+    });
+
+    describe('opening dropdown for not claimed returned item', () => {
+      beforeEach(async () => {
+        await OpenLoansInteractor.actionDropdowns(0).click('button');
+      });
+
+      it('should display claim returned button', () => {
+        expect(OpenLoansInteractor.actionDropdownClaimReturnedButton.isPresent).to.be.true;
+      });
+
+      describe('clicking claim returned button', () => {
+        beforeEach(async () => {
+          await OpenLoansInteractor.actionDropdownClaimReturnedButton.click();
+        });
+
+        it('should display claim returned dialog', () => {
+          expect(OpenLoansInteractor.claimReturnedDialog.isVisible).to.be.true;
+        });
+
+        it('should display disabled confirm button', () => {
+          expect(OpenLoansInteractor.claimReturnedDialog.confirmButton.isPresent).to.be.true;
+          expect(OpenLoansInteractor.claimReturnedDialog.isConfirmButtonDisabled).to.be.true;
+        });
+
+        it('should display cancel button', () => {
+          expect(OpenLoansInteractor.claimReturnedDialog.cancelButton.isPresent).to.be.true;
+        });
+
+        it('should display additional information textarea', () => {
+          expect(OpenLoansInteractor.claimReturnedDialog.additionalInfoTextArea.isPresent).to.be.true;
+        });
+
+        describe('clicking cancel button', () => {
+          beforeEach(async () => {
+            await OpenLoansInteractor.claimReturnedDialog.cancelButton.click();
+          });
+
+          it('should hide claim returned dialog', () => {
+            expect(OpenLoansInteractor.claimReturnedDialog.isPresent).to.be.false;
+          });
+        });
+
+        describe('filling additional information textarea', () => {
+          const additionalInfoText = 'text';
+
+          beforeEach(async () => {
+            await OpenLoansInteractor.claimReturnedDialog.additionalInfoTextArea.focus();
+            await OpenLoansInteractor.claimReturnedDialog.additionalInfoTextArea.fill(additionalInfoText);
+          });
+
+          it('should enable confirm button', () => {
+            expect(OpenLoansInteractor.claimReturnedDialog.isConfirmButtonDisabled).to.be.false;
+          });
+
+          describe('clicking confirm button', () => {
+            let parsedRequestBody;
+
+            beforeEach(async function () {
+              this.server.post(`/circulation/loans/${loan.id}/claim-item-returned`, (_, request) => {
+                parsedRequestBody = JSON.parse(request.requestBody);
+
+                return new Response(204, {});
+              });
+
+              await OpenLoansInteractor.claimReturnedDialog.confirmButton.click();
+            });
+
+            it('should send correct request body', () => {
+              expect(parsedRequestBody.comment).to.equal(additionalInfoText);
+            });
+
+            it('should hide claim returned dialog', () => {
+              expect(OpenLoansInteractor.claimReturnedDialog.isPresent).to.be.false;
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('Visiting open loans list page with claimed returned item', () => {
+    beforeEach(async function () {
+      const loan = this.server.create('loan', {
+        status: { name: 'Open' },
+        item: { status: { name: 'Claimed returned' } },
+      });
+
+      this.visit(`/users/${loan.userId}/loans/open`);
+
+      await OpenLoansInteractor.whenLoaded();
+    });
+
+    describe('opening dropdown for claimed returned item', () => {
+      beforeEach(async () => {
+        await OpenLoansInteractor.actionDropdowns(0).click('button');
+      });
+
+      it('should not display claim returned button', () => {
+        expect(OpenLoansInteractor.actionDropdownClaimReturnedButton.isPresent).to.be.false;
+      });
+    });
+  });
+
+  describe('Visiting loan details  page with not claimed returned item', () => {
+    beforeEach(async function () {
+      const loan = this.server.create('loan', {
+        status: { name: 'Open' },
+        loanPolicyId: 'test'
+      });
+
+      this.visit(`/users/${loan.userId}/loans/view/${loan.id}`);
+    });
+
+    it('should display enabled claim returned button', () => {
+      expect(LoanActionsHistory.claimReturnedButton.isPresent).to.be.true;
+      expect(LoanActionsHistory.isClaimReturnedButtonDisabled).to.be.false;
+    });
+
+    it('should display dash in `Claimed returned` field', () => {
+      expect(LoanActionsHistory.claimedReturnedDate.value.text).to.equal('-');
+    });
+
+    describe('clicking on claim returned button', () => {
+      beforeEach(async function () {
+        await LoanActionsHistory.claimReturnedButton.click();
+      });
+
+      it('should display claim returned dialog', () => {
+        expect(OpenLoansInteractor.claimReturnedDialog.isVisible).to.be.true;
+      });
+    });
+  });
+
+  describe('Visiting loan details page with claimed returned item', () => {
+    beforeEach(async function () {
+      const loan = this.server.create('loan', {
+        status: { name: 'Open' },
+        loanPolicyId: 'test',
+        action: 'claimedReturned',
+        actionComment: 'Claim returned confirmation',
+        item: { status: { name: 'Claimed returned' } },
+        itemStatus: 'Claimed returned',
+        claimedReturnedDate: new Date().toISOString(),
+      });
+
+      this.server.create('user', { id: loan.userId });
+
+      this.server.create('loanaction', {
+        loan: {
+          ...loan.attrs,
+        },
+      });
+
+      this.visit(`/users/${loan.userId}/loans/view/${loan.id}`);
+    });
+
+
+    it('should display disabled claim returned button', () => {
+      expect(LoanActionsHistory.claimReturnedButton.isPresent).to.be.true;
+      expect(LoanActionsHistory.isClaimReturnedButtonDisabled).to.be.true;
+    }).timeout(5000);
+
+    it('should display the claimed returned date in `Claimed returned` field', () => {
+      expect(LoanActionsHistory.claimedReturnedDate.value.text).to.not.equal('-');
+    });
+  });
+});

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -36,6 +36,7 @@
   "data.loanActionMap.renewedThroughOverride": "Renewed through override",
   "data.loanActionMap.checkedOutThroughOverride": "Checked out through override",
   "data.loanActionMap.declaredLost": "Declared lost",
+  "data.loanActionMap.claimedReturned": "Claimed returned",
 
   "action": "Action",
   "dueDate": "Due date",
@@ -67,6 +68,9 @@
   "loans.declareLostDialogBody": "<strong>{title} {materialType}</strong> (Barcode: {barcode}) will be <strong>declared lost</strong>",
   "loans.confirmLostState": "Confirm lost state",
   "loans.declareLost.additionalInfoPlaceholder": "Enter more information about the lost item (required)",
+  "loans.claimReturned": "Claim returned",
+  "loans.claimReturnedDialogBody": "<strong>{title} ({materialType})</strong> (Barcode: {barcode}) will be <strong>claimed returned</strong>",
+  "loans.confirmClaimReturned": "Confirm claim returned",
   "loans.newFeeFine": "New fee/fine",
   "loans.feeFineDetails": "Fee/fine details",
 


### PR DESCRIPTION
## Purpose
Add the ability to mark items "Claimed returned" on UI. [Story](https://issues.folio.org/browse/UIU-1213).

**Screenshot**
![Screen Shot 2020-02-19 at 15 41 35](https://user-images.githubusercontent.com/49517355/74840550-d9bf9080-532f-11ea-8f3e-efd4b79e2d74.png)
