### PR TITLE
UIU-1540: Add query param (#1214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 3.1.1 (IN PROGRESS)
+
+* Increase limit of service points in the Associated Service Points dropdown at Settings --> Users --> Fee/Fine Owners. Refs UIU-1540.
+
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)
 

--- a/src/settings/OwnerSettings.js
+++ b/src/settings/OwnerSettings.js
@@ -18,7 +18,7 @@ class OwnerSettings extends React.Component {
     ownerServicePoints: {
       type: 'okapi',
       resource: 'service-points',
-      path: 'service-points',
+      path: 'service-points?limit=200',
     },
     owners: {
       type: 'okapi',


### PR DESCRIPTION
Settings > Users > Fee/Fine Owners only displays ten service points
in the Associated Service Points drop-down. Bump the limit to 200.

Fixes [UIU-1540](https://issues.folio.org/browse/UIU-1540)