### PR TITLE
remove unused checkScope function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,10 +200,6 @@ class UsersRouting extends Component {
     },
   ];
 
-  checkScope = () => {
-    return document.body.contains(document.activeElement);
-  }
-
   render() {
     const {
       showSettings

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -159,10 +159,6 @@ class UserDetail extends React.Component {
     return selUser.find(u => u.id === id);
   }
 
-  checkScope = () => {
-    return document.getElementById('ModuleContainer').contains(document.activeElement);
-  };
-
   // This is a helper function for the "last updated" date element. Since the
   // date/time is actually set on the server when the record is updated, the
   // lastUpdated element of the record on the client side might contain a stale
@@ -320,8 +316,6 @@ class UserDetail extends React.Component {
       </IfPermission>
     );
   };
-
-  checkScope = () => true;
 
   goToEdit = () => {
     const { history, match: { params } } = this.props;


### PR DESCRIPTION
This function got added, twice, _months_ ago in PR #839, but SonarCloud
just started complaining about it now. I don't know why it only came up
now, but it is (1) clearly a duplicate function, which is a bug and (2)
not called anywhere, which means it's safe to just get rid of it. So I'm
getting rid of it.