### PR TITLE
increment ui-plugin-find-user for stripes compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Trim email address in user record to remove blanks. Fixes UIU-1528.
 * `withRenew` should include in-transit items when calculating the open-request-count. Fixes UIU-1254.
 * Restore `CommandList`, `HasCommand` wrappers now that they don't leak memory. Refs UIU-1457.
+* Increment `@folio/plugin-find-user` to `v3.0.0` for `@folio/stripes` `v4.0` compatibility.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -714,7 +714,7 @@
     "react-router-dom": "*"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^2.0.0"
+    "@folio/plugin-find-user": "^3.0.0"
   },
   "resolutions": {
     "moment": "~2.24.0"


### PR DESCRIPTION
`@folio/ui-plugin-find-user` must be updated for compatibility with
`@folio/stripes` `v4.0.0`.