### PR TITLE
UIU-1628: Fix Reset all button for filters and query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Match the protocol of the current page in images pulled from remote sites. Refs UIU-496.
 * Correctly configure fee/fines and profile-pictures permissions. Refs UIU-1574.
 * Increment `stripes` to `v4.0`, `react-intl` to `v4.5`, `react-intl-safe-html` to `v2.0`. Refs STRIPES-672.
+* Fix `Reset all` button for filters and query. Fixes UIU-1628.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -177,10 +177,6 @@ class UserSearchContainer extends React.Component {
   }
 
   render() {
-    const {
-      location: { search },
-    } = this.props;
-
     if (this.source) {
       this.source.update(this.props);
     }
@@ -188,7 +184,7 @@ class UserSearchContainer extends React.Component {
     return (
       <UserSearch
         source={this.source}
-        initialSearch={search}
+        initialSearch="?sort=name"
         onNeedMoreData={this.onNeedMoreData}
         queryGetter={this.queryGetter}
         querySetter={this.querySetter}

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -409,6 +409,7 @@ export default function config() {
   });
 
   this.get('/authn/credentials-existence', () => { });
+  this.post('/authn/credentials');
 
   this.get('/note-types');
 

--- a/test/bigtest/network/factories/credential.js
+++ b/test/bigtest/network/factories/credential.js
@@ -1,0 +1,6 @@
+import { Factory } from 'miragejs';
+import faker from 'faker';
+
+export default Factory.extend({
+  id: () => faker.random.uuid(),
+});

--- a/test/bigtest/network/models/credential.js
+++ b/test/bigtest/network/models/credential.js
@@ -1,0 +1,4 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({
+});


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1628

It looks like the work I did in: 

https://github.com/folio-org/ui-users/commit/7fb07a137e19b0d4e3a372bf98b675fd3be4ccc9#diff-26d2a657583a2e42dc1a61fc10acc892R191

broke `Reset all` button so this is pretty much reverting it back to what it was. 


