### PR TITLE
UIU-1203: Pass current servicePointId to declare-item-lost endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix routing loop caused by incorrect Custom Fields routing. Refs UIU-1594.
 * Settings > Users > Create/Edit Permission set. Refs UIU-1587.
 * Add `Closed loan` translation. Part of UIU-1603.
+* Pass current `servicePointId` to `declare-item-lost`. Part of UIU-1203.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -53,6 +53,11 @@ class ModalContent extends React.Component {
         POST: PropTypes.func.isRequired,
       }).isRequired,
     }).isRequired,
+    stripes: PropTypes.shape({
+      user: PropTypes.shape({
+        user: PropTypes.object,
+      }).isRequired,
+    }).isRequired,
     loanAction: PropTypes.string.isRequired,
     loan: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -73,13 +78,22 @@ class ModalContent extends React.Component {
   submit = async () => {
     const { additionalInfo } = this.state;
 
-    const { loanAction } = this.props;
+    const {
+      loanAction,
+      stripes: {
+        user: {
+          user: {
+            curServicePoint,
+          },
+        },
+      },
+    } = this.props;
 
     const {
       mutator: {
         [loanAction]: {
           POST,
-        }
+        },
       },
       onClose,
     } = this.props;
@@ -88,6 +102,11 @@ class ModalContent extends React.Component {
 
     if (loanAction === loanActions.CLAIMED_RETURNED) {
       requestData.itemClaimedReturnedDateTime = new Date().toISOString();
+    }
+
+    if (loanAction === loanActions.DECLARE_LOST) {
+      requestData.servicePointId = curServicePoint?.id;
+      requestData.declaredLostDateTime = new Date().toISOString();
     }
 
     await POST(requestData);

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -10,6 +10,7 @@ export default function setupApplication({
   hasAllPerms = true,
   modules,
   translations,
+  currentUser,
 } = {}) {
   setupStripesCore({
     mirageOptions,
@@ -18,7 +19,8 @@ export default function setupApplication({
     modules,
     translations,
     stripesConfig: {
-      hasAllPerms
+      hasAllPerms,
     },
+    currentUser,
   });
 }

--- a/test/bigtest/tests/declare-lost-test.js
+++ b/test/bigtest/tests/declare-lost-test.js
@@ -16,6 +16,9 @@ describe('Declare Lost', () => {
       'manualblocks.collection.get': true,
       'circulation.loans.collection.get': true,
     },
+    currentUser: {
+      curServicePoint: { id: 1 },
+    },
   });
 
   describe('Visiting open loans list page with not declared lost item', () => {


### PR DESCRIPTION
Based on the scenario 5 in https://issues.folio.org/browse/UIU-1203 we need to pass current servicePointId to `declare-item-lost` endpoint. This PR does just that.

https://issues.folio.org/browse/UIU-1203