### PR TITLE
UIU-1550 - Copy existing fee/fine owner table drop-down entries incorrect

### DIFF
--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -197,8 +197,8 @@ class FeeFineSettings extends React.Component {
     const { owners } = this.state;
 
     items.forEach(i => {
-      const owner = owners.find(o => o.id === i.ownerId) || {};
-      if (!filterOwners.some(o => o.id === owner.id) && owner.id !== (this.shared || {}).id) {
+      const owner = owners.find(o => o.id === i.ownerId);
+      if (owner && !filterOwners.some(o => o.id === owner.id) && owner.id !== (this.shared || {}).id) {
         filterOwners.push(owner);
       }
     });


### PR DESCRIPTION
# Purpose
Properly filter owners, ignore automatic fee fines for copy modal.

# Link
https://issues.folio.org/browse/UIU-1550

# Screenshot
**Before**
<img width="1662" alt="Screen Shot 2020-04-01 at 12 39 27" src="https://user-images.githubusercontent.com/43472449/78122770-e0a0ef00-7415-11ea-9733-75a4b66db3e8.png">
**After**
<img width="1680" alt="Screen Shot 2020-04-01 at 12 28 56" src="https://user-images.githubusercontent.com/43472449/78121699-60c65500-7414-11ea-8094-c33a79308b80.png">
