### PR TITLE
UIU-1518: Fix permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Update eslint to >= 6.2.1 or eslint-util >= 1.4.1. Refs UIU-1446.
 * Add 'Custom Fields' under User Settings to give circulation managers ability to add more fields to records. Refs UIU-1441
 * Validate presence of `user.personal` before accessing it. Fixes UIU-1510.
+* Fix bug with assign and unassign permissions to users. Refs UIU-1518.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/settings/permissions/PermissionSetDetails.js
+++ b/src/settings/permissions/PermissionSetDetails.js
@@ -112,7 +112,7 @@ class PermissionSetDetails extends React.Component {
           heading={<FormattedMessage id="ui-users.permissions.assignedPermissions" />}
           listedPermissions={selectedSet.subPermissions}
           permToRead="perms.permissions.get"
-          permToDelete="perms.permissions.item.put"
+          permToDelete="perms.permissions.item.delete"
           permToModify="perms.permissions.item.put"
           {...this.props}
         />

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -521,8 +521,8 @@ class UserForm extends React.Component {
                       onToggle={this.handleSectionToggle}
                       headlineContent={<FormattedMessage id="ui-users.permissions.userPermissions" />}
                       permToRead="perms.permissions.get"
-                      permToDelete="perms.permissions.item.delete"
-                      permToModify="perms.permissions.item.put"
+                      permToDelete="perms.users.item.delete"
+                      permToModify="perms.users.item.put"
                       formName="userForm"
                       permissionsField="permissions"
                     />

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -520,7 +520,7 @@ class UserForm extends React.Component {
                       expanded={sections.permissions}
                       onToggle={this.handleSectionToggle}
                       headlineContent={<FormattedMessage id="ui-users.permissions.userPermissions" />}
-                      permToRead="perms.permissions.get"
+                      permToRead="perms.users.get"
                       permToDelete="perms.users.item.delete"
                       permToModify="perms.users.item.put"
                       formName="userForm"


### PR DESCRIPTION
# Description
Bug fix: Can not assign and unassign permissions to users unless you have "Settings (Users): Can create, edit and remove permission sets"
# Issue
https://issues.folio.org/browse/UIU-1518
# Screenshots
![1](https://user-images.githubusercontent.com/55694637/76010203-323f8200-5f1b-11ea-903f-f7ec1b26f205.png)
![2](https://user-images.githubusercontent.com/55694637/76010205-32d81880-5f1b-11ea-9150-574aac8ce91f.png)
![3](https://user-images.githubusercontent.com/55694637/76010206-3370af00-5f1b-11ea-968e-592a77e05b37.png)
![4](https://user-images.githubusercontent.com/55694637/76010207-3370af00-5f1b-11ea-9aa8-eaeb047b68c8.png)
