### PR TITLE
Pin react-intl to v4.6.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -709,7 +709,7 @@
   "peerDependencies": {
     "@folio/stripes": "^4.0.0",
     "react": "*",
-    "react-intl": "^4.5.3",
+    "react-intl": "~4.6.10",
     "react-router": "*",
     "react-router-dom": "*"
   },

--- a/package.json
+++ b/package.json
@@ -686,7 +686,7 @@
     "mocha": "^5.2.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
-    "react-intl": "^4.5.3",
+    "react-intl": "~4.6.10",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.0.0",
     "redux": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -709,7 +709,7 @@
   "peerDependencies": {
     "@folio/stripes": "^4.0.0",
     "react": "*",
-    "react-intl": "~4.6.10",
+    "react-intl": "^4.5.3",
     "react-router": "*",
     "react-router-dom": "*"
   },


### PR DESCRIPTION
Pinning `react-intl` to `v4.6.10` to fix CI failures when installing `@formatjs/intl-datetimeformat`