### PR TITLE
UIU-1644 - Fee/Fine Details is not refreshing, which may result in user entering duplicate actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * Prevent change due date for claimed returned items. Refs UIU-1260.
 * Bring back `Declare lost` button. Fixes UIU-1662.
 * Use the app logo as a profile placeholder. Yep, it's kinda hacky. Refs UIU-496.
+* Fee/Fine Details is not refreshing, which may result in user entering duplicate actions. Fixes UIU-1644.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -528,6 +528,7 @@ class AccountDetails extends React.Component {
               // perfectly well without them. ¯\_(ツ)_/¯
               // this.getAccountActions();
               // handleAddRecords();
+              this.props.mutator.accountActions.GET();
             }}
           />
 


### PR DESCRIPTION
# Purpose
Refresh page after performing fee fine action.

# Link
https://issues.folio.org/browse/UIU-1644

# Approach
Manually call accountActions.GET() endpoint in order to trigger getDerivedStateFromProps with proper data.