### PR TITLE
UIU-1503: Fix updating user

### DIFF
--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -10,6 +10,7 @@ import {
   omit,
   differenceBy,
   get,
+  has,
 } from 'lodash';
 
 import { LoadingView } from '@folio/stripes/components';
@@ -252,7 +253,9 @@ class UserEdit extends React.Component {
       data.active = (moment(user.expirationDate).endOf('day').isSameOrAfter(today));
     }
 
-    if (user.username) {
+    const userBeforeUpdate = resources.records.records.find(({ id }) => id === user.id);
+
+    if (user.username && !has(userBeforeUpdate, 'username')) {
       const credentials = {
         password: '',
         ...creds,


### PR DESCRIPTION
# Description
Make the POST request when `username` is set after user was created
# Approach
When Users --> Edit:
We need to differ if `username` is setted now or it was already setted, so the check was added if user's object contains the `username` field
# Related issue
https://issues.folio.org/browse/UIU-1503