### PR TITLE
UIU-1671 do not create empty credentials records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * Display automated patron blocks on User Information page. Refs UIU-1273.
 * On user-edit screen, show "send reset password link" whenever username is present. Refs UIU-1672.
 * Display automated patron blocks on renewing in loans context. Refs UIU-1276.
+* Do not create an empty-string password when adding a username to a user. Refs UIU-1671.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)


### PR DESCRIPTION
Previously, the "reset password" functionality of mod-login would fail
if a credentials record for the given user did not already exist
(MODLOGIN-131). A hedge around this was to create credentials records
with empty-string passwords whenever a username was added to a user
record. But that's a giant security hole, and now that MODLOGIN-131 is
resolved we no longer need to keep that workaround in place.

Refs [UIU-1671](https://issues.folio.org/browse/UIU-1671), [MODLOGIN-131](https://issues.folio.org/browse/MODLOGIN-131)