### PR TITLE
UIU-1544 - updated recordId entity in manifest (#1217)

### DIFF
--- a/src/settings/CommentRequiredSettings.js
+++ b/src/settings/CommentRequiredSettings.js
@@ -9,22 +9,22 @@ import CommentRequiredForm from './CommentRequiredForm';
 
 class CommentRequiredSettings extends React.Component {
   static manifest = Object.freeze({
-    recordId: {},
+    record: {},
     commentRequired: {
       type: 'okapi',
       records: 'comments',
       path: 'comments',
       accumulate: 'true',
       PUT: {
-        path: 'comments/%{recordId}',
+        path: 'comments/%{record.id}',
       },
     },
   });
 
   static propTypes = {
     mutator: PropTypes.shape({
-      recordId: PropTypes.shape({
-        replace: PropTypes.func,
+      record: PropTypes.shape({
+        update: PropTypes.func,
       }),
       commentRequired: PropTypes.shape({
         POST: PropTypes.func,
@@ -61,7 +61,7 @@ class CommentRequiredSettings extends React.Component {
     const {
       mutator: {
         commentRequired,
-        recordId,
+        record,
       }
     } = this.props;
 
@@ -71,7 +71,7 @@ class CommentRequiredSettings extends React.Component {
         id: records[0].id,
         ...values
       };
-      recordId.replace(records[0].id);
+      record.update({ id: records[0].id });
       return body;
     }).then((b) => {
       commentRequired.PUT(b);


### PR DESCRIPTION
It's very confusing how to use a local resource that should evaluate to a scalar.
A resource is an object. It may have scalar values, but the resource itself is an 
object. 

Here, trying to embed the resource `%{recordId}` in the path caused an error
because `recordId`, i.e. the resource itself, is an object, and thus would be 
serialized to `[object Object]`. The documentation isn't great on how this is
supposed to work. 

Fixes [UIU-1544](https://issues.folio.org/browse/UIU-1544)