### PR TITLE
UIU-1660: Fix the arrangement of elements inside SafeHTMLMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Bring back `Declare lost` button. Fixes UIU-1662.
 * Use the app logo as a profile placeholder. Yep, it's kinda hacky. Refs UIU-496.
 * Fee/Fine Details is not refreshing, which may result in user entering duplicate actions. Fixes UIU-1644.
+* Fix the arrangement of elements inside the `SafeHTMLMessage` component. Fixes UIU-1660.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/components/BulkOverrideDialog/BulkOverrideInfo.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideInfo.js
@@ -183,14 +183,10 @@ class BulkOverrideInfo extends React.Component {
 
     return (
       <div>
-        <Layout className="flex">
-          <Layout className="flex">
-            <SafeHTMLMessage
-              id="ui-users.brd.itemsSelected"
-              values={{ count: selectedItems }}
-            />
-          </Layout>
-        </Layout>
+        <SafeHTMLMessage
+          id="ui-users.brd.itemsSelected"
+          values={{ count: selectedItems }}
+        />
         {
           showDueDatePicker &&
             <div data-test-due-date-picker>

--- a/src/components/BulkRenewalDialog/BulkRenewInfo.js
+++ b/src/components/BulkRenewalDialog/BulkRenewInfo.js
@@ -108,6 +108,7 @@ class BulkRenewInfo extends React.Component {
                 />
                 <SafeHTMLMessage
                   id="ui-users.brd.itemNotRenewed"
+                  tagName="span"
                   values={{
                     count: failedRenewals.length
                   }}
@@ -124,6 +125,7 @@ class BulkRenewInfo extends React.Component {
                 />
                 <SafeHTMLMessage
                   id="ui-users.brd.itemSuccessfullyRenewed"
+                  tagName="span"
                   values={{
                     count: successRenewals.length
                   }}

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -125,18 +125,14 @@ class ModalContent extends React.Component {
 
     return (
       <div>
-        <Layout className="flex">
-          <Layout className="flex">
-            <SafeHTMLMessage
-              id={`ui-users.loans.${loanAction}DialogBody`}
-              values={{
-                title: loan?.item?.title,
-                materialType: loan?.item?.materialType?.name,
-                barcode: loan?.item?.barcode,
-              }}
-            />
-          </Layout>
-        </Layout>
+        <SafeHTMLMessage
+          id={`ui-users.loans.${loanAction}DialogBody`}
+          values={{
+            title: loan?.item?.title,
+            materialType: loan?.item?.materialType?.name,
+            barcode: loan?.item?.barcode,
+          }}
+        />
         <Row>
           <Col sm={12} className={css.additionalInformation}>
             <TextArea


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1660

## Purpose
Due to changes in [response-intl-safe-html](https://github.com/folio-org/react-intl-safe-html/commit/f3d494e47fe25160082b0c2e0777aa20f1cfa475), in the `SafeHTMLMessage` component, the default value of `tagName` (`'span'`) was deleted. Therefore, all elements within the `SafeHTMLMessage` were arranged in the order determined by its parent tag.
## Approach
In those cases where the parent tag was used to align several elements (including `SafeHTMLMessage`), the property `tagHame='span'` has been explicitly set for the `SafeHTMLMessage`.
In other cases, the parent tag has been painlessly deleted.
### Screenshots
**_Before_**

![Before](https://user-images.githubusercontent.com/49517355/83668998-8a008e80-a5d9-11ea-9689-2ca95d006c1e.png)

**_After_**

![After](https://user-images.githubusercontent.com/49517355/83669024-94228d00-a5d9-11ea-9ad0-88a155e5a0b5.png)
