### PR TITLE
UIU-1521 provide permissions for custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 * Enable override for renewal of declared lost items. Refs UIU-1208.
 * Add more granular call number fields to loans exports. Refs. UIU-1358.
 * Show edit button only if user has "Can edit user profile" permission. Fixes UIU-1435.
-* Send `Notify Patron` checkbox value to backend in the Confirm fee/fine cancellation modal. Refs UIU-1483. 
+* Send `Notify Patron` checkbox value to backend in the Confirm fee/fine cancellation modal. Refs UIU-1483.
 * Add UI to mark items Claim returned. Refs UIU-1213.
 * Execute loan renew in sequence. Fixes UIU-1299.
 * Fix active/inactive state for Save button. Fixes UIU-1194.
@@ -41,6 +41,7 @@
 * Add 'Custom Fields' under User Settings to give circulation managers ability to add more fields to records. Refs UIU-1441
 * Validate presence of `user.personal` before accessing it. Fixes UIU-1510.
 * Add link to Overdue Fine Policy and Lost Item Fee Policy on Fee/Fine Details page. Refs UIU-1247.
+* Provide permissions to custom fields. Refs UIU-1521.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/settings/CustomFieldsSettings.js
+++ b/src/settings/CustomFieldsSettings.js
@@ -6,10 +6,13 @@ const propTypes = {
   history: PropTypes.shape({
     push: PropTypes.func.isRequired,
   }).isRequired,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 const CustomFieldsSettings = ({
-  history,
+  history, stripes,
 }) => {
   const redirectToEdit = () => {
     history.push('/users/custom-fields/edit');
@@ -20,6 +23,11 @@ const CustomFieldsSettings = ({
       backendModuleName="users"
       entityType="user"
       redirectToEdit={redirectToEdit}
+      permissions={{
+        canDelete: stripes.hasPerm('ui-users.settings.customfields.all'),
+        canEdit: stripes.hasPerm('ui-users.settings.customfields.edit'),
+        canView: stripes.hasPerm('ui-users.settings.customfields.view'),
+      }}
     />
   );
 };


### PR DESCRIPTION
[PR 730](https://github.com/folio-org/stripes-smart-components/pull/730) in stripes-smart-components changed the API for
`ViewCustomFieldSettings`. This change accommodates that one.

Refs [UIU-1521](https://issues.folio.org/browse/UIU-1521)