### PR TITLE
Remove route `/:id/accounts/:accountstatus/charge` to FeesFinesContainer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,15 +144,6 @@ class UsersRouting extends React.Component {
           )}
         />
         <Route
-          path={`${base}/:id/accounts/:accountstatus/charge`}
-          exact
-          render={(props) => (
-            <IfPermission perm="ui-users.feesfines.actions.all">
-              <Routes.FeesFinesContainer {...props} />
-            </IfPermission>
-          )}
-        />
-        <Route
           path={`${base}/:id/accounts/view/:accountid`}
           render={(props) => (
             <IfPermission perm="ui-users.feesfines.actions.all">


### PR DESCRIPTION
The routed-to component `Routes.FeesFinesContainer` does not exist, as
the `Routes` object imported from `./routes/index.js` does not have a
member of that name. This reference to a non-existent route is the
cause of the only surviving startup error reported by the Stripes CLI:

	WARNING in ../ui-users/src/index.js 191:46-71
	"export 'FeesFinesContainer' (imported as 'Routes') was not found in './routes'

This route seems to have been added in error as part of the very large
(11,220 lines!) commit 87a00e057, and from its first introduction
referred to a non-existent component.

As further corroboration for this interpretation:

* There seems to be no place in the code that generates a link to the
  route in question.
* Manually navigating to a URL that matches this route yields an error
  "Element type is invalid: expected a string (for built-in
  components) or a class/function (for composite components) but got:
  undefined".
* The permission that guards the route is used in several other
  places.

Removing this should give us a clean Stripes startup for the first
time in a long while.