### PR TITLE
UIU-1675: Add validation check for not decimal values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `withRenew` should include in-transit items when calculating the open-request-count. Fixes UIU-1254.
 * Restore `CommandList`, `HasCommand` wrappers now that they don't leak memory. Refs UIU-1457.
 * Retrieve up to 200 patron groups when setting Fee/Fine limits. Refs UIU-1715.
+* Add validation to integer values for patron block limits. Refs UIU-1675.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/settings/patronBlocks/Limits/LimitsForm.js
+++ b/src/settings/patronBlocks/Limits/LimitsForm.js
@@ -22,16 +22,25 @@ import { feeFineBalanceId } from '../../../constants';
 
 import css from '../patronBlocks.css';
 
+function isInteger(value) {
+  return value % 1 === 0;
+}
+
 function validation(value, min, max) {
   const numberValue = toNumber(value);
+  const errorMessage = (
+    <FormattedMessage
+      id="ui-users.settings.limits.validation.message"
+      values={{ min, max }}
+    />
+  );
 
   if (numberValue < min || numberValue > max) {
-    return (
-      <FormattedMessage
-        id="ui-users.settings.limits.validation.message"
-        values={{ min, max }}
-      />
-    );
+    return errorMessage;
+  }
+
+  if (isInteger(min) && !isInteger(value) && !Number.isNaN(value)) {
+    return errorMessage;
   }
 
   return null;

--- a/src/settings/patronBlocks/Limits/LimitsForm.js
+++ b/src/settings/patronBlocks/Limits/LimitsForm.js
@@ -39,7 +39,7 @@ function validation(value, min, max) {
     return errorMessage;
   }
 
-  if (isInteger(min) && !isInteger(value) && !Number.isNaN(value)) {
+  if (isInteger(min) && !isInteger(numberValue) && !Number.isNaN(numberValue)) {
     return errorMessage;
   }
 

--- a/test/bigtest/tests/patron-blocks/settings-limits-form-test.js
+++ b/test/bigtest/tests/patron-blocks/settings-limits-form-test.js
@@ -104,14 +104,15 @@ describe('Patron blocks limits form', () => {
       });
     });
 
-    describe('set float limit value for fee fine limit', () => {
+    describe('save float limit value for fee fine limit', () => {
       beforeEach(async function () {
         await SettingsLimitsForm.limitField(5)
           .fillAndBlur(12.5);
+        await SettingsLimitsForm.saveButton.click();
       });
 
-      it('should show error message', () => {
-        expect(SettingsLimitsForm.errorMessage.isPresent).to.be.false;
+      it('should appear callout message', () => {
+        expect(SettingsLimitsForm.calloutMessage.successCalloutIsPresent).to.be.true;
       });
     });
   });

--- a/test/bigtest/tests/patron-blocks/settings-limits-form-test.js
+++ b/test/bigtest/tests/patron-blocks/settings-limits-form-test.js
@@ -80,6 +80,18 @@ describe('Patron blocks limits form', () => {
       });
     });
 
+    describe('set float limit value', () => {
+      beforeEach(async function () {
+        await SettingsLimitsForm.limitField(0)
+          .fillAndBlur(12.5);
+      });
+
+      it('should show error message', () => {
+        expect(SettingsLimitsForm.errorMessage.isPresent).to.be.true;
+        expect(SettingsLimitsForm.errorMessage.text).to.equal(validationMessage);
+      });
+    });
+
     describe('set invalid limit value for fee fine limit', () => {
       beforeEach(async function () {
         await SettingsLimitsForm.limitField(5)
@@ -89,6 +101,17 @@ describe('Patron blocks limits form', () => {
       it('should show error message', () => {
         expect(SettingsLimitsForm.errorMessage.isPresent).to.be.true;
         expect(SettingsLimitsForm.errorMessage.text).to.equal(feeFineValidationMessage);
+      });
+    });
+
+    describe('set float limit value for fee fine limit', () => {
+      beforeEach(async function () {
+        await SettingsLimitsForm.limitField(5)
+          .fillAndBlur(12.5);
+      });
+
+      it('should show error message', () => {
+        expect(SettingsLimitsForm.errorMessage.isPresent).to.be.false;
       });
     });
   });


### PR DESCRIPTION
# Description
For patron block limits are allowed only integers values, but only for `Maximum outstanding fee/fine balance` condition allowed both decimal and integers.
# Issue
https://issues.folio.org/browse/UIU-1675
# Screenshot
![image](https://user-images.githubusercontent.com/55694637/85755907-09840800-b717-11ea-8f58-508c1a722056.png)
