### PR TITLE
Revert "UIU-1051: Fix Settings>Users spacing before Fee/fine section"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import { hot } from 'react-hot-loader';
-import _ from 'lodash';
 
 import { Route, Switch, IfPermission } from '@folio/stripes/core';
 
@@ -11,115 +10,14 @@ import * as Routes from './routes';
 
 import pkg from '../package';
 import Settings from './settings';
-import PermissionSets from './settings/permissions/PermissionSets';
-import PatronGroupsSettings from './settings/PatronGroupsSettings';
-import AddressTypesSettings from './settings/AddressTypesSettings';
-import ProfilePictureSettings from './settings/ProfilePictureSettings';
-import OwnerSettings from './settings/OwnerSettings';
-import FeeFineSettings from './settings/FeeFineSettings';
-import WaiveSettings from './settings/WaiveSettings';
-import PaymentSettings from './settings/PaymentSettings';
-import CommentRequiredSettings from './settings/CommentRequiredSettings';
-import RefundReasonsSettings from './settings/RefundReasonsSettings';
-import TransferAccountsSettings from './settings/TransferAccountsSettings';
-import CustomFieldsSettingsPane from './settings/CustomFieldsSettings';
+import sections from './settings/sections';
 import {
   NoteCreatePage,
   NoteViewPage,
   NoteEditPage
 } from './views';
 
-const settingsGeneral = [
-  {
-    route: 'perms',
-    label: <FormattedMessage id="ui-users.settings.permissionSet" />,
-    component: PermissionSets,
-    perm: 'ui-users.settings.permsets',
-  },
-  {
-    route: 'groups',
-    label: <FormattedMessage id="ui-users.settings.patronGroups" />,
-    component: PatronGroupsSettings,
-    perm: 'ui-users.settings.usergroups',
-  },
-  {
-    route: 'addresstypes',
-    label: <FormattedMessage id="ui-users.settings.addressTypes" />,
-    component: AddressTypesSettings,
-    perm: 'ui-users.settings.addresstypes',
-  },
-  {
-    route: 'profilepictures',
-    label: <FormattedMessage id="ui-users.settings.profilePictures" />,
-    component: ProfilePictureSettings,
-  },
-  {
-    route: 'custom-fields',
-    label: <FormattedMessage id="ui-users.settings.customFields" />,
-    component: CustomFieldsSettingsPane,
-    perm: 'ui-users.settings.customfields.view',
-  }
-];
-
-const settingsFeefines = [
-  {
-    route: 'owners',
-    label: <FormattedMessage id="ui-users.settings.owners" />,
-    component: OwnerSettings,
-    perm: 'ui-users.settings.feefine',
-  },
-  {
-    route: 'feefinestable',
-    label: <FormattedMessage id="ui-users.settings.manualCharges" />,
-    component: FeeFineSettings,
-    perm: 'ui-users.settings.feefine',
-  },
-  {
-    route: 'waivereasons',
-    label: <FormattedMessage id="ui-users.settings.waiveReasons" />,
-    component: WaiveSettings,
-    perm: 'ui-users.settings.feefine',
-  },
-  {
-    route: 'payments',
-    label: <FormattedMessage id="ui-users.settings.paymentMethods" />,
-    component: PaymentSettings,
-    perm: 'ui-users.settings.feefine',
-  },
-  {
-    route: 'refunds',
-    label: <FormattedMessage id="ui-users.settings.refundReasons" />,
-    component: RefundReasonsSettings,
-    perm: 'ui-users.settings.feefine',
-  },
-  {
-    route: 'comments',
-    label: <FormattedMessage id="ui-users.settings.commentRequired" />,
-    component: CommentRequiredSettings,
-    perm: 'ui-users.settings.feefine',
-  },
-  {
-    route: 'transfers',
-    label: <FormattedMessage id="ui-users.settings.transferAccounts" />,
-    component: TransferAccountsSettings,
-    perm: 'ui-users.settings.transfers',
-  },
-];
-
-export const settingsSections = [
-  {
-    label: <FormattedMessage id="ui-users.settings.general" />,
-    pages: _.sortBy(settingsGeneral, ['label']),
-  },
-  {
-    label: <FormattedMessage id="ui-users.settings.feefine" />,
-    pages: _.sortBy(settingsFeefines, ['label']),
-  },
-];
-
 class UsersRouting extends React.Component {
-  static actionNames = ['stripesHome', 'usersSortByName'];
-
   static propTypes = {
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
@@ -159,6 +57,8 @@ class UsersRouting extends React.Component {
       }
     }
   }
