### PR TITLE
UIU-1490 - Update Manual Charges display to exclude "automated" fees/fines and to not allow "automated" Fee/Fine Types to be duplicate as "manual" Fee/Fine Types

### DIFF
--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -148,7 +148,7 @@ class FeeFineSettings extends React.Component {
     const label = formatMessage({ id: 'ui-users.feefines.singular' });
     const itemErrors = validate(item, index, items, 'feeFineType', label);
     const isAutomatedFeeFineNameUsed = feefines.some(feeFine => {
-      return feeFine.automatic && item.feeFineType.toLowerCase() === feeFine.feeFineType.toLowerCase();
+      return item.feeFineType && feeFine.automatic && item.feeFineType.toLowerCase() === feeFine.feeFineType.toLowerCase();
     });
 
     if (Number.isNaN(Number(item.defaultAmount)) && item.defaultAmount) {


### PR DESCRIPTION
# Purpose
Fix broken condition caused by validation of empty object for manual fee fines.

# Link
https://issues.folio.org/browse/UIU-1490