### PR TITLE
UIU-1546 remove empty fields from request before submission

### DIFF
--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -256,6 +256,10 @@ class FeeFineSettings extends React.Component {
       return item;
     };
 
+    const preUpdateHook = (item) => {
+      return _.pickBy(item, field => field !== '');
+    };
+
     const owner = owners.find(o => o.id === ownerId) || {};
 
     const rowFilter =
@@ -290,6 +294,7 @@ class FeeFineSettings extends React.Component {
         nameKey="feefine"
         objectLabel=""
         preCreateHook={preCreateHook}
+        preUpdateHook={preUpdateHook}
         records="feefines"
         rowFilter={rowFilter}
         rowFilterFunction={(item) => (item.ownerId === ownerId && !item.automatic)}


### PR DESCRIPTION
Remove empty fields from the request before submitting it. When a field is present, 
its value is expected to contain a foreign key. Thus, empty-string values present a 
problem and should instead be omitted.

Refs [UIU-1546](https://issues.folio.org/browse/UIU-1546)