### PR TITLE
don't leak memory after unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Correctly configure fee/fines and profile-pictures permissions. Refs UIU-1574.
 * Increment `stripes` to `v4.0`, `react-intl` to `v4.5`, `react-intl-safe-html` to `v2.0`. Refs STRIPES-672.
 * Fix `Reset all` button for filters and query. Fixes UIU-1628.
+* Fix memory leak in `UserAccounts.js` discovered by @mkuklis.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -82,9 +82,13 @@ class UserAccounts extends React.Component {
       openAccounts: 0,
       closedAccounts: 0,
     };
+
+    this._isMounted = false;
   }
 
   componentDidMount() {
+    this._isMounted = true;
+
     this.props.mutator.openAccountsCount.GET().then(records => {
       this.setState({
         total: this.getTotalOpenAccounts(records.accounts),
@@ -101,17 +105,25 @@ class UserAccounts extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.addRecord !== prevProps.addRecord) {
       this.props.mutator.openAccountsCount.GET().then(records => {
-        this.setState({
-          total: this.getTotalOpenAccounts(records.accounts),
-          openAccounts: records.totalRecords,
-        });
+        if (this._isMounted) {
+          this.setState({
+            total: this.getTotalOpenAccounts(records.accounts),
+            openAccounts: records.totalRecords,
+          });
+        }
       });
       this.props.mutator.closedAccountsCount.GET().then(records => {
-        this.setState({
-          closedAccounts: records.totalRecords,
-        });
+        if (this._isMounted) {
+          this.setState({
+            closedAccounts: records.totalRecords,
+          });
+        }
       });
     }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
   }
 
   getTotalOpenAccounts = (accounts) => {


### PR DESCRIPTION
If a promise returns after a component has unmounted, you can no longer
call `setState()`, so now we don't.