### PR TITLE
fix custom fields payload formatting

### DIFF
--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -178,6 +178,18 @@ class UserEdit extends React.Component {
       });
   }
 
+  formatCustomFieldsPayload(customFields) {
+    const copiedCustomFields = { ...customFields };
+
+    Object.keys(copiedCustomFields).forEach(customFieldId => {
+      if (!copiedCustomFields[customFieldId]) {
+        delete copiedCustomFields[customFieldId];
+      }
+    });
+
+    return copiedCustomFields;
+  }
+
   update({ requestPreferences, ...userFormData }) {
     const {
       updateProxies,
@@ -224,6 +236,10 @@ class UserEdit extends React.Component {
     const today = moment().endOf('day');
     const curActive = user.active;
     const prevActive = prevUser.active;
+
+    const formattedCustomFieldsPayload = this.formatCustomFieldsPayload(data.customFields);
+
+    data.customFields = formattedCustomFieldsPayload;
 
     // if active has been changed manually on the form
     // or if the expirationDate has been removed

--- a/test/bigtest/interactors/settings-custom-fields.js
+++ b/test/bigtest/interactors/settings-custom-fields.js
@@ -12,7 +12,6 @@ import { AccordionSetInteractor } from '@folio/stripes-components/lib/Accordion/
   viewCustomFieldsPaneIsPresent = isPresent('#custom-fields-pane');
   editFieldsButtonPresent = isPresent('[data-test-custom-fields-edit-button]');
   clickEditFieldsButton = clickable('[data-test-custom-fields-edit-button]');
-  noCustomFieldsMessagePresent = isPresent('[data-test-custom-fields-no-fields-message]');
   customFieldsList = new AccordionSetInteractor('#custom-fields-list');
   deleteCustomFieldButtonsCount = count('[type="button"][data-test-custom-field-delete-button]');
 

--- a/test/bigtest/tests/settings-custom-fields-test.js
+++ b/test/bigtest/tests/settings-custom-fields-test.js
@@ -37,28 +37,6 @@ describe('Settings custom fields', () => {
     });
   });
 
-  describe('when there are no custom fields saved', () => {
-    before(() => {
-      setupApplication({
-        permissions: ['ui-users.settings.customfields.edit'],
-      });
-    });
-
-    beforeEach(async function () {
-      this.server.get('/custom-fields', () => ({
-        'customFields': [],
-        'totalRecords': 0
-      }));
-
-      this.visit('/settings/users/custom-fields');
-      await CustomFieldsInteractor.whenLoaded();
-    });
-
-    it('should render no custom fields message', () => {
-      expect(CustomFieldsInteractor.noCustomFieldsMessagePresent).to.be.true;
-    });
-  });
-
   describe('when clicking on Edit button', () => {
     before(() => {
       setupApplication({


### PR DESCRIPTION
When a custom field has no value, the backend expects us to not include that field in the payload.
