### PR TITLE
UIU-1524: Add resolve claim to loan details screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Display the correct link for create/reset password. Refs UIU-1608.
 * Add a bulk claim returned function. Refs UIU-1627.
 * Format action message for claim returned checkin. Refs UIU-1218.
+* Add resolve claim to loan details screen. Refs UIU-1524.
 * Capitalize user status when displayed. Fixes UIU-1523.
 * Permissions -> Users: Create/reset password send. Refs UIU-1337.
 

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -25,7 +25,9 @@ import {
   Row,
   Col,
   NoValue,
-  LoadingView
+  LoadingView,
+  Dropdown,
+  DropdownMenu,
 } from '@folio/stripes/components';
 import { IfPermission } from '@folio/stripes/core';
 import { effectiveCallNumber } from '@folio/stripes/util';
@@ -41,6 +43,7 @@ import {
   withRenew,
   withDeclareLost,
   withClaimReturned,
+  withMarkAsMissing,
 } from '../../components/Wrappers';
 import loanActionMap from '../../components/data/static/loanActionMap';
 import LoanProxyDetails from './LoanProxyDetails';
@@ -79,6 +82,7 @@ class LoanDetails extends React.Component {
     requestCounts: PropTypes.object,
     renew: PropTypes.func,
     declareLost: PropTypes.func,
+    markAsMissing: PropTypes.func,
     claimReturned: PropTypes.func,
     patronBlocks: PropTypes.arrayOf(PropTypes.object),
     intl: PropTypes.object.isRequired,
@@ -292,6 +296,7 @@ class LoanDetails extends React.Component {
       loanPolicies,
       requestCounts,
       declareLost,
+      markAsMissing,
       claimReturned,
     } = this.props;
 
@@ -391,16 +396,47 @@ class LoanDetails extends React.Component {
                     <FormattedMessage id="ui-users.renew" />
                   </Button>
                 </IfPermission>
-                <IfPermission perm="ui-users.loans.claim-item-returned">
-                  <Button
-                    data-test-claim-returned-button
-                    disabled={buttonDisabled || isClaimedReturnedItem}
-                    buttonStyle="primary"
-                    onClick={() => claimReturned(loan)}
+                {isClaimedReturnedItem &&
+                  <Dropdown
+                    id="resolve-claim-menu"
+                    label={<FormattedMessage id="ui-users.loans.resolveClaim" />}
+                    buttonProps={{ buttonStyle: 'primary' }}
                   >
-                    <FormattedMessage id="ui-users.loans.claimReturned" />
-                  </Button>
-                </IfPermission>
+                    <DropdownMenu data-test-resolve-claim-dropdown data-role="menu">
+                      <IfPermission perm="ui-users.loans.declare-item-lost">
+                        <Button
+                          buttonStyle="dropdownItem"
+                          data-test-declare-lost-button
+                          disabled={buttonDisabled || isDeclaredLostItem}
+                          onClick={() => declareLost(loan)}
+                        >
+                          <FormattedMessage id="ui-users.loans.declareLost" />
+                        </Button>
+                      </IfPermission>
+                      <IfPermission perm="ui-users.loans.declare-claimed-returned-item-as-missing">
+                        <Button
+                          buttonStyle="dropdownItem"
+                          data-test-dropdown-content-mark-as-missing-button
+                          onClick={() => markAsMissing(loan)}
+                        >
+                          <FormattedMessage id="ui-users.loans.markAsMissing" />
+                        </Button>
+                      </IfPermission>
+                    </DropdownMenu>
+                  </Dropdown>
+                }
+                {!isClaimedReturnedItem &&
+                  <IfPermission perm="ui-users.loans.claim-item-returned">
+                    <Button
+                      data-test-claim-returned-button
+                      disabled={buttonDisabled}
+                      buttonStyle="primary"
+                      onClick={() => claimReturned(loan)}
+                    >
+                      <FormattedMessage id="ui-users.loans.claimReturned" />
+                    </Button>
+                  </IfPermission>
+                }
                 <IfPermission perm="ui-users.loans.edit">
                   <Button
                     disabled={buttonDisabled || isDeclaredLostItem}
@@ -408,16 +444,6 @@ class LoanDetails extends React.Component {
                     onClick={this.showChangeDueDateDialog}
                   >
                     <FormattedMessage id="stripes-smart-components.cddd.changeDueDate" />
-                  </Button>
-                </IfPermission>
-                <IfPermission perm="ui-users.loans.declare-item-lost">
-                  <Button
-                    data-test-declare-lost-button
-                    disabled={buttonDisabled || isDeclaredLostItem}
-                    buttonStyle="primary"
-                    onClick={() => declareLost(loan)}
-                  >
-                    <FormattedMessage id="ui-users.loans.declareLost" />
                   </Button>
                 </IfPermission>
               </span>
@@ -607,4 +633,5 @@ export default compose(
   withRenew,
   withDeclareLost,
   withClaimReturned,
+  withMarkAsMissing,
 )(LoanDetails);

--- a/test/bigtest/interactors/loan-actions-history.js
+++ b/test/bigtest/interactors/loan-actions-history.js
@@ -4,6 +4,7 @@ import {
   clickable,
   ButtonInteractor,
   property,
+  isPresent,
 } from '@bigtest/interactor';
 
 import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor'; // eslint-disable-line
@@ -11,8 +12,7 @@ import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumn
 import KeyValue from './KeyValue';
 
 @interactor class LoanActionsHistory {
-  static defaultScope = '[data-test-loan-actions-history]';
-
+  actionHistoryPresent = isPresent('[data-test-loan-actions-history]');
   claimedReturnedDate = scoped('[data-test-loan-claimed-returned] div', KeyValue);
   requests = scoped('[data-test-loan-actions-history-requests] div', KeyValue);
   lostDate = scoped('[data-test-loan-actions-history-lost] div', KeyValue);
@@ -31,8 +31,10 @@ import KeyValue from './KeyValue';
   isRenewButtonDisabled = property('[data-test-renew-button]', 'disabled');
   loanActions = scoped('#list-loanactions', MultiColumnListInteractor);
 
+  resolveClaimMenu = scoped('#resolve-claim-menu button');
+
   whenLoaded() {
-    return this.when(() => this.isPresent).timeout(5000);
+    return this.when(() => this.actionHistoryPresent).timeout(5000);
   }
 }
 

--- a/test/bigtest/tests/claim-returned-test.js
+++ b/test/bigtest/tests/claim-returned-test.js
@@ -176,7 +176,7 @@ describe('Claim returned', () => {
     });
   });
 
-  describe('Visiting loan details  page with not claimed returned item', () => {
+  describe('Visiting loan details page with not claimed returned item', () => {
     beforeEach(async function () {
       const loan = this.server.create('loan', {
         status: { name: 'Open' },
@@ -233,13 +233,22 @@ describe('Claim returned', () => {
       expect(LoanActionsHistory.isRenewButtonDisabled).to.be.true;
     });
 
-    it('should display disabled claim returned button', () => {
-      expect(LoanActionsHistory.claimReturnedButton.isPresent).to.be.true;
-      expect(LoanActionsHistory.isClaimReturnedButtonDisabled).to.be.true;
+    it('should hide claim returned button', () => {
+      expect(LoanActionsHistory.claimReturnedButton.isPresent).to.be.false;
     }).timeout(5000);
 
     it('should display the claimed returned date in `Claimed returned` field', () => {
       expect(LoanActionsHistory.claimedReturnedDate.value.text).to.not.equal('-');
+    });
+
+    describe('show resolve claim menu with actions', () => {
+      beforeEach(async function () {
+        await LoanActionsHistory.resolveClaimMenu.click();
+      });
+
+      it('should show declare lost button', () => {
+        expect(LoanActionsHistory.declareLostButton.isPresent).to.be.true;
+      }).timeout(5000);
     });
   });
 });

--- a/test/bigtest/tests/declare-lost-test.js
+++ b/test/bigtest/tests/declare-lost-test.js
@@ -142,14 +142,28 @@ describe('Declare Lost', () => {
     });
   });
 
-  describe('Visiting loan details  page with not declared lost item', () => {
+  describe('Visiting loan details page with not declared lost item', () => {
     beforeEach(async function () {
       const loan = this.server.create('loan', {
         status: { name: 'Open' },
-        loanPolicyId: 'test'
+        loanPolicyId: 'test',
+        action: 'claimedReturned',
+        actionComment: 'Claim returned confirmation',
+        item: { status: { name: 'Claimed returned' } },
+        itemStatus: 'Claimed returned',
+        claimedReturnedDate: new Date().toISOString(),
+      });
+
+      this.server.create('user', { id: loan.userId });
+      this.server.create('loanaction', {
+        loan: {
+          ...loan.attrs,
+        },
       });
 
       this.visit(`/users/${loan.userId}/loans/view/${loan.id}`);
+
+      await LoanActionsHistory.resolveClaimMenu.click();
     });
 
     it('should display enabled declare lost button', () => {
@@ -197,10 +211,8 @@ describe('Declare Lost', () => {
       this.visit(`/users/${loan.userId}/loans/view/${loan.id}`);
     });
 
-
-    it('should display disabled declare lost button', () => {
-      expect(LoanActionsHistory.declareLostButton.isPresent).to.be.true;
-      expect(LoanActionsHistory.isDeclareLostButtonDisabled).to.be.true;
+    it('should hide declare lost button', () => {
+      expect(LoanActionsHistory.declareLostButton.isPresent).to.be.false;
     }).timeout(5000);
 
     it('should display the lost date in lost field', () => {

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -85,6 +85,7 @@
   "loans.newFeeFine": "New fee/fine",
   "loans.feeFineDetails": "Fee/fine details",
   "loans.history": "Loan action history",
+  "loans.resolveClaim": "Resolve claim",
 
   "settings.label": "Users",
   "settings.general": "General",


### PR DESCRIPTION
Introduce `Resolve claim` menu on the loan details view.

https://issues.folio.org/browse/UIU-1524

![resolve_claim](https://user-images.githubusercontent.com/63545/83215248-7fa34800-a134-11ea-84b8-513e36e31737.png)
