### PR TITLE
UIU-1486 - Default charge and action notices not saved on manual fee/fine charge settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Add link to Overdue Fine Policy and Lost Item Fee Policy on Fee/Fine Details page. Refs UIU-1247.
 * Provide permissions to custom fields. Refs UIU-1521.
 * Fix bug with assign and unassign permissions to users. Refs UIU-1518.
+* Default charge and action notices not saved on manual fee/fine charge settings. Refs UIU-1486.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -9,7 +9,6 @@ import {
 import { Field } from 'redux-form';
 import { Select } from '@folio/stripes/components';
 import { ControlledVocab } from '@folio/stripes/smart-components';
-import { stripesConnect, withStripes } from '@folio/stripes/core';
 
 import { validate } from '../components/util';
 import {
@@ -265,7 +264,7 @@ class FeeFineSettings extends React.Component {
 
     return (
       <this.connectedControlledVocab
-        {...this.props}
+        stripes={this.props.stripes}
         baseUrl="feefines"
         columnMapping={{
           feeFineType: formatMessage({ id: 'ui-users.feefines.columns.type' }),
@@ -293,4 +292,4 @@ class FeeFineSettings extends React.Component {
   }
 }
 
-export default injectIntl(withStripes(FeeFineSettings));
+export default injectIntl(FeeFineSettings);

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -293,4 +293,4 @@ class FeeFineSettings extends React.Component {
   }
 }
 
-export default injectIntl(withStripes(stripesConnect(FeeFineSettings)));
+export default injectIntl(withStripes(FeeFineSettings));


### PR DESCRIPTION
# Purpose
Fix form save where url depends on local resource.

# Link
https://issues.folio.org/browse/UIU-1486

# Screenshot
<img width="652" alt="Screenshot 2020-03-11 at 20 44 53" src="https://user-images.githubusercontent.com/43472449/76452095-2e0edb00-63d9-11ea-9846-7323361eebe8.png">
