### PR TITLE
UIU-1672 be dumber about the "reset password" link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Protect loan action history page from CQL null query errors. Fixes UIU-1652.
 * Fix the arrangement of elements inside the `SafeHTMLMessage` component. Fixes UIU-1660.
 * Fix Patron Group, Status, and Preferred contact fields, are not read a required by screen reader. Refs UIU-1642.
+* On user-edit screen, show "send reset password link" whenever username is present. Refs UIU-1672.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)


### PR DESCRIPTION
Previously, the `CreateResetPasswordControl` component would retrieve
the credentials of the given user in order to investigate the hash to
see if it looked like an empty string, because new users were given
empty string as a password, in order to choose whether to show the
"create password" or "reset password" modal.

There are two big problems with that: (1) we were creating users with
empty string passwords which should not be allowed, and (2) we were
able to retrieve a password's hash and salt which should not be allowed.
So assuming we're going to stop creating users in that manner, and that
we're going to stop allowing the retrieval of password hashes and salts,
the easiest thing to do here is to just show the "reset password"
component and not worry about "reset" vs "create".

Refs [UIU-1672](https://issues.folio.org/browse/UIU-1672), [UIU-1671](https://issues.folio.org/browse/UIU-1671), [MODLOGIN-128](https://issues.folio.org/browse/MODLOGIN-128), [UIU-1608](https://issues.folio.org/browse/UIU-1608) / #1302.