### PR TITLE
UIU-1550 - removed blank option from copy modal owners dropdown

### DIFF
--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -197,8 +197,8 @@ class FeeFineSettings extends React.Component {
     const { owners } = this.state;
 
     items.forEach(i => {
-      const owner = owners.find(o => o.id === i.ownerId) || {};
-      if (!filterOwners.some(o => o.id === owner.id) && owner.id !== (this.shared || {}).id) {
+      const owner = owners.find(o => o.id === i.ownerId);
+      if (owner && !filterOwners.some(o => o.id === owner.id) && owner.id !== (this.shared || {}).id) {
         filterOwners.push(owner);
       }
     });

--- a/test/bigtest/network/factories/user.js
+++ b/test/bigtest/network/factories/user.js
@@ -16,7 +16,7 @@ export default Factory.extend({
     'group7',
   ]),
   enrollmentDate: () => '2015-12-14T00:00:00.000+0000',
-  expirationDate: () => '2020-04-07T00:00:00.000+0000',
+  expirationDate: () => faker.date.future(10),
   createdDate: () => '2018-11-20T11:42:53.385+0000',
   updatedDate: () => '2018-11-20T20:00:47.409+0000',
 


### PR DESCRIPTION
The owners-dropdown should only display owners who are affiliated with manual fee/fine types. Previously, it would erroneously include a blank entry which Holly figured out corresponded to automated charges created via overdue fine or lost item policies. This PR removes the blank entry.

Refs [UIU-1550](https://issues.folio.org/browse/UIU-1550)