### PR TITLE
STRIPES-678 pin moment to ~2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Pass current `servicePointId` to `declare-item-lost`. Part of UIU-1203.
 * Preserve filters after user is edited. Fixes UIU-1604.
 * Remove hardcoded ids from Parton Block Conditions page. Refs UIU-1609.
+* Pin `moment` at `~2.24.0`. Refs STRIPES-678.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -780,7 +780,7 @@
     "@folio/stripes-util": "^2.0.0",
     "hashcode": "^1.0.3",
     "lodash": "^4.17.4",
-    "moment": "^2.22.2",
+    "moment": "~2.24.0",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
     "react-hot-loader": "^4.3.12",
@@ -798,5 +798,8 @@
   },
   "optionalDependencies": {
     "@folio/plugin-find-user": "^2.0.0"
+  },
+  "resolutions": {
+    "moment": "~2.24.0"
   }
 }


### PR DESCRIPTION
Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0`
([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).

The `resolutions` entry is necessary because `2.25` leaks in via
transitive deps. I don't know why it is necessary here when it isn't,
say, in ui-circulation, which pulls it in via the same route of
stripes-cli and stripes-core. That makes no sense. Alas.

Refs [STRIPES-678](https://issues.folio.org/browse/STRIPES-678)