### PR TITLE
UIU-1532: Add 'Load more' button at the end of the result list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix bug preventing closed loans list from loading properly when an item has been deleted. Fixes UIU-1411.
 * Fix import path to stripes util. Fixes UIU-1515.
 * Use localized permission names. Refs UIU-488.
+* Add `Load more` button at the end of the result list. Fixes UIU-1532.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -32,11 +32,12 @@ class UserSearchContainer extends React.Component {
     initializedFilterConfig: { initialValue: false },
     query: { initialValue: { sort: 'name' } },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
+    resultOffset: { initialValue: 0 },
     records: {
       type: 'okapi',
       records: 'users',
-      recordsRequired: '%{resultCount}',
-      perRequest: 30,
+      resultOffset: '%{resultOffset}',
+      perRequest: 100,
       path: 'users',
       GET: {
         params: {
@@ -91,7 +92,7 @@ class UserSearchContainer extends React.Component {
     resources: PropTypes.shape({
       patronGroups: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
-      })
+      }),
     }).isRequired,
     mutator: PropTypes.shape({
       initializedFilterConfig: PropTypes.shape({
@@ -107,6 +108,9 @@ class UserSearchContainer extends React.Component {
       loans: PropTypes.shape({
         GET: PropTypes.func.isRequired,
         reset: PropTypes.func.isRequired,
+      }),
+      resultOffset: PropTypes.shape({
+        replace: PropTypes.func.isRequired,
       }),
     }).isRequired,
     stripes: PropTypes.shape({
@@ -142,9 +146,15 @@ class UserSearchContainer extends React.Component {
     this.source.update(this.props);
   }
 
-  onNeedMoreData = () => {
+  onNeedMoreData = (askAmount, index) => {
+    const { resultOffset } = this.props.mutator;
+
     if (this.source) {
-      this.source.fetchMore(RESULT_COUNT_INCREMENT);
+      if (resultOffset && index >= 0) {
+        this.source.fetchOffset(index);
+      } else {
+        this.source.fetchMore(RESULT_COUNT_INCREMENT);
+      }
     }
   };
 

--- a/src/views/UserSearch/Filters.js
+++ b/src/views/UserSearch/Filters.js
@@ -24,6 +24,9 @@ export default class Filters extends React.Component {
     activeFilters: PropTypes.object,
     resources: PropTypes.object.isRequired,
     onChangeHandlers: PropTypes.object.isRequired,
+    resultOffset: PropTypes.shape({
+      replace: PropTypes.func.isRequired,
+    }),
   };
 
   static defaultProps = {
@@ -48,7 +51,12 @@ export default class Filters extends React.Component {
     const {
       activeFilters,
       onChangeHandlers,
+      resultOffset,
     } = this.props;
+
+    if (resultOffset) {
+      resultOffset.replace(0);
+    }
 
     onChangeHandlers.state({
       ...activeFilters,

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -60,6 +60,9 @@ class UserSearch extends React.Component {
     }).isRequired,
     mutator: PropTypes.shape({
       loans: PropTypes.object,
+      resultOffset: PropTypes.shape({
+        replace: PropTypes.func.isRequired,
+      }),
     }).isRequired,
     source: PropTypes.object,
     visibleColumns: PropTypes.arrayOf(PropTypes.string),
@@ -277,6 +280,7 @@ class UserSearch extends React.Component {
       onNeedMoreData,
       resources,
       contentRef,
+      mutator: { resultOffset },
     } = this.props;
 
     const users = get(resources, 'records.records', []);
@@ -402,8 +406,9 @@ class UserSearch extends React.Component {
                             </div>
                             <Filters
                               activeFilters={activeFilters.state}
-                              resources={this.props.resources}
+                              resources={resources}
                               onChangeHandlers={getFilterHandlers()}
+                              resultOffset={resultOffset}
                             />
                           </form>
                         </Pane>
@@ -444,6 +449,8 @@ class UserSearch extends React.Component {
                           autosize
                           virtualize
                           hasMargin
+                          pageAmount={100}
+                          pagingType="click"
                         />
 
                       </Pane>


### PR DESCRIPTION
## Purpose
Add `Load more` button at the end of the result list in order to scroll records more easily.
Story [UIU-1532](https://issues.folio.org/browse/UIU-1532).

### Approach
To achieve the needed functionality, in addition to the steps described in the [Migration Paths](https://github.com/folio-org/stripes-connect/blob/master/MIGRATIONPATHS.md), it was necessary to override the `onNeedMoreData` method in the `UserSearchContainer` component.
Thanks, @ryandberger, for pointing this out.

### Screenshot
![Screen Shot 2020-04-10 at 21 50 19](https://user-images.githubusercontent.com/49517355/79015401-4f4c1e00-7b75-11ea-9155-ce2fd5b34667.png)

