### PR TITLE
UIU-1204: Fix incorrect date display in Return date field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * On user-edit screen, show "send reset password link" whenever username is present. Refs UIU-1672.
 * Display automated patron blocks on renewing in loans context. Refs UIU-1276.
 * Do not create an empty-string password when adding a username to a user. Refs UIU-1671.
+* Fix incorrect display of the date in the `Return date` field. Refs UIU-1204.
 
 ## [3.0.0](https://github.com/folio-org/ui-users/tree/v3.0.0) (2020-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v2.26.0...v3.0.0)

--- a/src/components/Loans/ClosedLoans/ClosedLoans.js
+++ b/src/components/Loans/ClosedLoans/ClosedLoans.js
@@ -225,12 +225,14 @@ class ClosedLoans extends React.Component {
         />;
       },
       'returnDate': loan => {
-        return <FormattedTime
-          value={loan.returnDate}
-          day="numeric"
-          month="numeric"
-          year="numeric"
-        />;
+        return loan.returnDate
+          ? (<FormattedTime
+            value={loan.returnDate}
+            day="numeric"
+            month="numeric"
+            year="numeric"
+          />)
+          : '-';
       },
       'checkinServicePoint': loan => _.get(loan, ['checkinServicePoint', 'name'], '-'),
       ' ': loan => {


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1204

### Purpose
Fix the bug of incorrect display of the date in the `Return date` field in the `Closed loans` table for the item was declared lost.

### Approach
The functionality of the `<FormattedTime>` component from `react-intl` is implemented in such a way that when no return date presents, the current date and time are used by default. Therefore it was added a check for the presence of `Return date` value.