### PR TITLE
update to compatible version of plugin-find-user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change history for ui-users
 
 ## 2.27.0 (IN PROGRESS)
+## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
+[Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)
+
+
 * Add default settings for user status and preferred contact in new user creation. Refs UIU-1385.
 * Fix navigation paths on cancel button click on loan details, open and closed loan lists pages. Refs UIU-1377.
 * Prevent loan details opening upon click in loans action menu without selecting link. Fixes UIU-1359.
@@ -44,6 +48,7 @@
 * Provide permissions to custom fields. Refs UIU-1521.
 * Fix bug with assign and unassign permissions to users. Refs UIU-1518.
 * Default charge and action notices not saved on manual fee/fine charge settings. Refs UIU-1486.
+* Update to `@folio/stripes` `v3.0.0` compatible version of `plugin-find-user`.
 
 ## [2.26.0](https://github.com/folio-org/ui-users/tree/v2.26.0) (2019-12-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.25.3...v2.26.0)

--- a/package.json
+++ b/package.json
@@ -762,6 +762,6 @@
     "react-router-dom": "*"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^1.1.0"
+    "@folio/plugin-find-user": "^2.0.0"
   }
 }


### PR DESCRIPTION
`plugin-find-user` `v2.0.0` uses `@folio/stripes` `v3.0.0`.