### PR TITLE
UIU-1596: Build filter string by using ids instead of names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Create Patron Blocks Limits Table in Settings -> Users. Refs UIU-1167.
 * Add `Load more` button at the end of the result list. Fixes UIU-1532.
 * Increase limit of patron fee/fines, owners and patron groups. Refs UIU-1585.
+* Build filter string by using ids instead of names. Fixes UIU-1596.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/views/UserSearch/Filters.js
+++ b/src/views/UserSearch/Filters.js
@@ -42,8 +42,7 @@ export default class Filters extends React.Component {
 
   getValuesFromResources = (type, key) => {
     const items = get(this.props.resources, `${type}.records`, [])
-      .map(item => ({ label: item[key], value: item[key] }));
-
+      .map(item => ({ label: item[key], value: item.id }));
     return sortBy(items, 'label');
   };
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1596

Thanks to @MikeTaylor for advocating for this approach. It made me look at this again and it turned out there was a way to use the `ids` instead of the names when building up the filter string.