### PR TITLE
correctly import useStripes

### DIFF
--- a/src/routes/EditCustomFields.js
+++ b/src/routes/EditCustomFields.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { useStripes } from '@folio/stripes-core';
+import { useStripes } from '@folio/stripes/core';
 import { EditCustomFieldsSettings } from '@folio/stripes/smart-components';
 
 const propTypes = {

--- a/src/settings/CustomFieldsSettings.js
+++ b/src/settings/CustomFieldsSettings.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { useStripes } from '@folio/stripes-core';
+import { useStripes } from '@folio/stripes/core';
 import { ViewCustomFieldsSettings } from '@folio/stripes/smart-components';
 
 const propTypes = {


### PR DESCRIPTION
Import from `@folio/stripes/core` instead of `@folio/stripes-core` in
order to prevent NPEs. I think this worked prior to #1202 because the
SSC `<Settings>` component inadvertently, but fortuitously, provided
`stripes` to this component.