### PR TITLE
PERF-62 use == for more efficient queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Trim email address in user record to remove blanks. Fixes UIU-1528.
 * `withRenew` should include in-transit items when calculating the open-request-count. Fixes UIU-1254.
+* Use `==` for more efficient queries. Refs PERF-62.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/Accounts/Actions/Actions.js
+++ b/src/components/Accounts/Actions/Actions.js
@@ -33,7 +33,7 @@ class Actions extends React.Component {
     accounts: {
       type: 'okapi',
       records: 'accounts',
-      path: 'accounts?query=(userId=%{user.id})&limit=10000',
+      path: 'accounts?query=(userId==%{user.id})&limit=10000',
       PUT: {
         path: 'accounts/%{activeRecord.id}'
       },

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -27,21 +27,21 @@ class UserAccounts extends React.Component {
       type: 'okapi',
       records: 'accounts',
       GET: {
-        path: 'accounts?query=(userId=:{id})&limit=10000',
+        path: 'accounts?query=(userId==:{id})&limit=10000',
       },
     },
     openAccountsCount: {
       type: 'okapi',
       accumulate: 'true',
       GET: {
-        path: 'accounts?query=(userId=:{id} and status.name<>Closed)&limit=10000',
+        path: 'accounts?query=(userId==:{id} and status.name<>Closed)&limit=10000',
       },
     },
     closedAccountsCount: {
       type: 'okapi',
       accumulate: 'true',
       GET: {
-        path: 'accounts?query=(userId=:{id} and status.name=Closed)&limit=1',
+        path: 'accounts?query=(userId==:{id} and status.name=Closed)&limit=1',
       },
     },
     activeRecord: {},

--- a/src/routes/AccountDetailsContainer.js
+++ b/src/routes/AccountDetailsContainer.js
@@ -36,7 +36,7 @@ class AccountDetailsContainer extends React.Component {
       type: 'okapi',
       records: 'feefineactions',
       accumulate: 'true',
-      path: 'feefineactions?query=(accountId=:{accountid})&limit=10000',
+      path: 'feefineactions?query=(accountId==:{accountid})&limit=10000',
     },
     activeRecord: {
       accountId: '0',
@@ -44,7 +44,7 @@ class AccountDetailsContainer extends React.Component {
     loans: {
       type: 'okapi',
       records: 'loans',
-      path: 'circulation/loans?query=(userId=:{id})&limit=1000',
+      path: 'circulation/loans?query=(userId==:{id})&limit=1000',
     },
   });
 

--- a/src/routes/AccountsListingContainer.js
+++ b/src/routes/AccountsListingContainer.js
@@ -36,7 +36,7 @@ const queryFunction = (findAll, queryTemplate, sortMap, fConfig, failOnCondition
   return (queryParams, pathComponents, resourceValues, logger) => {
     let cql = getCql(queryParams, pathComponents, resourceValues, logger);
     const userId = a[0].value;
-    if (cql === undefined) { cql = `userId=${userId}`; } else { cql = `(${cql}) and (userId=${userId})`; }
+    if (cql === undefined) { cql = `userId==${userId}`; } else { cql = `(${cql}) and (userId==${userId})`; }
     return cql;
   };
 };
@@ -70,18 +70,18 @@ class AccountsListingContainer extends React.Component {
     comments: {
       type: 'okapi',
       records: 'feefineactions',
-      path: 'feefineactions?query=(userId=:{id} and comments=*)&limit=%{activeRecord.comments}',
+      path: 'feefineactions?query=(userId==:{id} and comments=*)&limit=%{activeRecord.comments}',
     },
     filter: {
       type: 'okapi',
       records: 'accounts',
       recordsRequired: '%{activeRecord.records}',
-      path: 'accounts?query=userId=:{id}&limit=10000',
+      path: 'accounts?query=userId==:{id}&limit=10000',
     },
     loans: {
       type: 'okapi',
       records: 'loans',
-      path: 'circulation/loans?query=(userId=:{id}) sortby id&limit=100',
+      path: 'circulation/loans?query=(userId==:{id}) sortby id&limit=100',
       permissionsRequired: 'circulation.loans.collection.get',
     },
     feefineshistory: {

--- a/src/routes/ChargeFeesFinesContainer.js
+++ b/src/routes/ChargeFeesFinesContainer.js
@@ -68,7 +68,7 @@ class ChargeFeesFinesContainer extends React.Component {
       type: 'okapi',
       records: 'feefines',
       GET: {
-        path: 'feefines?query=(ownerId=%{activeRecord.ownerId} or ownerId=%{activeRecord.shared})&limit=10000',
+        path: 'feefines?query=(ownerId==%{activeRecord.ownerId} or ownerId==%{activeRecord.shared})&limit=10000',
       },
     },
     feefineactions: {

--- a/src/routes/LoanDetailContainer.js
+++ b/src/routes/LoanDetailContainer.js
@@ -45,7 +45,7 @@ class LoanDetailContainer extends React.Component {
     loanHistory: {
       type: 'okapi',
       records: 'loans',
-      path: 'circulation/loans?query=(userId=:{id}) sortby id&limit=100',
+      path: 'circulation/loans?query=(userId==:{id}) sortby id&limit=100',
       permissionsRequired: 'circulation.loans.collection.get',
     },
     requests: {
@@ -58,7 +58,7 @@ class LoanDetailContainer extends React.Component {
     },
     loanActions: {
       type: 'okapi',
-      path: 'loan-storage/loan-history?query=(loan.id=:{loanid})&limit=100',
+      path: 'loan-storage/loan-history?query=(loan.id==:{loanid})&limit=100',
       records: 'loansHistory',
       resourceShouldRefresh: true,
       shouldRefresh: (resource, action, refresh) => {
@@ -84,7 +84,7 @@ class LoanDetailContainer extends React.Component {
     hasManualPatronBlocks: {
       type: 'okapi',
       records: 'manualblocks',
-      path: 'manualblocks?query=(userId=:{id})&limit=100',
+      path: 'manualblocks?query=(userId==:{id})&limit=100',
       permissionsRequired: 'manualblocks.collection.get',
     },
     hasAutomatedPatronBlocks: {

--- a/src/routes/LoansListingContainer.js
+++ b/src/routes/LoansListingContainer.js
@@ -34,7 +34,7 @@ class LoansListingContainer extends React.Component {
     loansHistory: {
       type: 'okapi',
       records: 'loans',
-      path: 'circulation/loans?query=(userId=:{id}) sortby id&limit=100000',
+      path: 'circulation/loans?query=(userId==:{id}) sortby id&limit=100000',
       permissionsRequired: 'circulation.loans.collection.get',
       shouldRefresh: (_, action, refresh) => {
         const { path } = action.meta;
@@ -51,7 +51,7 @@ class LoansListingContainer extends React.Component {
     hasManualPatronBlocks: {
       type: 'okapi',
       records: 'manualblocks',
-      path: 'manualblocks?query=(userId=:{id})&limit=100',
+      path: 'manualblocks?query=(userId==:{id})&limit=100',
       permissionsRequired: 'manualblocks.collection.get',
     },
     hasAutomatedPatronBlocks: {
@@ -71,7 +71,7 @@ class LoansListingContainer extends React.Component {
     loanAccount: {
       type: 'okapi',
       records: 'accounts',
-      path: 'accounts?query=userId=:{id}&limit=10000',
+      path: 'accounts?query=userId==:{id}&limit=10000',
     },
     renew: {
       fetch: false,

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -26,7 +26,7 @@ class UserRecordContainer extends React.Component {
     hasManualPatronBlocks: {
       type: 'okapi',
       records: 'manualblocks',
-      path: 'manualblocks?query=(userId=:{id})&limit=100',
+      path: 'manualblocks?query=(userId==:{id})&limit=100',
       permissionsRequired: 'manualblocks.collection.get',
     },
     hasAutomatedPatronBlocks: {
@@ -39,7 +39,7 @@ class UserRecordContainer extends React.Component {
     loansHistory: {
       type: 'okapi',
       records: 'loans',
-      path: 'circulation/loans?query=(userId=:{id}) sortby id&limit=100',
+      path: 'circulation/loans?query=(userId==:{id}) sortby id&limit=100',
       permissionsRequired: 'circulation.loans.collection.get',
     },
     patronGroups: {


### PR DESCRIPTION
Use `==` instead of `=` for more efficient queries.

Refs [PERF-62](https://issues.folio.org/browse/PERF-62)