### PR TITLE
UIU-1279: Apply Custom Fields page components for record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## [3.1.0](IN PROGRESS)
+
+* Add posibility to view/create/edit custom fields on user record. UIU-1279.
+
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)
 

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -494,7 +494,7 @@ class UserDetail extends React.Component {
               <ViewCustomFieldsRecord
                 accordionId="customFields"
                 onToggle={this.handleSectionToggle}
-                expanded={this.state.sections.customFields}
+                expanded={sections.customFields}
                 backendModuleName="users"
                 entityType="user"
                 customFieldsValues={customFields}

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -28,7 +28,8 @@ import {
 } from '@folio/stripes/components';
 
 import {
-  NotesSmartAccordion
+  NotesSmartAccordion,
+  ViewCustomFieldsRecord,
 } from '@folio/stripes/smart-components';
 
 import {
@@ -145,6 +146,7 @@ class UserDetail extends React.Component {
         permissionsSection: false,
         servicePointsSection: false,
         notesAccordion: false,
+        customFields: false,
       },
     };
   }
@@ -398,6 +400,7 @@ class UserDetail extends React.Component {
       'addressType',
       '',
     );
+    const customFields = user?.customFields || [];
 
     if (!user) {
       return (
@@ -487,6 +490,14 @@ class UserDetail extends React.Component {
                 addressTypes={addressTypes}
                 expanded={sections.contactInfoSection}
                 onToggle={this.handleSectionToggle}
+              />
+              <ViewCustomFieldsRecord
+                accordionId="customFields"
+                onToggle={this.handleSectionToggle}
+                expanded={this.state.sections.customFields}
+                backendModuleName="users"
+                entityType="user"
+                customFieldsValues={customFields}
               />
               <IfPermission perm="proxiesfor.collection.get">
                 <ProxyPermissions

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
+import { Field } from 'redux-form';
 
 import { AppIcon } from '@folio/stripes/core';
 import {
@@ -20,6 +21,7 @@ import {
   Headline,
   AccordionSet,
 } from '@folio/stripes/components';
+import { EditCustomFieldsRecord } from '@folio/stripes/smart-components';
 import stripesForm from '@folio/stripes/form';
 
 import {
@@ -234,6 +236,7 @@ class UserForm extends React.Component {
         proxyAccordion: false,
         permissions: false,
         servicePoints: false,
+        customFields: true,
       },
     };
 
@@ -491,6 +494,14 @@ class UserForm extends React.Component {
                   onToggle={this.handleSectionToggle}
                   addressTypes={formData.addressTypes}
                   preferredContactTypeId={initialValues.preferredContactTypeId}
+                />
+                <EditCustomFieldsRecord
+                  accordionId="customFields"
+                  onToggle={this.handleSectionToggle}
+                  expanded={this.state.sections.customFields}
+                  backendModuleName="users"
+                  entityType="user"
+                  fieldComponent={Field}
                 />
                 {initialValues.id &&
                   <div>

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -498,7 +498,7 @@ class UserForm extends React.Component {
                 <EditCustomFieldsRecord
                   accordionId="customFields"
                   onToggle={this.handleSectionToggle}
-                  expanded={this.state.sections.customFields}
+                  expanded={sections.customFields}
                   backendModuleName="users"
                   entityType="user"
                   fieldComponent={Field}

--- a/test/bigtest/interactors/user-form-page.js
+++ b/test/bigtest/interactors/user-form-page.js
@@ -11,6 +11,7 @@ import {
   selectable,
   property,
   focusable,
+  isPresent,
 } from '@bigtest/interactor';
 
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor'; // eslint-disable-line
@@ -70,6 +71,25 @@ import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/P
   notificationsSentTo = new SelectInteractor('[data-test-proxy-notifcations-sent-to]');
 }
 
+@interactor class CustomFieldsSectionInteractor {
+  fields = collection('[data-test-record-edit-custom-field]', {
+    input: scoped('[type="text"]', {
+      fillInput: fillable(),
+      blurInput: blurrable(),
+
+      fillAndBlur(val) {
+        return this
+          .fillInput(val)
+          .blurInput();
+      }
+    }),
+    popoverIsPresent: isPresent('[class^=popoverTarget---]'),
+    validationMessage: text('[class^=feedbackError---]'),
+  });
+
+  label = text('[class*="labelArea---"]');
+}
+
 @interactor class UserFormPage {
   // isLoaded = isPresent('[class*=paneTitleLabel---]');
 
@@ -108,6 +128,8 @@ import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/P
   firstAddressTypeField = new SelectFieldInteractor('[name="personal.addresses[0].addressType"]');
   secondAddressTypeField = new SelectFieldInteractor('[name="personal.addresses[1].addressType"]');
   defaultAddressTypeField = new SelectFieldInteractor('[data-test-default-delivery-address-field] select');
+
+  customFieldsSection = scoped('#customFields', CustomFieldsSectionInteractor);
 }
 
 export default new UserFormPage('[data-test-form-page]');

--- a/test/bigtest/interactors/user-view-page.js
+++ b/test/bigtest/interactors/user-view-page.js
@@ -33,6 +33,11 @@ import proxyItemCSS from '../../../src/components/ProxyGroup/ProxyItem/ProxyItem
   }
 }
 
+@interactor class CustomFieldsSectionInteractor {
+  accordionButton = scoped('#accordion-toggle-button-customfields', ButtonInteractor);
+  label = text('[class*="labelArea---"]');
+}
+
 @interactor class InstanceViewPage {
   title = text('[data-test-header-title]');
   headerDropdown = new HeaderDropdown();
@@ -46,6 +51,7 @@ import proxyItemCSS from '../../../src/components/ProxyGroup/ProxyItem/ProxyItem
   fulfillmentPreference = text('[data-test-fulfillment-preference]');
   defaultPickupServicePoint = text('[data-test-default-pickup-service-point]');
   defaultDeliveryAddress = text('[data-test-default-delivery-address]');
+  customFieldsSection = scoped('#customFields', CustomFieldsSectionInteractor);
 
   whenLoaded() {
     return this.when(() => this.isPresent).timeout(5000);

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -29,8 +29,20 @@ export default function config() {
     ssoEnabled: false
   });
 
-  this.get('/configurations/entries', {
-    configs: []
+  this.get('/configurations/entries', (schema, request) => {
+    if (request.url.includes('custom_fields_label')) {
+      return {
+        configs: [{
+          id: 'tested-custom-field-label',
+          module: 'USERS',
+          configName: 'custom_fields_label',
+          enabled: true,
+          value: 'Custom Fields Test',
+        }],
+      };
+    }
+
+    return { configs: [] };
   });
   this.post('/bl-users/login', () => {
     return new Response(
@@ -513,4 +525,48 @@ export default function config() {
   });
 
   this.post('/request-preference-storage/request-preference');
+
+  this.get('/custom-fields', {
+    'customFields': [{
+      'id': '1',
+      'name': 'Textbox 1',
+      'refId': 'textbox-1',
+      'type': 'TEXTBOX_SHORT',
+      'entityType': 'user',
+      'visible': true,
+      'required': true,
+      'order': 1,
+      'helpText': 'helpful text',
+    }, {
+      'id': '2',
+      'name': 'Textbox 2',
+      'refId': 'textbox-2',
+      'type': 'TEXTBOX_SHORT',
+      'entityType': 'user',
+      'visible': true,
+      'required': false,
+      'order': 2,
+      'helpText': '',
+    }, {
+      'id': '3',
+      'name': 'Textarea 3',
+      'refId': 'textarea-3',
+      'type': 'TEXTBOX_LONG',
+      'entityType': 'user',
+      'visible': false,
+      'required': false,
+      'order': 3,
+      'helpText': '',
+    }, {
+      'id': '4',
+      'name': 'Textarea 4',
+      'refId': 'textarea-4',
+      'type': 'TEXTBOX_LONG',
+      'entityType': 'user',
+      'visible': true,
+      'required': true,
+      'order': 4,
+      'helpText': 'help text',
+    }]
+  });
 }

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -564,7 +564,7 @@ export default function config() {
       'type': 'TEXTBOX_LONG',
       'entityType': 'user',
       'visible': true,
-      'required': true,
+      'required': false,
       'order': 4,
       'helpText': 'help text',
     }]

--- a/test/bigtest/network/factories/user.js
+++ b/test/bigtest/network/factories/user.js
@@ -19,6 +19,12 @@ export default Factory.extend({
   expirationDate: () => '2020-04-07T00:00:00.000+0000',
   createdDate: () => '2018-11-20T11:42:53.385+0000',
   updatedDate: () => '2018-11-20T20:00:47.409+0000',
+  customFields: {
+    'textbox-1': faker.lorem.sentence(),
+    'textbox-2': faker.lorem.sentence(),
+    'textarea-3': faker.lorem.sentence(),
+    'textarea-4': ''
+  },
 
   afterCreate(user, server) {
     server.create('service-points-user', {

--- a/test/bigtest/tests/settings-custom-fields-test.js
+++ b/test/bigtest/tests/settings-custom-fields-test.js
@@ -11,45 +11,6 @@ import setupApplication from '../helpers/setup-application';
 import CustomFieldsInteractor from '../interactors/settings-custom-fields';
 
 describe('Settings custom fields', () => {
-  const customFields = [
-    {
-      id: 'daf98472-7311-487d-a018-65fb2496e3e4',
-      name: 'Custom field 1',
-      refId: 'custom-field-_1',
-      type: 'TEXTBOX_LONG',
-      entityType: 'user',
-      visible: false,
-      required: false,
-      order: 1,
-      helpText: 'Very helpful text',
-      metadata: {
-        createdDate: '2020-02-25T09:06:16.182+0000',
-        createdByUserId: '6be4382b-cfa9-5571-a7ed-cb89536de85b',
-        createdByUsername: 'diku_admin',
-        updatedDate: '2020-02-25T09:06:16.182+0000',
-        updatedByUserId: '6be4382b-cfa9-5571-a7ed-cb89536de85b'
-      }
-    },
-    {
-      id: '4e8f8e16-8fd2-4d69-8d64-3ee8c0bb385f',
-      name: 'Custom field 2',
-      refId: 'custom-field-_2',
-      type: 'TEXTBOX_SHORT',
-      entityType: 'user',
-      visible: true,
-      required: true,
-      order: 2,
-      helpText: '',
-      metadata: {
-        createdDate: '2020-02-25T09:06:16.182+0000',
-        createdByUserId: '6be4382b-cfa9-5571-a7ed-cb89536de85b',
-        createdByUsername: 'diku_admin',
-        updatedDate: '2020-02-25T09:06:16.182+0000',
-        updatedByUserId: '6be4382b-cfa9-5571-a7ed-cb89536de85b'
-      }
-    },
-  ];
-
   describe('when there are custom fields saved', () => {
     before(() => {
       setupApplication({
@@ -58,11 +19,6 @@ describe('Settings custom fields', () => {
     });
 
     beforeEach(async function () {
-      this.server.get('/custom-fields', () => ({
-        'customFields': customFields,
-        'totalRecords': 2,
-      }));
-
       this.visit('/settings/users/custom-fields');
 
       await CustomFieldsInteractor.whenCustomFieldsLoaded();
@@ -77,7 +33,7 @@ describe('Settings custom fields', () => {
     });
 
     it('should render all available custom fields', () => {
-      expect(CustomFieldsInteractor.customFieldsList.set().length).to.equal(2);
+      expect(CustomFieldsInteractor.customFieldsList.set().length).to.equal(4);
     });
   });
 
@@ -111,11 +67,6 @@ describe('Settings custom fields', () => {
     });
 
     beforeEach(async function () {
-      this.server.get('/custom-fields', () => ({
-        'customFields': [],
-        'totalRecords': 0,
-      }));
-
       this.visit('/settings/users/custom-fields');
       await CustomFieldsInteractor.whenLoaded();
       await CustomFieldsInteractor.clickEditFieldsButton();
@@ -127,13 +78,6 @@ describe('Settings custom fields', () => {
   });
 
   describe('permissions', () => {
-    beforeEach(function () {
-      this.server.get('/custom-fields', () => ({
-        'customFields': customFields,
-        'totalRecords': 2,
-      }));
-    });
-
     describe('when user does not have view permissions', () => {
       beforeEach(async function () {
         this.visit('/settings/users/custom-fields');
@@ -257,7 +201,7 @@ describe('Settings custom fields', () => {
         });
 
         it('should render all delete buttons', () => {
-          expect(CustomFieldsInteractor.deleteCustomFieldButtonsCount).to.equal(customFields.length);
+          expect(CustomFieldsInteractor.deleteCustomFieldButtonsCount).to.equal(4);
         });
       });
     });

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -159,50 +159,50 @@ describe('User Edit Page', () => {
     });
   });
 
-  describe('with custom fields', () => {
-    it('custom fields accordion is present', () => {
+  describe('when custom fields are in stock', () => {
+    it('should show custom fields accordion', () => {
       expect(UserFormPage.customFieldsSection.isPresent).to.be.true;
     });
 
-    it('has correct accordion label', () => {
+    it('should display correct accordion label', () => {
       expect(UserFormPage.customFieldsSection.label).to.equal('Custom Fields Test');
     });
 
-    it('custom fields length', () => {
+    it('should display all visible custom fields', () => {
       expect(UserFormPage.customFieldsSection.fields().length).to.equal(3);
     });
 
-    it('field has popover', () => {
+    it('should display popover for the first field', () => {
       expect(UserFormPage.customFieldsSection.fields(0).popoverIsPresent).to.be.true;
     });
 
-    describe('set empty falue to required field', () => {
+    describe('when set empty falue to required field', () => {
       beforeEach(async () => {
         await UserFormPage.customFieldsSection.fields(0).input.fillAndBlur('');
       });
 
-      it('show validation message', () => {
+      it('should show validation message', () => {
         expect(UserFormPage.customFieldsSection.fields(0).validationMessage).to.equal('Textbox 1 is required');
       });
     });
 
-    describe('set value to textbox out of length limit', () => {
+    describe('when set value to textbox out of length limit', () => {
       beforeEach(async () => {
         await UserFormPage.customFieldsSection.fields(0).input.fillAndBlur((new Array(151)).fill('a').join(''));
       });
 
-      it('show validation message', () => {
+      it('should show validation message', () => {
         expect(UserFormPage.customFieldsSection.fields(0).validationMessage)
           .to.equal('Textbox 1 character limit has been exceeded. Please revise.');
       });
     });
 
-    describe('set to textarea value out of length limit', () => {
+    describe('when set to textarea value out of length limit', () => {
       beforeEach(async () => {
         await UserFormPage.customFieldsSection.fields(2).input.fillAndBlur((new Array(1501)).fill('a').join(''));
       });
 
-      it('show validation message', () => {
+      it('should show validation message', () => {
         expect(UserFormPage.customFieldsSection.fields(2).validationMessage)
           .to.equal('Textarea 4 character limit has been exceeded. Please revise.');
       });
@@ -210,7 +210,7 @@ describe('User Edit Page', () => {
   });
 });
 
-describe('without custom fields', () => {
+describe('when custom fields are not in stock', () => {
   setupApplication();
 
   beforeEach(async function () {
@@ -224,7 +224,7 @@ describe('without custom fields', () => {
     await UserFormPage.whenLoaded();
   });
 
-  it('custom-fields accordion does not present', () => {
+  it('should custom fields accordion does not present', () => {
     expect(UserFormPage.customFieldsSection.isPresent).to.be.false;
   });
 });

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -158,4 +158,73 @@ describe('User Edit Page', () => {
       });
     });
   });
+
+  describe('with custom fields', () => {
+    it('custom fields accordion is present', () => {
+      expect(UserFormPage.customFieldsSection.isPresent).to.be.true;
+    });
+
+    it('has correct accordion label', () => {
+      expect(UserFormPage.customFieldsSection.label).to.equal('Custom Fields Test');
+    });
+
+    it('custom fields length', () => {
+      expect(UserFormPage.customFieldsSection.fields().length).to.equal(3);
+    });
+
+    it('field has popover', () => {
+      expect(UserFormPage.customFieldsSection.fields(0).popoverIsPresent).to.be.true;
+    });
+
+    describe('set empty falue to required field', () => {
+      beforeEach(async () => {
+        await UserFormPage.customFieldsSection.fields(0).input.fillAndBlur('');
+      });
+
+      it('show validation message', () => {
+        expect(UserFormPage.customFieldsSection.fields(0).validationMessage).to.equal('Textbox 1 is required');
+      });
+    });
+
+    describe('set value to textbox out of length limit', () => {
+      beforeEach(async () => {
+        await UserFormPage.customFieldsSection.fields(0).input.fillAndBlur((new Array(151)).fill('a').join(''));
+      });
+
+      it('show validation message', () => {
+        expect(UserFormPage.customFieldsSection.fields(0).validationMessage)
+          .to.equal('Textbox 1 character limit has been exceeded. Please revise.');
+      });
+    });
+
+    describe('set to textarea value out of length limit', () => {
+      beforeEach(async () => {
+        await UserFormPage.customFieldsSection.fields(2).input.fillAndBlur((new Array(1501)).fill('a').join(''));
+      });
+
+      it('show validation message', () => {
+        expect(UserFormPage.customFieldsSection.fields(2).validationMessage)
+          .to.equal('Textarea 4 character limit has been exceeded. Please revise.');
+      });
+    });
+  });
+});
+
+describe('without custom fields', () => {
+  setupApplication();
+
+  beforeEach(async function () {
+    const user = this.server.create('user');
+
+    this.server.get('/custom-fields', {
+      customFields: [],
+    });
+
+    this.visit(`/users/${user.id}/edit`);
+    await UserFormPage.whenLoaded();
+  });
+
+  it('custom-fields accordion does not present', () => {
+    expect(UserFormPage.customFieldsSection.isPresent).to.be.false;
+  });
 });

--- a/test/bigtest/tests/user-view-page-test.js
+++ b/test/bigtest/tests/user-view-page-test.js
@@ -64,7 +64,7 @@ describe('User view', () => {
       });
     });
 
-    describe('custom fields section', () => {
+    describe('when custom fields are in stock', () => {
       it('should display custom fields accordion', () => {
         expect(InstanceViewPage.customFieldsSection.isPresent).to.be.true;
       });
@@ -75,18 +75,18 @@ describe('User view', () => {
     });
   });
 
-  describe('visit user-details without custom fields', () => {
+  describe('when custom fields are not in stock', () => {
     beforeEach(async function () {
       user = this.server.create('user');
       this.server.get('/custom-fields', {
-        customFiedls: [],
+        customFields: [],
       });
 
       this.visit(`/users/view/${user.id}`);
       await InstanceViewPage.whenLoaded();
     });
 
-    it('does not display custom fields accordion', () => {
+    it('should not display custom fields accordion', () => {
       expect(InstanceViewPage.customFieldsSection.isPresent).to.be.false;
     });
   });

--- a/test/bigtest/tests/user-view-page-test.js
+++ b/test/bigtest/tests/user-view-page-test.js
@@ -63,5 +63,31 @@ describe('User view', () => {
         expect(InstanceViewPage.defaultDeliveryAddress).to.equal('Claim');
       });
     });
+
+    describe('custom fields section', () => {
+      it('should display custom fields accordion', () => {
+        expect(InstanceViewPage.customFieldsSection.isPresent).to.be.true;
+      });
+
+      it('should display correct accordion title', () => {
+        expect(InstanceViewPage.customFieldsSection.label).to.equal('Custom Fields Test');
+      });
+    });
+  });
+
+  describe('visit user-details without custom fields', () => {
+    beforeEach(async function () {
+      user = this.server.create('user');
+      this.server.get('/custom-fields', {
+        customFiedls: [],
+      });
+
+      this.visit(`/users/view/${user.id}`);
+      await InstanceViewPage.whenLoaded();
+    });
+
+    it('does not display custom fields accordion', () => {
+      expect(InstanceViewPage.customFieldsSection.isPresent).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Description
- Add Custom Fields accordion to User Details Page
- Add Custom Fields accordion to Create/Edit User Page
- Add tests

Implementation of accordions in [`stripes-smart-components`](https://github.com/folio-org/stripes-smart-components/pull/743)

## Issue
[UIU-1279](https://issues.folio.org/browse/UIU-1279)

## Screenshots

### User Details Page
![image](https://user-images.githubusercontent.com/55701515/76852458-0a71e780-6854-11ea-9802-ac04763d005d.png)

### User Edit Page
![image](https://user-images.githubusercontent.com/55701515/76852597-5d4b9f00-6854-11ea-96fe-4004dfceace0.png)
