### PR TITLE
UIU-1514: pass correct props to custom fields edit component

### DIFF
--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -497,6 +497,8 @@ class UserForm extends React.Component {
                   preferredContactTypeId={initialValues.preferredContactTypeId}
                 />
                 <EditCustomFieldsRecord
+                  formName="userForm"
+                  isReduxForm
                   accordionId="customFields"
                   onToggle={this.handleSectionToggle}
                   expanded={sections.customFields}


### PR DESCRIPTION
`formName` and `isReduxForm` props were added to make custom fields able to be used with both `final-form` and `redux-form` 