### PR TITLE
stripes devDeps must use caret, not tilde

### DIFF
--- a/package.json
+++ b/package.json
@@ -744,7 +744,7 @@
     "@folio/eslint-config-stripes": "^5.2.0",
     "@folio/stripes": "^3.0.0",
     "@folio/stripes-cli": "^1.13.0",
-    "@folio/stripes-core": "~4.0.0",
+    "@folio/stripes-core": "^4.0.0",
     "@folio/stripes-components": "^5.0.3",
     "@folio/stripes-final-form": "^2.0.0",
     "babel-eslint": "^10.0.3",


### PR DESCRIPTION
`yarn` will load deps based on the _loosest_ dependency it finds, not
the strictest. This means if you have transitive deps on `~1.2.3` and
`^1.2.3` and the available package is `1.3.0` you'll get TWO copies!
Hooray! Poop.

We only want one copy of each of the `@folio/stripes-*` libraries in our
builds. With multiple copies, unit tests will not run.

Reverts that change from #1195.