### PR TITLE
correctly restrict stripes-core devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -725,7 +725,7 @@
     "@folio/eslint-config-stripes": "^5.2.0",
     "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.13.0",
-    "@folio/stripes-core": "~4.0.0",
+    "@folio/stripes-core": "^4.0.0",
     "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",
     "core-js": "^3.6.4",


### PR DESCRIPTION
PR #1178 changed the dev-dep on `stripes-core` from caret to tilde
without explanation. I think this was unintentional, but it had the
effect of pulling multiple copies of `stripes-core` into the build as
soon as the next minor version of `stripes-core` was published. This
happened because the looser caret dev-dep on `@folio/stripes` pulled
in the new version while the tilde dev-dep specified here held on to
the old version.