### PR TITLE
UIU-1511: Remove password field

### DIFF
--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -15,7 +15,6 @@ import {
 
 import { addressTypesShape } from '../../../shapes';
 
-import PasswordControl from './PasswordControl';
 import CreateResetPasswordControl from './CreateResetPasswordControl';
 import RequestPreferencesEdit from './RequestPreferencesEdit';
 
@@ -27,12 +26,9 @@ class EditExtendedInfo extends Component {
     userEmail: PropTypes.string.isRequired,
     accordionId: PropTypes.string.isRequired,
     userFirstName: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
     onToggle: PropTypes.func.isRequired,
   };
-
-  state = { isCredentialFieldRequired: false };
-
-  toggleCredentialFieldRequired = (_, value) => this.setState({ isCredentialFieldRequired: !!value });
 
   buildAccordionHeader = () => {
     return (
@@ -53,10 +49,9 @@ class EditExtendedInfo extends Component {
       userId,
       userFirstName,
       userEmail,
+      username,
       addressTypes,
     } = this.props;
-
-    const { isCredentialFieldRequired } = this.state;
 
     const accordionHeader = this.buildAccordionHeader();
     const isEditForm = !!userId;
@@ -128,27 +123,21 @@ class EditExtendedInfo extends Component {
               id="adduser_username"
               component={TextField}
               fullWidth
-              required={isCredentialFieldRequired}
               validStylesEnabled
-              onChange={this.toggleCredentialFieldRequired}
             />
           </Col>
-          {
-            isEditForm
-              ? (
-                <CreateResetPasswordControl
-                  userId={userId}
-                  email={userEmail}
-                  name={userFirstName}
-                />
-              )
-              : (
-                <PasswordControl
-                  isRequired={isCredentialFieldRequired}
-                  toggleRequired={this.toggleCredentialFieldRequired}
-                />
-              )
+          {isEditForm && username &&
+            (
+              <CreateResetPasswordControl
+                userId={userId}
+                email={userEmail}
+                name={userFirstName}
+                username={username}
+              />
+            )
           }
+        </Row>
+        <Row>
           <RequestPreferencesEdit addressTypes={addressTypes} />
         </Row>
         <br />

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -20,7 +20,6 @@ import {
   expandAllFunction,
   ExpandAllButton,
   Button,
-  Icon,
   Row,
   Col,
   Headline,

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -485,6 +485,7 @@ class UserForm extends React.Component {
                   userId={initialValues.id}
                   userFirstName={initialValues.personal.firstName}
                   userEmail={initialValues.personal.email}
+                  username={initialValues.username}
                   servicePoints={servicePoints}
                   addressTypes={formData.addressTypes}
                 />

--- a/test/bigtest/interactors/user-form-page.js
+++ b/test/bigtest/interactors/user-form-page.js
@@ -101,8 +101,7 @@ import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/P
   barcodeField = new InputFieldInteractor('#adduser_barcode');
   usernameField = new InputFieldInteractor('#adduser_username');
   isUsernameFieldRequired = property('#adduser_username', 'required');
-  passwordField = new InputFieldInteractor('#pw');
-  isPasswordFieldRequired = property('#pw', 'required');
+  resetPasswordLink = scoped('[class*=resetPasswordButton]');
   expirationDate = new InputFieldInteractor('#adduser_expirationdate');
 
   feedbackError = text('[class^="feedbackError---"]');

--- a/test/bigtest/tests/user-create-page-test.js
+++ b/test/bigtest/tests/user-create-page-test.js
@@ -43,60 +43,6 @@ describe('User Create Page', () => {
         });
       });
 
-      describe('Extended information', () => {
-        it('should not display "username" field as required', () => {
-          expect(UserFormPage.isUsernameFieldRequired).to.be.false;
-        });
-
-        it('should not display "password" field as required', () => {
-          expect(UserFormPage.isPasswordFieldRequired).to.be.false;
-        });
-
-        describe('filling "username" field', () => {
-          beforeEach(async function () {
-            await UserFormPage.usernameField.fillAndBlur('test');
-          });
-
-          it('should mark "username" and "password" fields as required', () => {
-            expect(UserFormPage.isUsernameFieldRequired).to.be.true;
-            expect(UserFormPage.isPasswordFieldRequired).to.be.true;
-          });
-
-          describe('clearing "username" field', () => {
-            beforeEach(async function () {
-              await UserFormPage.usernameField.fillAndBlur('');
-            });
-
-            it('should unmark "username" and "password" fields as required', () => {
-              expect(UserFormPage.isUsernameFieldRequired).to.be.false;
-              expect(UserFormPage.isPasswordFieldRequired).to.be.false;
-            });
-          });
-        });
-
-        describe('filling "password" field', () => {
-          beforeEach(async function () {
-            await UserFormPage.passwordField.fillAndBlur('test');
-          });
-
-          it('should mark "username" and "password" fields as required', () => {
-            expect(UserFormPage.isUsernameFieldRequired).to.be.true;
-            expect(UserFormPage.isPasswordFieldRequired).to.be.true;
-          });
-
-          describe('clearing "username" field', () => {
-            beforeEach(async function () {
-              await UserFormPage.passwordField.fillAndBlur('');
-            });
-
-            it('should unmark "username" and "password" fields as required', () => {
-              expect(UserFormPage.isUsernameFieldRequired).to.be.false;
-              expect(UserFormPage.isPasswordFieldRequired).to.be.false;
-            });
-          });
-        });
-      });
-
       describe('request preferences', () => {
         it('should display "hold shelf" checkbox as checked', () => {
           expect(UserFormPage.holdShelfCheckboxIsChecked).to.be.true;
@@ -187,6 +133,16 @@ describe('User Create Page', () => {
               expect(UserFormPage.defaultAddressTypeValidationMessage).to.equal('Please, add at least one address inside "Addresses" section');
             });
           });
+        });
+      });
+
+      describe('fill username', () => {
+        beforeEach(async () => {
+          await UserFormPage.usernameField.fillAndBlur('username');
+        });
+
+        it('should display reset password link', () => {
+          expect(UserFormPage.resetPasswordLink.isPresent).to.be.false;
         });
       });
     });

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -36,6 +36,10 @@ describe('User Edit Page', () => {
     expect(UserFormPage.title).to.equal(user1.username);
   });
 
+  it('should display reset password link', () => {
+    expect(UserFormPage.resetPasswordLink.isPresent).to.be.true;
+  });
+
   describe('validating user barcode', () => {
     beforeEach(async function () {
       await UserFormPage.barcodeField.fillAndBlur(user2.barcode);


### PR DESCRIPTION
# Description
- On Create New user record should no longer show a password field
- Entering a username should no longer require entering a password
- If username has already been saved to the record then display the Send a create password email link
# Story
https://issues.folio.org/browse/UIU-1511
# Screenshots
![image](https://user-images.githubusercontent.com/55694637/77323969-bc128c00-6d1e-11ea-8929-90f559d5e3ae.png)
