### PR TITLE
UIU-1542 - fixed incorrect close behavior (#1216)

### DIFF
--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -194,6 +194,19 @@ class AccountDetails extends React.Component {
     return instanceTitle ? `${instanceTitle} ${instanceTypeString}` : '-';
   }
 
+  handleClose = () => {
+    const {
+      history,
+      match: { params },
+      resources
+    } = this.props;
+
+    const account = _.get(resources, ['accountHistory', 'records', 0]) || {};
+    const status = account?.status?.name?.toLowerCase() || 'all';
+
+    history.push({ pathname: `/users/${params.id}/accounts/${status}` });
+  };
+
   render() {
     const {
       sortOrder,
@@ -271,7 +284,7 @@ class AccountDetails extends React.Component {
           id="pane-account-action-history"
           defaultWidth="100%"
           dismissible
-          onClose={() => { history.goBack(); }}
+          onClose={this.handleClose}
           paneTitle={(
             <FormattedMessage id="ui-users.details.paneTitle.feeFineDetails">
               {(msg) => `${msg} - ${getFullName(user)} (${_.upperFirst(patron.group)}) `}


### PR DESCRIPTION
Instead of using `history.goBack()`, which can lead to navigation loops if
you arrive at the details-pane from an external application, use 
`history.push()` to navigate to `/users/${params.id}/accounts/${status}`.

Fixes [UIU-1542](https://issues.folio.org/browse/UIU-1542)