### PR TITLE
UIU-1547 - Incorrectly unable to save Fee/Fine Types already saved by other Fee/Fine Owners

### DIFF
--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -89,7 +89,7 @@ class FeeFineSettings extends React.Component {
 
   componentDidMount() {
     this.props.mutator.owners.GET().then(records => {
-      const shared = records.find(o => o.owner === 'Shared');
+      const shared = records.find(o => o?.owner?.toLowerCase() === 'shared');
       this.shared = shared;
       const ownerId = (shared) ? shared.id : ((records.length > 0) ? records[0].id : '');
       this.setState({ ownerId, owners: records });


### PR DESCRIPTION
# Purpose
Updated check to identify shared user.

# Link
https://issues.folio.org/browse/UIU-1547