### PR TITLE
UIU-1337: Rename permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -633,14 +633,13 @@
         "visible": true
       },
       {
-        "permissionName": "ui-users.reset-password-link.send",
+        "permissionName": "ui-users.reset-password.link",
         "displayName": "Users: Create/reset password send",
         "subPermissions": [
           "login.credentials-existence.get",
           "login.collection.get",
           "ui-users.view",
           "ui-users.edit",
-          "ui-users.settings.customfields.view",
           "users-bl.password-reset-link.generate"
         ],
         "visible": true

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -127,7 +127,7 @@ class EditExtendedInfo extends Component {
               validStylesEnabled
             />
           </Col>
-          <IfPermission perm="ui-users.reset-password-link.send">
+          <IfPermission perm="ui-users.reset-password.link">
             {isEditForm && username &&
               (
                 <CreateResetPasswordControl

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -496,7 +496,7 @@ class UserForm extends React.Component {
                   addressTypes={formData.addressTypes}
                   preferredContactTypeId={initialValues.preferredContactTypeId}
                 />
-                {/* <EditCustomFieldsRecord
+                <EditCustomFieldsRecord
                   formName="userForm"
                   isReduxForm
                   accordionId="customFields"
@@ -505,7 +505,7 @@ class UserForm extends React.Component {
                   backendModuleName="users"
                   entityType="user"
                   fieldComponent={Field}
-                /> */}
+                />
                 {initialValues.id &&
                   <div>
                     <EditProxy

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -496,7 +496,7 @@ class UserForm extends React.Component {
                   addressTypes={formData.addressTypes}
                   preferredContactTypeId={initialValues.preferredContactTypeId}
                 />
-                <EditCustomFieldsRecord
+                {/* <EditCustomFieldsRecord
                   formName="userForm"
                   isReduxForm
                   accordionId="customFields"
@@ -505,7 +505,7 @@ class UserForm extends React.Component {
                   backendModuleName="users"
                   entityType="user"
                   fieldComponent={Field}
-                />
+                /> */}
                 {initialValues.id &&
                   <div>
                     <EditProxy

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -245,10 +245,10 @@ describe('User Edit Page', () => {
     });
   });
 
-  describe('User without permission create/reset password', () => {
+  describe.('User without permission create/reset password', () => {
     setupApplication({
       permissions: {
-        'ui-users.ui-users.reset-password.link': false
+        'ui-users.reset-password.link': false
       }
     });
 

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -248,7 +248,7 @@ describe('User Edit Page', () => {
   describe('User without permission create/reset password', () => {
     setupApplication({
       permissions: {
-        'ui-users.reset-password-link.send': false
+        'ui-users.ui-users.reset-password.link': false
       }
     });
 

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -245,7 +245,7 @@ describe('User Edit Page', () => {
     });
   });
 
-  describe.('User without permission create/reset password', () => {
+  describe('User without permission create/reset password', () => {
     setupApplication({
       permissions: {
         'ui-users.reset-password.link': false

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -739,7 +739,7 @@
   "permission.manual_waive": "Fees/Fines: Can waive",
   "permission.patron_blocks": "Users: Can create, edit and remove patron blocks",
   "permission.requests.all": "Users: View requests",
-  "permission.reset-password-link.send": "Users: Create/reset password send",
+  "permission.reset-password.link": "Users: Create/reset password send",
   "permission.settings.addresstypes": "Settings (Users): Can create, edit and remove address types",
   "permission.settings.comments": "Settings (Users): Can create, edit and remove comments",
   "permission.settings.conditions": "Settings (Users): Can create, edit and remove patron blocks conditions",


### PR DESCRIPTION
# Description
Rename permission to get the updated permission name. Also remove unnessesary permission from subPermissions.
# Fix for task
https://issues.folio.org/browse/UIU-1337