### PR TITLE
UIU-1510 validate presence of user.personal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Tweak text for declared lost modal. Refs UIU-1444.
 * Update eslint to >= 6.2.1 or eslint-util >= 1.4.1. Refs UIU-1446.
 * Add 'Custom Fields' under User Settings to give circulation managers ability to add more fields to records. Refs UIU-1441
+* Validate presence of `user.personal` before accessing it. Fixes UIU-1510.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/components/UserDetailSections/ExtendedInfo/ExtendedInfo.js
+++ b/src/components/UserDetailSections/ExtendedInfo/ExtendedInfo.js
@@ -43,7 +43,7 @@ const ExtendedInfo = (props) => {
         </Col>
         <Col xs={12} md={3}>
           <KeyValue label={<FormattedMessage id="ui-users.extended.birthDate" />}>
-            {user.personal.dateOfBirth ? <FormattedDate value={user.personal.dateOfBirth} timeZone="UTC" /> : '-'}
+            {user.personal?.dateOfBirth ? <FormattedDate value={user.personal.dateOfBirth} timeZone="UTC" /> : '-'}
           </KeyValue>
         </Col>
       </Row>

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -99,6 +99,10 @@ class UserEdit extends React.Component {
       'permissions',
     );
 
+    if (!userFormValues.personal) {
+      userFormValues.personal = {};
+    }
+
     userFormValues.personal.addresses = getFormAddressList(get(user, 'personal.addresses', []));
 
     return {


### PR DESCRIPTION
It turns out `user.personal` is not a required attribute but there is
some front-end code that made such an assumption.

Refs [UIU-1510](https://issues.folio.org/browse/UIU-1510)