+
+  static actionNames = ['stripesHome', 'usersSortByName'];
 
   noMatch() {
     const {
@@ -215,7 +115,7 @@ class UsersRouting extends React.Component {
       return (
         <Route path={path} component={Settings}>
           <Switch>
-            {[].concat(...settingsSections.map(section => section.pages))
+            {[].concat(...sections.map(section => section.pages))
               .filter(setting => !setting.perm || stripes.hasPerm(setting.perm))
               .map(setting => <Route path={`${path}/${setting.route}`} key={setting.route} component={setting.component} />)
             }

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -10,6 +10,7 @@ import { stripesConnect } from '@folio/stripes/core';
 import {
   makeQueryFunction,
   StripesConnectedSource,
+  buildUrl,
 } from '@folio/stripes/smart-components';
 
 import filterConfig from './filterConfig';
@@ -148,11 +149,17 @@ class UserSearchContainer extends React.Component {
   };
 
   querySetter = ({ nsValues, state }) => {
-    if (/reset/.test(state.changeType)) {
-      this.props.mutator.query.replace(nsValues);
-    } else {
-      this.props.mutator.query.update(nsValues);
+    const { location : locationProp, history } = this.props;
+
+    let location = locationProp;
+    // modifying the location hides the user detail view if a search/filter is triggered.
+    if (state.changeType !== 'init.reset' && !location.pathname.endsWith('users')) {
+      const pathname = '/users';
+      location = { ...locationProp, pathname };
     }
+
+    const url = buildUrl(location, nsValues);
+    history.push(url);
   }
 
   queryGetter = () => {
@@ -170,6 +177,7 @@ class UserSearchContainer extends React.Component {
         initialSearch="?sort=name"
         onNeedMoreData={this.onNeedMoreData}
         queryGetter={this.queryGetter}
+        querySetter={this.querySetter}
         {...this.props}
       >
         { this.props.children }

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -9,6 +9,8 @@ import {
 import { Field } from 'redux-form';
 import { Select } from '@folio/stripes/components';
 import { ControlledVocab } from '@folio/stripes/smart-components';
+import { stripesConnect, withStripes } from '@folio/stripes/core';
+
 
 import { validate } from '../components/util';
 import {
@@ -301,4 +303,4 @@ class FeeFineSettings extends React.Component {
   }
 }
 
-export default injectIntl(FeeFineSettings);
+export default injectIntl(withStripes(stripesConnect(FeeFineSettings)));

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { IfPermission } from '@folio/stripes/core';
@@ -23,7 +23,7 @@ export default class Settings extends Component {
     const { children, match: { path } } = this.props;
 
     return (
-      <Fragment>
+      <>
         <Pane
           defaultWidth="20%"
           paneTitle={
@@ -50,7 +50,7 @@ export default class Settings extends Component {
           </NavList>
         </Pane>
         {children}
-      </Fragment>
+      </>
     );
   }
 }

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -10,7 +10,8 @@ import {
   Pane,
   PaneBackLink,
 } from '@folio/stripes/components';
-import { settingsSections } from '..';
+
+import sections from './sections';
 
 export default class Settings extends Component {
   static propTypes = {
@@ -35,7 +36,7 @@ export default class Settings extends Component {
           )}
         >
           <NavList>
-            {settingsSections.map((section, index) => (
+            {sections.map((section, index) => (
               <NavListSection key={index} label={section.label}>
                 {section.pages.map(setting => (setting.perm ? (
                   <IfPermission key={setting.route} perm={setting.perm}>

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,0 +1,55 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { IfPermission } from '@folio/stripes/core';
+import {
+  Headline,
+  NavList,
+  NavListItem,
+  NavListSection,
+  Pane,
+  PaneBackLink,
+} from '@folio/stripes/components';
+import { settingsSections } from '..';
+
+export default class Settings extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    match: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { children, match: { path } } = this.props;
+
+    return (
+      <Fragment>
+        <Pane
+          defaultWidth="20%"
+          paneTitle={
+            <Headline tag="h3" margin="none">
+              <FormattedMessage id="ui-users.settings.label" />
+            </Headline>
+          }
+          firstMenu={(
+            <PaneBackLink to="/settings" />
+          )}
+        >
+          <NavList>
+            {settingsSections.map((section, index) => (
+              <NavListSection key={index} label={section.label}>
+                {section.pages.map(setting => (setting.perm ? (
+                  <IfPermission key={setting.route} perm={setting.perm}>
+                    <NavListItem to={`${path}/${setting.route}`}>{setting.label}</NavListItem>
+                  </IfPermission>
+                ) : (
+                  <NavListItem key={setting.route} to={`${path}/${setting.route}`}>{setting.label}</NavListItem>
+                )))}
+              </NavListSection>
+            ))}
+          </NavList>
+        </Pane>
+        {children}
+      </Fragment>
+    );
+  }
+}

--- a/src/settings/sections.js
+++ b/src/settings/sections.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { sortBy } from 'lodash';
+
+import PermissionSets from './permissions/PermissionSets';
+import PatronGroupsSettings from './PatronGroupsSettings';
+import AddressTypesSettings from './AddressTypesSettings';
+import ProfilePictureSettings from './ProfilePictureSettings';
+import OwnerSettings from './OwnerSettings';
+import FeeFineSettings from './FeeFineSettings';
+import WaiveSettings from './WaiveSettings';
+import PaymentSettings from './PaymentSettings';
+import CommentRequiredSettings from './CommentRequiredSettings';
+import RefundReasonsSettings from './RefundReasonsSettings';
+import TransferAccountsSettings from './TransferAccountsSettings';
+import CustomFieldsSettingsPane from './CustomFieldsSettings';
+
+
+const settingsGeneral = [
+  {
+    route: 'perms',
+    label: <FormattedMessage id="ui-users.settings.permissionSet" />,
+    component: PermissionSets,
+    perm: 'ui-users.settings.permsets',
+  },
+  {
+    route: 'groups',
+    label: <FormattedMessage id="ui-users.settings.patronGroups" />,
+    component: PatronGroupsSettings,
+    perm: 'ui-users.settings.usergroups',
+  },
+  {
+    route: 'addresstypes',
+    label: <FormattedMessage id="ui-users.settings.addressTypes" />,
+    component: AddressTypesSettings,
+    perm: 'ui-users.settings.addresstypes',
+  },
+  {
+    route: 'profilepictures',
+    label: <FormattedMessage id="ui-users.settings.profilePictures" />,
+    component: ProfilePictureSettings,
+  },
+  {
+    route: 'custom-fields',
+    label: <FormattedMessage id="ui-users.settings.customFields" />,
+    component: CustomFieldsSettingsPane,
+    perm: 'ui-users.settings.customfields.view',
+  }
+];
+
+const settingsFeefines = [
+  {
+    route: 'owners',
+    label: <FormattedMessage id="ui-users.settings.owners" />,
+    component: OwnerSettings,
+    perm: 'ui-users.settings.feefine',
+  },
+  {
+    route: 'feefinestable',
+    label: <FormattedMessage id="ui-users.settings.manualCharges" />,
+    component: FeeFineSettings,
+    perm: 'ui-users.settings.feefine',
+  },
+  {
+    route: 'waivereasons',
+    label: <FormattedMessage id="ui-users.settings.waiveReasons" />,
+    component: WaiveSettings,
+    perm: 'ui-users.settings.feefine',
+  },
+  {
+    route: 'payments',
+    label: <FormattedMessage id="ui-users.settings.paymentMethods" />,
+    component: PaymentSettings,
+    perm: 'ui-users.settings.feefine',
+  },
+  {
+    route: 'refunds',
+    label: <FormattedMessage id="ui-users.settings.refundReasons" />,
+    component: RefundReasonsSettings,
+    perm: 'ui-users.settings.feefine',
+  },
+  {
+    route: 'comments',
+    label: <FormattedMessage id="ui-users.settings.commentRequired" />,
+    component: CommentRequiredSettings,
+    perm: 'ui-users.settings.feefine',
+  },
+  {
+    route: 'transfers',
+    label: <FormattedMessage id="ui-users.settings.transferAccounts" />,
+    component: TransferAccountsSettings,
+    perm: 'ui-users.settings.transfers',
+  },
+];
+
+export default [
+  {
+    label: <FormattedMessage id="ui-users.settings.general" />,
+    pages: sortBy(settingsGeneral, ['label']),
+  },
+  {
+    label: <FormattedMessage id="ui-users.settings.feefine" />,
+    pages: sortBy(settingsFeefines, ['label']),
+  },
+];


### PR DESCRIPTION
Reverts folio-org/ui-users#1066

Rather than completely bailing on local routing and deferring to `@folio/stripes/smart-components/Settings`, I think we can accomplish UIU-1051 simply by defining the necessary style in `@folio/stripes/components/NavListSection`.