### PR TITLE
UIU-1600: Add interface checks for notes, feesfines and circulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Protect loan action history page from CQL null query errors. Fixes UIU-1652.
 * Fix the arrangement of elements inside the `SafeHTMLMessage` component. Fixes UIU-1660.
 * Fix Patron Group, Status, and Preferred contact fields, are not read a required by screen reader. Refs UIU-1642.
+* Add checks for multiple okapi interfaces on user's details screen. Fixes UIU-1600.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -34,14 +34,17 @@
     "okapiInterfaces": {
       "users": "15.0",
       "configuration": "2.0",
-      "circulation": "9.0",
       "permissions": "5.0",
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0 7.0",
       "login": "6.0",
-      "feesfines": "15.0",
       "request-storage": "2.5 3.0",
       "users-bl": "5.0"
+    },
+    "optionalOkapiInterfaces": {
+      "circulation": "9.0",
+      "feesfines": "15.0",
+      "notes": "1.0"
     },
     "permissionSets": [
       {

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -444,19 +444,21 @@ class UserDetail extends React.Component {
                 expanded={sections.userInformationSection}
                 onToggle={this.handleSectionToggle}
               />
-              <IfPermission perm="manualblocks.collection.get">
-                <PatronBlock
-                  accordionId="patronBlocksSection"
-                  user={user}
-                  hasPatronBlocks={(hasPatronBlocks === 1 && totalPatronBlocks > 0)}
-                  patronBlocks={patronBlocks}
-                  expanded={sections.patronBlocksSection}
-                  onToggle={this.handleSectionToggle}
-                  onClickViewPatronBlock={this.onClickViewPatronBlock}
-                  addRecord={this.state.addRecord}
-                  {...this.props}
-                />
-              </IfPermission>
+              <IfInterface name="feesfines">
+                <IfPermission perm="manualblocks.collection.get">
+                  <PatronBlock
+                    accordionId="patronBlocksSection"
+                    user={user}
+                    hasPatronBlocks={(hasPatronBlocks === 1 && totalPatronBlocks > 0)}
+                    patronBlocks={patronBlocks}
+                    expanded={sections.patronBlocksSection}
+                    onToggle={this.handleSectionToggle}
+                    onClickViewPatronBlock={this.onClickViewPatronBlock}
+                    addRecord={this.state.addRecord}
+                    {...this.props}
+                  />
+                </IfPermission>
+              </IfInterface>
               <ExtendedInfo
                 accordionId="extendedInfoSection"
                 user={user}
@@ -494,16 +496,18 @@ class UserDetail extends React.Component {
                   {...this.props}
                 />
               </IfPermission>
-              <IfPermission perm="ui-users.feesfines.actions.all">
-                <UserAccounts
-                  expanded={sections.accountsSection}
-                  onToggle={this.handleSectionToggle}
-                  accordionId="accountsSection"
-                  addRecord={addRecord}
-                  location={location}
-                  match={match}
-                />
-              </IfPermission>
+              <IfInterface name="feesfines">
+                <IfPermission perm="ui-users.feesfines.actions.all">
+                  <UserAccounts
+                    expanded={sections.accountsSection}
+                    onToggle={this.handleSectionToggle}
+                    accordionId="accountsSection"
+                    addRecord={addRecord}
+                    location={location}
+                    match={match}
+                  />
+                </IfPermission>
+              </IfInterface>
 
               <IfPermission perm="ui-users.loans.view">
                 <IfInterface name="loan-policy-storage">
@@ -526,13 +530,15 @@ class UserDetail extends React.Component {
 
               <IfPermission perm="ui-users.requests.all">
                 <IfInterface name="request-storage" version="2.5 3.0">
-                  <UserRequests
-                    expanded={sections.requestsSection}
-                    onToggle={this.handleSectionToggle}
-                    accordionId="requestsSection"
-                    user={user}
-                    {...this.props}
-                  />
+                  <IfInterface name="circulation">
+                    <UserRequests
+                      expanded={sections.requestsSection}
+                      onToggle={this.handleSectionToggle}
+                      accordionId="requestsSection"
+                      user={user}
+                      {...this.props}
+                    />
+                  </IfInterface>
                 </IfInterface>
               </IfPermission>
 
@@ -560,20 +566,22 @@ class UserDetail extends React.Component {
                   />
                 </IfInterface>
               </IfPermission>
-              <IfPermission perm="ui-notes.item.view">
-                <NotesSmartAccordion
-                  domainName="users"
-                  entityId={match.params.id}
-                  entityName={getFullName(user)}
-                  open={this.state.sections.notesAccordion}
-                  onToggle={this.handleSectionToggle}
-                  id="notesAccordion"
-                  entityType="user"
-                  pathToNoteCreate="/users/notes/new"
-                  pathToNoteDetails="/users/notes"
-                  hideAssignButton
-                />
-              </IfPermission>
+              <IfInterface name="notes">
+                <IfPermission perm="ui-notes.item.view">
+                  <NotesSmartAccordion
+                    domainName="users"
+                    entityId={match.params.id}
+                    entityName={getFullName(user)}
+                    open={this.state.sections.notesAccordion}
+                    onToggle={this.handleSectionToggle}
+                    id="notesAccordion"
+                    entityType="user"
+                    pathToNoteCreate="/users/notes/new"
+                    pathToNoteDetails="/users/notes"
+                    hideAssignButton
+                  />
+                </IfPermission>
+              </IfInterface>
             </AccordionSet>
           </Pane>
           { helperApp && <HelperApp appName={helperApp} onClose={this.closeHelperApp} /> }

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -23,6 +23,14 @@ export default function config() {
       name: 'users',
       provides: []
     },
+    {
+      id: 'mod-feesfines-15.8.0-SNAPSHOT.73',
+      name: 'feesfines',
+      provides: [{
+        id: 'feesfines',
+        version: '15.2',
+      }]
+    }
   ]);
 
   this.get('/saml/check', {


### PR DESCRIPTION
This PR is trying to address issue described in: 

https://issues.folio.org/browse/UIU-1600

The user's details screen and edit form should now work without throwing bunch of errors when the `feefines` and `notes` interfaces are not present.

