### PR TITLE
UIU-1540: Add query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.1.0](IN PROGRESS)
 
 * Add posibility to view/create/edit custom fields on user record. UIU-1279.
+* Increase limit of service points in the Associated Service Points dropdown at Settings --> Users --> Fee/Fine Owners. Refs UIU-1540.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/settings/OwnerSettings.js
+++ b/src/settings/OwnerSettings.js
@@ -18,7 +18,7 @@ class OwnerSettings extends React.Component {
     ownerServicePoints: {
       type: 'okapi',
       resource: 'service-points',
-      path: 'service-points',
+      path: 'service-points?limit=50',
     },
     owners: {
       type: 'okapi',

--- a/src/settings/OwnerSettings.js
+++ b/src/settings/OwnerSettings.js
@@ -18,7 +18,7 @@ class OwnerSettings extends React.Component {
     ownerServicePoints: {
       type: 'okapi',
       resource: 'service-points',
-      path: 'service-points?limit=50',
+      path: 'service-points?limit=200',
     },
     owners: {
       type: 'okapi',


### PR DESCRIPTION
# Description
**Bug:** Settings --> Users --> Fee/Fine Owners only displays ten service points in the Associated Service Points drop-down.

**To do:** increase limit of service points in query
# Issue
https://issues.folio.org/browse/UIU-1540
# Screenshot
**Before**

![image](https://user-images.githubusercontent.com/55694637/77649825-24f24200-6f73-11ea-9bad-ab39ca9db889.png)

**After**

![image](https://user-images.githubusercontent.com/55694637/77650021-83b7bb80-6f73-11ea-8f0c-58f634d9a62b.png)
