### PR TITLE
UIU-1669: Fix feefine details link

### DIFF
--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -168,9 +168,10 @@ class LoanDetails extends React.Component {
   }
 
   feefinedetails = (e) => {
-    const { history, match: { params } } = this.props;
-    const { feesFines: { accounts } } = this.state;
+    const { history, match: { params }, resources } = this.props;
+    const accounts = resources?.loanAccountsActions?.records ?? [];
     const loan = this.loan || {};
+
     if (accounts.length === 1) {
       nav.onClickViewAccountActionsHistory(e, { id: accounts[0].id }, history, params);
     } else if (accounts.length > 1) {


### PR DESCRIPTION
This is a continuation of work done under https://github.com/folio-org/ui-users/pull/1392 which belongs to

https://issues.folio.org/browse/UIU-1669

The link to the feefine details was broken after the refactoring done in  https://github.com/folio-org/ui-users/pull/1392