### PR TITLE
UIU-1663 - Add 7.0 login interface version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [4.0.0] (IN PROGRESS)
 
+* Support `login` `v7.0` (some unused endpoints were removed). Refs UIU-1663, UIU-1672.
+* Support `users-bl` `v6.0` (some unused endpoints were removed). Refs STCOR-436, STRIPES-685.
 * Change Fee/Fine Owner by Service Point name where the transaction took place. Refs. UIU-1398.
 * Support `loan-storage` interface version 7.0. UIU-1598.
 * Add posibility to view/create/edit custom fields on user record. UIU-1279.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "permissions": "5.0",
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0 7.0",
-      "login": "6.0",
+      "login": "6.0 7.0",
       "request-storage": "2.5 3.0",
       "users-bl": "5.0",
       "automated-patron-blocks": "0.1"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
       "loan-storage": "4.0 5.0 6.0 7.0",
       "login": "6.0 7.0",
       "request-storage": "2.5 3.0",
-      "users-bl": "5.0",
+      "users-bl": "5.0 6.0",
       "automated-patron-blocks": "0.1"
     },
     "optionalOkapiInterfaces": {


### PR DESCRIPTION
See https://issues.folio.org/browse/UIU-1663 

I think https://github.com/folio-org/ui-users/pull/1353 allows us to have dual support for login 6.0 and 7.0

For additional context, see https://issues.folio.org/browse/MODLOGIN-128 and related issues