### PR TITLE
UIU-913: Fix ability to mark user as inactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.1.0](IN PROGRESS)
 
 * Add posibility to view/create/edit custom fields on user record. UIU-1279.
+* Fix ability to mark user as inactive. Fixes UIU-913.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -36,7 +36,6 @@ class EditUserInfo extends React.Component {
       intl,
     } = this.props;
 
-
     const isUserExpired = () => {
       const expirationDate = new Date(initialValues.expirationDate);
       const now = Date.now();
@@ -63,11 +62,11 @@ class EditUserInfo extends React.Component {
 
     const statusOptions = [
       {
-        value: 'true',
+        value: true,
         label: intl.formatMessage({ id: 'ui-users.active' })
       },
       {
-        value: 'false',
+        value: false,
         label: intl.formatMessage({ id: 'ui-users.inactive' })
       }
     ];
@@ -152,7 +151,6 @@ class EditUserInfo extends React.Component {
               fullWidth
               disabled={isStatusFieldDisabled()}
               dataOptions={statusOptions}
-              format={(value) => (value ? 'true' : 'false')}
               defaultValue={initialValues.active}
             />
             {isUserExpired() && (

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -209,6 +209,7 @@ class UserEdit extends React.Component {
     } = this.props;
 
     const user = cloneDeep(userFormData);
+    const prevUser = resources?.selUser?.records?.[0] ?? {};
 
     if (get(resources, 'requestPreferences.records[0].totalRecords')) {
       this.updateRequestPreferences(requestPreferences);
@@ -235,8 +236,16 @@ class UserEdit extends React.Component {
 
     const data = omit(user, ['creds', 'proxies', 'sponsors', 'permissions', 'servicePoints', 'preferredServicePoint']);
     const today = moment().endOf('day');
+    const curActive = user.active;
+    const prevActive = prevUser.active;
 
-    data.active = (moment(user.expirationDate).endOf('day').isSameOrAfter(today));
+    // if active has been changed manually on the form
+    // or if the expirationDate has been removed
+    if (curActive !== prevActive || !user.expirationDate) {
+      data.active = curActive;
+    } else {
+      data.active = (moment(user.expirationDate).endOf('day').isSameOrAfter(today));
+    }
 
     mutator.selUser.PUT(data).then(() => {
       history.push({

--- a/test/bigtest/interactors/user-form-page.js
+++ b/test/bigtest/interactors/user-form-page.js
@@ -103,6 +103,7 @@ import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/P
   isUsernameFieldRequired = property('#adduser_username', 'required');
   resetPasswordLink = scoped('[class*=resetPasswordButton]');
   expirationDate = new InputFieldInteractor('#adduser_expirationdate');
+  clearExpirationDate = clickable('#datepicker-clear-button-adduser_expirationdate');
 
   feedbackError = text('[class^="feedbackError---"]');
   cancelButton = new ButtonInteractor('[data-test-user-form-cancel-button]');
@@ -127,7 +128,7 @@ import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/P
   firstAddressTypeField = new SelectFieldInteractor('[name="personal.addresses[0].addressType"]');
   secondAddressTypeField = new SelectFieldInteractor('[name="personal.addresses[1].addressType"]');
   defaultAddressTypeField = new SelectFieldInteractor('[data-test-default-delivery-address-field] select');
-
+  statusField = new SelectFieldInteractor('#useractive');
   customFieldsSection = scoped('#customFields', CustomFieldsSectionInteractor);
 }
 

--- a/test/bigtest/interactors/user-view-page.js
+++ b/test/bigtest/interactors/user-view-page.js
@@ -5,10 +5,15 @@ import {
   isPresent,
   scoped,
   count,
+  collection,
   ButtonInteractor,
 } from '@bigtest/interactor';
 
 import proxyItemCSS from '../../../src/components/ProxyGroup/ProxyItem/ProxyItem.css';
+
+@interactor class AccordionSection {
+  keyValues = collection('[data-test-kv-value]');
+}
 
 @interactor class ProxySectionInteractor {
   proxyCount = count(`[data-test="proxies"] .${proxyItemCSS.item}`);
@@ -44,6 +49,7 @@ import proxyItemCSS from '../../../src/components/ProxyGroup/ProxyItem/ProxyItem
   defaultPickupServicePoint = text('[data-test-default-pickup-service-point]');
   defaultDeliveryAddress = text('[data-test-default-delivery-address]');
   customFieldsSection = scoped('#customFields', CustomFieldsSectionInteractor);
+  userInfo = new AccordionSection('#userInformationSection');
 
   whenLoaded() {
     return this.when(() => this.isPresent).timeout(5000);

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -158,8 +158,16 @@ export default function config() {
     return schema.users.find(request.params.id).attrs;
   });
 
-  this.put('/users/:id', (schema, request) => {
-    return schema.users.find(request.params.id).attrs;
+  this.put('/users/:id', (schema, { params, requestBody }) => {
+    const data = JSON.parse(requestBody);
+    // The active field is not converted to boolean correctly
+    // So we do it here manually
+    data.active = (data.active === 'true');
+    const user = schema.users.find(params.id);
+
+    user.update(data);
+
+    return user.attrs;
   });
 
   this.get('/proxiesfor', {

--- a/test/bigtest/network/factories/user.js
+++ b/test/bigtest/network/factories/user.js
@@ -16,7 +16,7 @@ export default Factory.extend({
     'group7',
   ]),
   enrollmentDate: () => '2015-12-14T00:00:00.000+0000',
-  expirationDate: () => '2020-04-07T00:00:00.000+0000',
+  expirationDate: () => faker.date.future(10),
   createdDate: () => '2018-11-20T11:42:53.385+0000',
   updatedDate: () => '2018-11-20T20:00:47.409+0000',
   customFields: {

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -212,6 +212,33 @@ describe('User Edit Page', () => {
       });
     });
   });
+
+  describe('changing status field', () => {
+    describe('changing status to inactive', () => {
+      beforeEach(async function () {
+        await UserFormPage.statusField.selectAndBlur('Inactive');
+        await UserFormPage.submitButton.click();
+        await InstanceViewPage.whenLoaded();
+      });
+
+      it('should display inactive status', () => {
+        expect(InstanceViewPage.userInfo.keyValues(5).text).to.equal('inactive');
+      });
+    });
+
+    describe('clearing expirationDate field', () => {
+      beforeEach(async function () {
+        await UserFormPage.statusField.selectAndBlur('Active');
+        await UserFormPage.clearExpirationDate();
+        await UserFormPage.submitButton.click();
+        await InstanceViewPage.whenLoaded();
+      });
+
+      it('should display active status', () => {
+        expect(InstanceViewPage.userInfo.keyValues(5).text).to.equal('active');
+      });
+    });
+  });
 });
 
 describe('when custom fields are not in stock', () => {


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-913

This PR should fix two cases:

1. Changing status to inactive when `expirationDate` is empty or set with the date in the future
2. Keeping status as active when `expirationDate` is removed