### PR TITLE
UIU-1265: Implement declare items lost permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * Restore display of "invisible" permissions. Refs UIU-1372.
 * Rename "Loans: All permissions" permission to "Users: User loans view, edit, renew (all)". Refs UIU-1344.
 * Add `autoFocus` prop to `<SearchField>`. Refs UIU-1248.
+* Implement declare items lost permission. Refs UIU-1265.
 
 ## [2.25.3](https://github.com/folio-org/ui-users/tree/v2.25.3) (2019-09-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.2...v2.25.3)

--- a/package.json
+++ b/package.json
@@ -597,6 +597,19 @@
         "visible": true
       },
       {
+        "permissionName": "ui-users.loans.declare-item-lost",
+        "displayName": "Users: User loans declare lost",
+        "description": "Also includes backend permissions to declare items lost",
+        "subPermissions": [
+          "circulation.loans.declare-item-lost.post",
+          "circulation-storage.loans.item.get",
+          "inventory-storage.items.item.get",
+          "inventory-storage.holdings.item.get",
+          "inventory-storage.instances.item.get"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-users.loans.view",
         "displayName": "Users: User loans view",
         "description": "Also includes basic permissions to view users",

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -19,6 +19,8 @@ import {
   getOpenRequestsPath,
 } from '../../../../util';
 
+import { itemStatuses } from '../../../../../constants';
+
 class ActionsDropdown extends React.Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
@@ -41,6 +43,7 @@ class ActionsDropdown extends React.Component {
       match: { params },
     } = this.props;
 
+    const itemStatusName = loan?.item?.status?.name;
     const itemDetailsLink = `/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`;
     const loanPolicyLink = `/settings/circulation/loan-policies/${loan.loanPolicyId}`;
     const buttonDisabled = !stripes.hasPerm('ui-users.feesfines.actions.all');
@@ -67,7 +70,7 @@ class ActionsDropdown extends React.Component {
             <FormattedMessage id="ui-users.renew" />
           </Button>
         </IfPermission>
-        { loan?.item?.status?.name !== 'Claimed returned' &&
+        { itemStatusName !== itemStatuses.CLAIMED_RETURNED &&
           <Button
             buttonStyle="dropdownItem"
             data-test-dropdown-content-claim-returned-button
@@ -80,7 +83,7 @@ class ActionsDropdown extends React.Component {
           </Button>
         }
         <IfPermission perm="ui-users.loans.edit">
-          { loan?.item?.status?.name !== 'Declared lost' &&
+          { itemStatusName !== itemStatuses.DECLARED_LOST &&
             <Button
               buttonStyle="dropdownItem"
               data-test-dropdown-content-change-due-date-button
@@ -93,18 +96,20 @@ class ActionsDropdown extends React.Component {
             </Button>
           }
         </IfPermission>
-        { loan?.item?.status?.name !== 'Declared lost' &&
-          <Button
-            buttonStyle="dropdownItem"
-            data-test-dropdown-content-declare-lost-button
-            onClick={e => {
-              handleOptionsChange({ loan, action:'declareLost' });
-              onToggle(e);
-            }}
-          >
-            <FormattedMessage id="ui-users.loans.declareLost" />
-          </Button>
-        }
+        <IfPermission perm="ui-users.loans.declare-item-lost">
+          { itemStatusName !== itemStatuses.DECLARED_LOST &&
+            <Button
+              buttonStyle="dropdownItem"
+              data-test-dropdown-content-declare-lost-button
+              onClick={e => {
+                handleOptionsChange({ loan, action:'declareLost' });
+                onToggle(e);
+              }}
+            >
+              <FormattedMessage id="ui-users.loans.declareLost" />
+            </Button>
+          }
+        </IfPermission>
         <IfPermission perm="circulation-storage.loan-policies.item.get">
           <Button
             buttonStyle="dropdownItem"

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,11 @@ export const requestStatuses = {
   UNFILLED: 'Closed - Unfilled',
 };
 
+export const itemStatuses = {
+  CLAIMED_RETURNED: 'Claimed returned',
+  DECLARED_LOST: 'Declared lost',
+};
+
 export const deliveryFulfillmentValues = {
   HOLD_SHELF: 'Hold Shelf',
   DELIVERY: 'Delivery',

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -323,7 +323,7 @@ class LoanDetails extends React.Component {
       actionDate: la => <FormattedTime value={get(la, ['metadata', 'updatedDate'], '-')} day="numeric" month="numeric" year="numeric" />,
       dueDate: la => <FormattedTime value={la.dueDate} day="numeric" month="numeric" year="numeric" />,
       itemStatus: la => la.itemStatus,
-      source: la => <Link to={`/users/view/${la.user.id}`}>{getFullName(la.user)}</Link>,
+      source: la => <Link to={`/users/view/${la.user?.id}`}>{getFullName(la.user)}</Link>,
       comments: ({ actionComment }) => (actionComment || '-'),
     };
 
@@ -406,14 +406,16 @@ class LoanDetails extends React.Component {
                     <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
                   </Button>
                 </IfPermission>
-                <Button
-                  data-test-declare-lost-button
-                  disabled={buttonDisabled || isDeclaredLostItem}
-                  buttonStyle="primary"
-                  onClick={() => declareLost(loan)}
-                >
-                  <FormattedMessage id="ui-users.loans.declareLost" />
-                </Button>
+                <IfPermission perm="ui-users.loans.declare-item-lost">
+                  <Button
+                    data-test-declare-lost-button
+                    disabled={buttonDisabled || isDeclaredLostItem}
+                    buttonStyle="primary"
+                    onClick={() => declareLost(loan)}
+                  >
+                    <FormattedMessage id="ui-users.loans.declareLost" />
+                  </Button>
+                </IfPermission>
               </span>
             </Row>
             <Row>


### PR DESCRIPTION
## Purpose

Implement declare items lost permission as part of [UIU-1265](https://issues.folio.org/browse/UIU-1265). This permission works in conjunction with permissions for viewing the loans.

## Screenshot

![Screen Shot 2020-02-27 at 13 24 58](https://user-images.githubusercontent.com/49517355/75556795-8cd26d00-5a47-11ea-80bb-029088e38102.png)
