### PR TITLE
UIU-1585 increase fetch limits for fee/fines endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 3.0.3 (IN PROGRESS)
+
+* Increase limit of patron fee/fines, owners and patron groups. Refs UIU-1585.
+
 ## [3.0.2](https://github.com/folio-org/ui-users/tree/v3.0.2) (2020-04-09)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.1...v3.0.2)
 

--- a/src/components/Accounts/Actions/Actions.js
+++ b/src/components/Accounts/Actions/Actions.js
@@ -34,7 +34,7 @@ class Actions extends React.Component {
     accounts: {
       type: 'okapi',
       records: 'accounts',
-      path: 'accounts?query=(userId=%{user.id})&limit=100',
+      path: 'accounts?query=(userId=%{user.id})&limit=10000',
       PUT: {
         path: 'accounts/%{activeRecord.id}'
       },
@@ -42,7 +42,7 @@ class Actions extends React.Component {
     feefineactions: {
       type: 'okapi',
       records: 'feefineactions',
-      path: 'feefineactions',
+      path: 'feefineactions?limit=10000',
     },
     payments: {
       type: 'okapi',
@@ -57,12 +57,12 @@ class Actions extends React.Component {
     owners: {
       type: 'okapi',
       records: 'owners',
-      path: 'owners?query=cql.allRecords=1&limit=100',
+      path: 'owners?query=cql.allRecords=1&limit=2000',
     },
     feefineTypes: {
       type: 'okapi',
       records: 'feefines',
-      path: 'feefines?query=cql.allRecords=1&limit=100',
+      path: 'feefines?query=cql.allRecords=1&limit=10000',
     },
     transfers: {
       type: 'okapi',

--- a/src/components/Accounts/Actions/Actions.js
+++ b/src/components/Accounts/Actions/Actions.js
@@ -62,7 +62,7 @@ class Actions extends React.Component {
     feefineTypes: {
       type: 'okapi',
       records: 'feefines',
-      path: 'feefines?query=cql.allRecords=1&limit=10000',
+      path: 'feefines?query=cql.allRecords=1&limit=100',
     },
     transfers: {
       type: 'okapi',

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -27,14 +27,14 @@ class UserAccounts extends React.Component {
       type: 'okapi',
       records: 'accounts',
       GET: {
-        path: 'accounts?query=(userId=:{id})&limit=100',
+        path: 'accounts?query=(userId=:{id})&limit=10000',
       },
     },
     openAccountsCount: {
       type: 'okapi',
       accumulate: 'true',
       GET: {
-        path: 'accounts?query=(userId=:{id} and status.name<>Closed)&limit=100',
+        path: 'accounts?query=(userId=:{id} and status.name<>Closed)&limit=10000',
       },
     },
     closedAccountsCount: {

--- a/src/routes/AccountDetailsContainer.js
+++ b/src/routes/AccountDetailsContainer.js
@@ -22,7 +22,7 @@ class AccountDetailsContainer extends React.Component {
       path: 'groups',
       params: {
         query: 'cql.allRecords=1 sortby group',
-        limit: '40',
+        limit: '200',
       },
       records: 'usergroups',
     },
@@ -35,7 +35,7 @@ class AccountDetailsContainer extends React.Component {
       type: 'okapi',
       records: 'feefineactions',
       accumulate: 'true',
-      path: 'feefineactions?query=(accountId=:{accountid})&limit=50',
+      path: 'feefineactions?query=(accountId=:{accountid})&limit=10000',
     },
     activeRecord: {
       accountId: '0',

--- a/src/routes/AccountsListingContainer.js
+++ b/src/routes/AccountsListingContainer.js
@@ -61,7 +61,7 @@ class AccountsListingContainer extends React.Component {
       path: 'groups',
       params: {
         query: 'cql.allRecords=1 sortby group',
-        limit: '40',
+        limit: '200',
       },
       records: 'usergroups',
     },
@@ -76,7 +76,7 @@ class AccountsListingContainer extends React.Component {
       type: 'okapi',
       records: 'accounts',
       recordsRequired: '%{activeRecord.records}',
-      path: 'accounts?query=userId=:{id}&limit=100',
+      path: 'accounts?query=userId=:{id}&limit=10000',
     },
     loans: {
       type: 'okapi',
@@ -89,7 +89,7 @@ class AccountsListingContainer extends React.Component {
       records: 'accounts',
       path: 'accounts',
       recordsRequired: '%{activeRecord.records}',
-      perRequest: 50,
+      perRequest: 10000,
       GET: {
         params: {
           query: queryFunction(
@@ -105,7 +105,7 @@ class AccountsListingContainer extends React.Component {
         staticFallback: { params: {} },
       },
     },
-    activeRecord: { records: 50 },
+    activeRecord: { records: 10000 },
     user: {},
   });
 

--- a/src/routes/ChargeFeesFinesContainer.js
+++ b/src/routes/ChargeFeesFinesContainer.js
@@ -68,13 +68,13 @@ class ChargeFeesFinesContainer extends React.Component {
       type: 'okapi',
       records: 'feefines',
       GET: {
-        path: 'feefines?query=(ownerId=%{activeRecord.ownerId} or ownerId=%{activeRecord.shared})&limit=100',
+        path: 'feefines?query=(ownerId=%{activeRecord.ownerId} or ownerId=%{activeRecord.shared})&limit=10000',
       },
     },
     feefineactions: {
       type: 'okapi',
       records: 'feefineactions',
-      path: 'feefineactions',
+      path: 'feefineactions?limit=10000',
     },
     accounts: {
       type: 'okapi',
@@ -93,7 +93,7 @@ class ChargeFeesFinesContainer extends React.Component {
     owners: {
       type: 'okapi',
       records: 'owners',
-      path: 'owners?limit=100',
+      path: 'owners?limit=2000',
     },
     payments: {
       type: 'okapi',
@@ -108,7 +108,7 @@ class ChargeFeesFinesContainer extends React.Component {
     allfeefines: {
       type: 'okapi',
       records: 'feefines',
-      path: 'feefines?limit=100',
+      path: 'feefines?limit=10000',
     },
     activeRecord: {},
   });

--- a/src/routes/LoanDetailContainer.js
+++ b/src/routes/LoanDetailContainer.js
@@ -36,7 +36,7 @@ class LoanDetailContainer extends React.Component {
       path: 'groups',
       params: {
         query: 'cql.allRecords=1 sortby group',
-        limit: '40',
+        limit: '200',
       },
       records: 'usergroups',
     },

--- a/src/routes/LoansListingContainer.js
+++ b/src/routes/LoansListingContainer.js
@@ -22,7 +22,7 @@ class LoansListingContainer extends React.Component {
       path: 'groups',
       params: {
         query: 'cql.allRecords=1 sortby group',
-        limit: '40',
+        limit: '200',
       },
       records: 'usergroups',
     },
@@ -60,7 +60,7 @@ class LoansListingContainer extends React.Component {
     loanAccount: {
       type: 'okapi',
       records: 'accounts',
-      path: 'accounts?query=userId=:{id}&limit=100',
+      path: 'accounts?query=userId=:{id}&limit=10000',
     },
     renew: {
       fetch: false,

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -40,7 +40,7 @@ class UserRecordContainer extends React.Component {
       path: 'groups',
       params: {
         query: 'cql.allRecords=1 sortby group',
-        limit: '40',
+        limit: '200',
       },
       records: 'usergroups',
     },

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -64,7 +64,7 @@ class UserSearchContainer extends React.Component {
       path: 'groups',
       params: {
         query: 'cql.allRecords=1 sortby group',
-        limit: '40',
+        limit: '200',
       },
       records: 'usergroups',
     },

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -27,13 +27,13 @@ class FeeFineSettings extends React.Component {
       path: 'feefines',
       throwErrors: false,
       GET: {
-        path: 'feefines?query=cql.allRecords=1 sortby feeFineType&limit=500',
+        path: 'feefines?query=cql.allRecords=1 sortby feeFineType&limit=10000',
       },
     },
     owners: {
       type: 'okapi',
       records: 'owners',
-      path: 'owners?query=cql.allRecords=1 sortby owner&limit=500',
+      path: 'owners?query=cql.allRecords=1 sortby owner&limit=2000',
       accumulate: 'true',
       PUT: {
         path: 'owners/%{activeRecord.ownerId}',

--- a/src/settings/OwnerSettings.js
+++ b/src/settings/OwnerSettings.js
@@ -25,7 +25,7 @@ class OwnerSettings extends React.Component {
       records: 'owners',
       path: 'owners',
       GET: {
-        path: 'owners?query=cql.allRecords=1 sortby owner&limit=500'
+        path: 'owners?query=cql.allRecords=1 sortby owner&limit=2000'
       }
     },
   });


### PR DESCRIPTION
Increase limits of fee-fines-related fetches:
* `accounts` - 10 000
* `feefineactions` - 10 000
* `feefines` - 10 000
* `owners` - 2000
* `groups` - 200 (patron groups)

Refs [UIU-1585](https://issues.folio.org/browse/UIU-1585)