### PR TITLE
UIU-1260: Prevent change due date for claimed returned items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Add resolve claim to loan details screen. Refs UIU-1524.
 * Capitalize user status when displayed. Fixes UIU-1523.
 * Permissions -> Users: Create/reset password send. Refs UIU-1337.
+* Prevent change due date for claimed returned items. Refs UIU-1260.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -88,6 +88,7 @@ class ActionsDropdown extends React.Component {
         </IfPermission>
         <IfPermission perm="ui-users.loans.edit">
           { itemStatusName !== itemStatuses.DECLARED_LOST &&
+            itemStatusName !== itemStatuses.CLAIMED_RETURNED &&
             <Button
               buttonStyle="dropdownItem"
               data-test-dropdown-content-change-due-date-button

--- a/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
@@ -200,7 +200,7 @@ class OpenLoansSubHeader extends React.Component {
               <Button
                 marginBottom0
                 id="change-due-date-all"
-                disabled={noSelectedLoans || onlyLostItemsSelected}
+                disabled={noSelectedLoans || onlyLostItemsSelected || onlyClaimedReturnedItemsSelected}
                 onClick={showChangeDueDateDialog}
               >
                 <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -439,7 +439,8 @@ class LoanDetails extends React.Component {
                 }
                 <IfPermission perm="ui-users.loans.edit">
                   <Button
-                    disabled={buttonDisabled || isDeclaredLostItem}
+                    data-test-change-due-date-button
+                    disabled={buttonDisabled || isDeclaredLostItem || isClaimedReturnedItem}
                     buttonStyle="primary"
                     onClick={this.showChangeDueDateDialog}
                   >

--- a/test/bigtest/interactors/loan-actions-history.js
+++ b/test/bigtest/interactors/loan-actions-history.js
@@ -29,6 +29,7 @@ import KeyValue from './KeyValue';
   claimReturnedButton = scoped('[data-test-claim-returned-button]', ButtonInteractor);
   isClaimReturnedButtonDisabled = property('[data-test-claim-returned-button]', 'disabled');
   isRenewButtonDisabled = property('[data-test-renew-button]', 'disabled');
+  isChangeDueDateButtonDisabled = property('[data-test-change-due-date-button]', 'disabled');
   loanActions = scoped('#list-loanactions', MultiColumnListInteractor);
 
   resolveClaimMenu = scoped('#resolve-claim-menu button');

--- a/test/bigtest/interactors/open-loans.js
+++ b/test/bigtest/interactors/open-loans.js
@@ -85,6 +85,7 @@ import DialogInteractor from './dialog';
 
   isBulkRenewButtonDisabled = property('#renew-all', 'disabled');
   isBulkClaimReturnedDisabled = property('#bulk-claim-returned', 'disabled');
+  isBulkChangeDueDateButtonDisabled = property('#change-due-date-all', 'disabled');
 
   itemsPresent = isVisible('#list-loanshistory [role="gridcell"]');
 

--- a/test/bigtest/tests/claim-returned-test.js
+++ b/test/bigtest/tests/claim-returned-test.js
@@ -150,6 +150,10 @@ describe('Claim returned', () => {
         expect(OpenLoansInteractor.actionDropdownRenewButton.isVisible).to.be.false;
       });
 
+      it('should not display change due date button', () => {
+        expect(OpenLoansInteractor.actionDropdownChangeDueDateButton.isVisible).to.be.false;
+      });
+
       it('should not display claim returned button', () => {
         expect(OpenLoansInteractor.actionDropdownClaimReturnedButton.isVisible).to.be.false;
       });
@@ -164,6 +168,10 @@ describe('Claim returned', () => {
         expect(OpenLoansInteractor.isBulkRenewButtonDisabled).to.be.true;
       });
 
+      it('should display disabled bulk change due date button', () => {
+        expect(OpenLoansInteractor.isBulkChangeDueDateButtonDisabled).to.be.true;
+      });
+
       describe('when check the checked out item', () => {
         beforeEach(async () => {
           await OpenLoansInteractor.checkboxes(0).clickInput();
@@ -171,6 +179,10 @@ describe('Claim returned', () => {
 
         it('should display enabled bulk renew button', () => {
           expect(OpenLoansInteractor.isBulkRenewButtonDisabled).to.be.false;
+        });
+
+        it('should display enabled bulk change due date button', () => {
+          expect(OpenLoansInteractor.isBulkChangeDueDateButtonDisabled).to.be.false;
         });
       });
     });
@@ -235,7 +247,11 @@ describe('Claim returned', () => {
 
     it('should hide claim returned button', () => {
       expect(LoanActionsHistory.claimReturnedButton.isPresent).to.be.false;
-    }).timeout(5000);
+    });
+
+    it('should display disabled change due date button', () => {
+      expect(LoanActionsHistory.isChangeDueDateButtonDisabled).to.be.true;
+    });
 
     it('should display the claimed returned date in `Claimed returned` field', () => {
       expect(LoanActionsHistory.claimedReturnedDate.value.text).to.not.equal('-');


### PR DESCRIPTION
## Purpose
Added functionality to disable/hide the `Change due date` button if the item with status Claimed returned selected.
Story [UIU-1260](https://issues.folio.org/browse/UIU-1260).

### Screenshot
![Screen Shot 2020-05-27 at 21 09 53](https://user-images.githubusercontent.com/49517355/83058481-1999c080-a061-11ea-9929-bae21ca28d3c.png)
