### PR TITLE
Use history.push correctly. Part of UIU-1620

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Settings > Users > Fee/Fine > Comment | Move Save button to the footer. Refs UIU-1589.
 * Pin `moment` at `~2.24.0`. Refs STRIPES-678.
 * Add possibility to create system user from already existing account. Refs UIU-1503.
+* Provide `search` explicitly to `history.push`. Fixes UIU-1620.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -268,7 +268,8 @@ class UserEdit extends React.Component {
 
     mutator.selUser.PUT(data).then(() => {
       history.push({
-        pathname: params.id ? `/users/preview/${params.id}/${search}` : `/users/${search}`,
+        pathname: params.id ? `/users/preview/${params.id}` : '/users',
+        search,
         state,
       });
     });


### PR DESCRIPTION
It looks like history was getting confused because we were not using `history.push` correctly:

When object is being passed to `history.push` we have to provide `search` and other parts of the url explicitly otherwise the path is not parsed correctly and the `search` part of the history object is lost.

The `search` piece is being used in locationService:

https://github.com/folio-org/stripes-core/blob/master/src/locationService.js#L6

and when that becomes incorrect it causes issues.