### PR TITLE
UIU-1648 correct state init in withServicePoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Correctly configure fee/fines and profile-pictures permissions. Refs UIU-1574.
 * Increment `stripes` to `v4.0`, `react-intl` to `v4.5`, `react-intl-safe-html` to `v2.0`. Refs STRIPES-672.
 * Fix `Reset all` button for filters and query. Fixes UIU-1628.
+* Don't leak memory in `withServicePoints` wrapper. Refs FOLIO-2097.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/components/Wrappers/withServicePoints.js
+++ b/src/components/Wrappers/withServicePoints.js
@@ -69,10 +69,14 @@ const withServicePoints = WrappedComponent => class WithServicePointsComponent e
       stripes: stripesShape.isRequired,
     };
 
-    state = {
-      userServicePoints: [],
-      userPreferredServicePoint: undefined,
-    };
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        userServicePoints: [],
+        userPreferredServicePoint: undefined,
+      };
+    }
 
     static getDerivedStateFromProps(nextProps, state) {
       // Save the id of the record in the service-points-users table for later use when mutating it.


### PR DESCRIPTION
The original implementation did not correctly initialize state within a
constructor, leading to a memory leak that was notably apparent in unit
tests. Heap memory would balloon > 700MB, leading to failed tests due
to timeouts. With state correctly initialized, heap memory is reduced by
roughly 90% to ~55MB.

Post-fix, there are 1365 fewer copies of `Wrapper` components (`Wrapper` is the name of the class returned from `stripes-connect` when a component is connected) in the heap when unit tests finish running: 

![Screen Shot 2020-05-18 at 9 37 37 PM](https://user-images.githubusercontent.com/199241/82275370-9980a600-9950-11ea-98ad-69862e7b47f3.png)
![Screen Shot 2020-05-18 at 9 39 13 PM](https://user-images.githubusercontent.com/199241/82275372-9ab1d300-9950-11ea-8a50-a3b134feea0d.png)


Refs [FOLIO-2097](https://issues.folio.org/browse/FOLIO-2097), [UIU-1648](https://issues.folio.org/browse/UIU-1648)