### PR TITLE
UIU-1475: Fix typo

### DIFF
--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -214,7 +214,7 @@
 
   "extended.createPasswordModal.label": "Create password email confirmation",
   "extended.createPasswordModal.linkWasSent": "A create password link was sent to:",
-  "extended.createPasswordModal.linkInstructions": "The following link can be sent if the email was now received",
+  "extended.createPasswordModal.linkInstructions": "The following link can be sent if the email was not received",
 
   "contact.contactInformation": "Contact Information",
   "contact.email": "Email",


### PR DESCRIPTION
# Description
Fix typo in `Create password email confirmation` modal
# Issue
https://issues.folio.org/browse/UIU-1475