### PR TITLE
UIU-1653: Check for an empty loan to protect from generating incorrect CQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Protect loan action history page from CQL null query errors. Fixes UIU-1652.
 * Fix the arrangement of elements inside the `SafeHTMLMessage` component. Fixes UIU-1660.
 * Fix Patron Group, Status, and Preferred contact fields, are not read a required by screen reader. Refs UIU-1642.
+* Check for an empty loan to protect from generating incorrect CQL. Fixes UIU-1653.
 * Add checks for multiple okapi interfaces on user's details screen. Fixes UIU-1600.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)

--- a/src/routes/LoanDetailContainer.js
+++ b/src/routes/LoanDetailContainer.js
@@ -1,3 +1,4 @@
+import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
@@ -183,7 +184,7 @@ class LoanDetailContainer extends React.Component {
 
     return (
       <LoanDetails
-        loans={loan ? [loan] : []}
+        loans={isEmpty(loan) ? [] : [loan]}
         loanActionsWithUser={loanActionsWithUser}
         loan={loan}
         user={this.getUser()}


### PR DESCRIPTION
This is a continuation of work @Baroquem did under https://github.com/folio-org/ui-users/pull/1340.

It looks like in some circumstances an empty loan object is being created here:

https://github.com/folio-org/ui-users/blob/3a3a2cf25082cb8dc8260b64a41ffec94a3f2071/src/routes/LoanDetailContainer.js#L129

Which was causing bunch of issues in `withRenew` (because the `loans` array contained one empty loan object):

https://github.com/folio-org/ui-users/blob/2f10ab037d7fb1704e6ec09441127b502cefdcf9/src/components/Wrappers/withRenew.js#L83

https://github.com/folio-org/ui-users/blob/2f10ab037d7fb1704e6ec09441127b502cefdcf9/src/components/Wrappers/withRenew.js#L63

This PR should address it.

### Link

https://issues.folio.org/browse/UIU-1653



