### PR TITLE
MODUSERBL-89 remove custom fields routes to prevent carnage

### DIFF
--- a/src/settings/sections.js
+++ b/src/settings/sections.js
@@ -13,7 +13,7 @@ import PaymentSettings from './PaymentSettings';
 import CommentRequiredSettings from './CommentRequiredSettings';
 import RefundReasonsSettings from './RefundReasonsSettings';
 import TransferAccountsSettings from './TransferAccountsSettings';
-import CustomFieldsSettingsPane from './CustomFieldsSettings';
+// import CustomFieldsSettingsPane from './CustomFieldsSettings';
 import ConditionsSettings from './ConditionsSettings';
 import LimitsSettings from './LimitsSettings';
 
@@ -43,12 +43,12 @@ const settingsGeneral = [
     component: ProfilePictureSettings,
     perm: 'ui-users.settings.profilePictures'
   },
-  {
-    route: 'custom-fields',
-    label: <FormattedMessage id="ui-users.settings.customFields" />,
-    component: CustomFieldsSettingsPane,
-    perm: 'ui-users.settings.customfields.view',
-  }
+  // {
+  //   route: 'custom-fields',
+  //   label: <FormattedMessage id="ui-users.settings.customFields" />,
+  //   component: CustomFieldsSettingsPane,
+  //   perm: 'ui-users.settings.customfields.view',
+  // }
 ];
 
 const settingsFeefines = [

--- a/test/bigtest/tests/settings-custom-fields-test.js
+++ b/test/bigtest/tests/settings-custom-fields-test.js
@@ -10,7 +10,7 @@ import {
 import setupApplication from '../helpers/setup-application';
 import CustomFieldsInteractor from '../interactors/settings-custom-fields';
 
-describe('Settings custom fields', () => {
+describe.skip('Settings custom fields', () => {
   describe('when there are custom fields saved', () => {
     before(() => {
       setupApplication({

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -163,7 +163,7 @@ describe('User Edit Page', () => {
     });
   });
 
-  describe('when custom fields are in stock', () => {
+  describe.skip('when custom fields are in stock', () => {
     it('should show custom fields accordion', () => {
       expect(UserFormPage.customFieldsSection.isPresent).to.be.true;
     });


### PR DESCRIPTION
Users with custom fields attached cannot login at present. This creates
problems in the production environments if folks happen to add
custom-fields values to common users like `diku_admin`. Until we resolve
this larger issue, we are disabling the custom-fields routes to prevent
this common problem.

Refs [MODUSERBL-89](https://issues.folio.org/browse/MODUSERBL-89)