### PR TITLE
UIU-1652: Protect loan action history page from CQL null query errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Bring back `Declare lost` button. Fixes UIU-1662.
 * Use the app logo as a profile placeholder. Yep, it's kinda hacky. Refs UIU-496.
 * Fee/Fine Details is not refreshing, which may result in user entering duplicate actions. Fixes UIU-1644.
+* Protect loan action history page from CQL null query errors. Fixes UIU-1652.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/components/Wrappers/withRenew.js
+++ b/src/components/Wrappers/withRenew.js
@@ -250,7 +250,10 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
     const step = 50;
     for (let i = 0; i < loans.length; i += step) {
       const loansSlice = loans.slice(i, i + step);
-      const q = loansSlice.map(loan => loan.itemId).join(' or ');
+      const q = loansSlice
+        .filter(loan => loan.itemId)
+        .map(loan => loan.itemId)
+        .join(' or ');
       const query = `(itemId==(${q})) and status==("Open - Awaiting pickup" or "Open - Not yet filled") sortby requestDate desc`;
       reset();
       GET({ params: { query } })
@@ -279,7 +282,11 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
   fetchLoanPolicyNames = () => {
     // get a list of unique policy IDs to retrieve. multiple loans may share
     // the same policy; we only need to retrieve that policy once.
-    const query = `id==(${[...new Set(this.state.loans.map(loan => loan.loanPolicyId))].join(' or ')})`;
+    const ids = [...new Set(this.state.loans
+      .filter(loan => loan.loanPolicyId)
+      .map(loan => loan.loanPolicyId))]
+      .join(' or ');
+    const query = `id==(${ids})`;
     const {
       mutator: {
         loanPolicies: {


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1652

This is a difficult bug to reproduce as reported, since it apparently stems from an abnormal condition in which a loan is missing either an itemId or a loanPolicyId. But in artificial tests (i.e., deliberately breaking things), filtering out the null values before mapping the arrays seems to protect against the CQL errors.