### PR TITLE
Revert "MODUSERBL-89 remove custom fields routes to prevent carnage"

### DIFF
--- a/src/settings/sections.js
+++ b/src/settings/sections.js
@@ -13,7 +13,7 @@ import PaymentSettings from './PaymentSettings';
 import CommentRequiredSettings from './CommentRequiredSettings';
 import RefundReasonsSettings from './RefundReasonsSettings';
 import TransferAccountsSettings from './TransferAccountsSettings';
-// import CustomFieldsSettingsPane from './CustomFieldsSettings';
+import CustomFieldsSettingsPane from './CustomFieldsSettings';
 import ConditionsSettings from './ConditionsSettings';
 import LimitsSettings from './LimitsSettings';
 
@@ -43,12 +43,12 @@ const settingsGeneral = [
     component: ProfilePictureSettings,
     perm: 'ui-users.settings.profilePictures'
   },
-  // {
-  //   route: 'custom-fields',
-  //   label: <FormattedMessage id="ui-users.settings.customFields" />,
-  //   component: CustomFieldsSettingsPane,
-  //   perm: 'ui-users.settings.customfields.view',
-  // }
+  {
+    route: 'custom-fields',
+    label: <FormattedMessage id="ui-users.settings.customFields" />,
+    component: CustomFieldsSettingsPane,
+    perm: 'ui-users.settings.customfields.view',
+  }
 ];
 
 const settingsFeefines = [

--- a/test/bigtest/tests/settings-custom-fields-test.js
+++ b/test/bigtest/tests/settings-custom-fields-test.js
@@ -10,7 +10,7 @@ import {
 import setupApplication from '../helpers/setup-application';
 import CustomFieldsInteractor from '../interactors/settings-custom-fields';
 
-describe.skip('Settings custom fields', () => {
+describe('Settings custom fields', () => {
   describe('when there are custom fields saved', () => {
     before(() => {
       setupApplication({

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -163,7 +163,7 @@ describe('User Edit Page', () => {
     });
   });
 
-  describe.skip('when custom fields are in stock', () => {
+  describe('when custom fields are in stock', () => {
     it('should show custom fields accordion', () => {
       expect(UserFormPage.customFieldsSection.isPresent).to.be.true;
     });


### PR DESCRIPTION
Reverts folio-org/ui-users#1303

Restore custom fields just as soon as we figure out how to git mod-user-bl to cope with them so accounts with custom fields can still authenticate.