### PR TITLE
UIU-1261: Prevent renewal of claimed returned item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Sort user permissions in alphabetical order on create/edit screen. Refs UIU-1353.
 * Fix memory leak in `UserAccounts.js` discovered by @mkuklis.
 * UI updates to the Permissions modal. Refs UIU-1466.
+* Prevent the renewal of claimed returned items. Refs UIU-1261.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -59,6 +59,7 @@ class ActionsDropdown extends React.Component {
           </Button>
         </IfPermission>
         <IfPermission perm="ui-users.loans.renew">
+          { itemStatusName !== itemStatuses.CLAIMED_RETURNED &&
           <Button
             buttonStyle="dropdownItem"
             data-test-dropdown-content-renew-button
@@ -69,6 +70,7 @@ class ActionsDropdown extends React.Component {
           >
             <FormattedMessage id="ui-users.renew" />
           </Button>
+          }
         </IfPermission>
         <IfPermission perm="ui-users.loans.claim-item-returned">
           { itemStatusName !== itemStatuses.CLAIMED_RETURNED &&

--- a/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
@@ -22,6 +22,8 @@ import {
 import ActionsBar from '../../../components/ActionsBar/ActionsBar';
 import { itemStatuses } from '../../../../../constants';
 
+import { hasEveryLoanItemStatus } from '../../../../util';
+
 import css from './OpenLoansSubHeader.css';
 
 class OpenLoansSubHeader extends React.Component {
@@ -135,7 +137,8 @@ class OpenLoansSubHeader extends React.Component {
     // and values being the associated loan properties -- e.g. { uuid: {loan}, uuid2: {loan2} }. This makes
     // it a little complicated to determine whether any loan in checkedLoans has a particular property -- like
     // an item that's been declared lost
-    const onlyLostItemsSelected = !Object.values(checkedLoans).find(loan => loan?.item?.status?.name !== 'Declared lost');
+    const onlyLostItemsSelected = hasEveryLoanItemStatus(checkedLoans, itemStatuses.DECLARED_LOST);
+    const onlyClaimedReturnedItemsSelected = hasEveryLoanItemStatus(checkedLoans, itemStatuses.CLAIMED_RETURNED);
 
     return (
       <ActionsBar
@@ -179,7 +182,7 @@ class OpenLoansSubHeader extends React.Component {
               <Button
                 marginBottom0
                 id="renew-all"
-                disabled={noSelectedLoans}
+                disabled={noSelectedLoans || onlyClaimedReturnedItemsSelected}
                 onClick={!isEmpty(countRenews)
                   ? openPatronBlockedModal
                   : renewSelected

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -112,3 +112,7 @@ export function calculateSortParams({
 
   return sortParams;
 }
+
+export function hasEveryLoanItemStatus(loans, itemStatus) {
+  return _.every(Object.values(loans), loan => loan?.item?.status?.name === itemStatus);
+}

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -36,6 +36,7 @@ import {
   nav,
   getOpenRequestsPath,
 } from '../../components/util';
+import { itemStatuses } from '../../constants';
 import {
   withRenew,
   withDeclareLost,
@@ -337,8 +338,9 @@ class LoanDetails extends React.Component {
     const overduePolicyName = get(loan, ['overdueFinePolicy', 'name'], '-');
     const lostItemPolicyName = get(loan, ['lostItemPolicy', 'name'], '-');
     const itemStatus = get(loan, ['item', 'status', 'name'], '-');
-    const claimedReturnedDate = itemStatus === 'Claimed returned' && loan.claimedReturnedDate;
-    const isDeclaredLostItem = itemStatus === 'Declared lost';
+    const claimedReturnedDate = itemStatus === itemStatuses.CLAIMED_RETURNED && loan.claimedReturnedDate;
+    const isClaimedReturnedItem = itemStatus === itemStatuses.CLAIMED_RETURNED;
+    const isDeclaredLostItem = itemStatus === itemStatuses.DECLARED_LOST;
     let lostDate;
     const declaredLostActions = loanActionsWithUser.filter(currentAction => get(currentAction, ['action'], '') === 'declaredLost');
 
@@ -381,7 +383,8 @@ class LoanDetails extends React.Component {
               <span>
                 <IfPermission perm="ui-users.loans.renew">
                   <Button
-                    disabled={buttonDisabled}
+                    data-test-renew-button
+                    disabled={buttonDisabled || isClaimedReturnedItem}
                     buttonStyle="primary"
                     onClick={this.renew}
                   >
@@ -391,7 +394,7 @@ class LoanDetails extends React.Component {
                 <IfPermission perm="ui-users.loans.claim-item-returned">
                   <Button
                     data-test-claim-returned-button
-                    disabled={buttonDisabled || itemStatus === 'Claimed returned'}
+                    disabled={buttonDisabled || isClaimedReturnedItem}
                     buttonStyle="primary"
                     onClick={() => claimReturned(loan)}
                   >

--- a/test/bigtest/interactors/loan-actions-history.js
+++ b/test/bigtest/interactors/loan-actions-history.js
@@ -28,6 +28,7 @@ import KeyValue from './KeyValue';
   isDeclareLostButtonDisabled = property('[data-test-declare-lost-button]', 'disabled');
   claimReturnedButton = scoped('[data-test-claim-returned-button]', ButtonInteractor);
   isClaimReturnedButtonDisabled = property('[data-test-claim-returned-button]', 'disabled');
+  isRenewButtonDisabled = property('[data-test-renew-button]', 'disabled');
   loanActions = scoped('#list-loanactions', MultiColumnListInteractor);
 
   whenLoaded() {

--- a/test/bigtest/interactors/open-loans.js
+++ b/test/bigtest/interactors/open-loans.js
@@ -12,6 +12,7 @@ import moment from 'moment';
 
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor'; // eslint-disable-line
 import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/interactor'; // eslint-disable-line
+import CheckboxInteractor from '@folio/stripes-components/lib/Checkbox/tests/interactor';
 
 import DialogInteractor from './dialog';
 
@@ -69,7 +70,10 @@ import DialogInteractor from './dialog';
   loanCount = text('#loan-count');
 
   selectAllCheckboxes = clickable('#clickable-list-column- input[type="checkbox"]');
+  checkboxes = collection('#list-loanshistory button[role="row"]', CheckboxInteractor);
   clickRenew = clickable('#renew-all');
+
+  isBulkRenewButtonDisabled = property('#renew-all', 'disabled');
 
   whenLoaded() {
     return this.when(() => this.list.isVisible);

--- a/test/bigtest/tests/claim-returned-test.js
+++ b/test/bigtest/tests/claim-returned-test.js
@@ -118,27 +118,60 @@ describe('Claim returned', () => {
 
   describe('Visiting open loans list page with claimed returned item', () => {
     beforeEach(async function () {
-      const loan = this.server.create('loan', {
+      const user = this.server.create('user');
+
+      this.server.create('loan', {
         status: { name: 'Open' },
-        item: { status: { name: 'Claimed returned' } },
+        item: { status: { name: 'Checked out' } },
+        userId: user.id,
       });
 
-      this.visit(`/users/${loan.userId}/loans/open`);
+      this.server.create('loan', {
+        status: { name: 'Open' },
+        item: { status: { name: 'Claimed returned' } },
+        userId: user.id,
+      });
+
+      this.visit(`/users/${user.id}/loans/open`);
 
       await OpenLoansInteractor.whenLoaded();
     });
 
     it('should display claimed returned count', () => {
-      expect(OpenLoansInteractor.loanCount).to.equal('1 record found (1 claimed returned)');
+      expect(OpenLoansInteractor.loanCount).to.equal('2 records found (1 claimed returned)');
     });
 
     describe('opening dropdown for claimed returned item', () => {
       beforeEach(async () => {
-        await OpenLoansInteractor.actionDropdowns(0).click('button');
+        await OpenLoansInteractor.actionDropdowns(1).click('button');
+      });
+
+      it('should not display renew button', () => {
+        expect(OpenLoansInteractor.actionDropdownRenewButton.isVisible).to.be.false;
       });
 
       it('should not display claim returned button', () => {
-        expect(OpenLoansInteractor.actionDropdownClaimReturnedButton.isPresent).to.be.false;
+        expect(OpenLoansInteractor.actionDropdownClaimReturnedButton.isVisible).to.be.false;
+      });
+    });
+
+    describe('when check the claimed returned item', () => {
+      beforeEach(async () => {
+        await OpenLoansInteractor.checkboxes(1).clickInput();
+      });
+
+      it('should display disabled bulk renew button', () => {
+        expect(OpenLoansInteractor.isBulkRenewButtonDisabled).to.be.true;
+      });
+
+      describe('when check the checked out item', () => {
+        beforeEach(async () => {
+          await OpenLoansInteractor.checkboxes(0).clickInput();
+        });
+
+        it('should display enabled bulk renew button', () => {
+          expect(OpenLoansInteractor.isBulkRenewButtonDisabled).to.be.false;
+        });
       });
     });
   });
@@ -194,6 +227,10 @@ describe('Claim returned', () => {
       });
 
       this.visit(`/users/${loan.userId}/loans/view/${loan.id}`);
+    });
+
+    it('should display disabled renew button', () => {
+      expect(LoanActionsHistory.isRenewButtonDisabled).to.be.true;
     });
 
     it('should display disabled claim returned button', () => {


### PR DESCRIPTION
## Purpose
Added functionality to disable/hide the Renew button if the item with status Claimed returned selected.
Story [UIU-1261](https://issues.folio.org/browse/UIU-1261).

### Screenshot
![Screen Shot 2020-05-21 at 17 18 42](https://user-images.githubusercontent.com/49517355/82570240-ff0ba700-9b89-11ea-915f-f6bbba9fb80b.png)
