### PR TITLE
UIU-1337: Change permission name

### DIFF
--- a/package.json
+++ b/package.json
@@ -633,8 +633,8 @@
         "visible": true
       },
       {
-        "permissionName": "ui-users.reset-password.link",
-        "displayName": "Users: Create/reset password send",
+        "permissionName": "ui-users.reset.password",
+        "displayName": "Users: Create/reset password",
         "subPermissions": [
           "login.credentials-existence.get",
           "login.collection.get",

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -127,7 +127,7 @@ class EditExtendedInfo extends Component {
               validStylesEnabled
             />
           </Col>
-          <IfPermission perm="ui-users.reset-password.link">
+          <IfPermission perm="ui-users.reset.password">
             {isEditForm && username &&
               (
                 <CreateResetPasswordControl

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -248,7 +248,7 @@ describe('User Edit Page', () => {
   describe('User without permission create/reset password', () => {
     setupApplication({
       permissions: {
-        'ui-users.reset-password.link': false
+        'ui-users.reset.password': false
       }
     });
 

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -739,7 +739,7 @@
   "permission.manual_waive": "Fees/Fines: Can waive",
   "permission.patron_blocks": "Users: Can create, edit and remove patron blocks",
   "permission.requests.all": "Users: View requests",
-  "permission.reset-password.link": "Users: Create/reset password send",
+  "permission.reset.password": "Users: Create/reset password",
   "permission.settings.addresstypes": "Settings (Users): Can create, edit and remove address types",
   "permission.settings.comments": "Settings (Users): Can create, edit and remove comments",
   "permission.settings.conditions": "Settings (Users): Can create, edit and remove patron blocks conditions",


### PR DESCRIPTION
# Description
Rename permission from `Users: Create/reset password send` to `Users: Create/reset password`
# Fix
https://issues.folio.org/browse/UIU-1337