### PR TITLE
UIU-1736:Fix Receive a toast error that maybe tied to custom field permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Refresh Fine incurred field when item declared lost. Fixes UIU-1669.
 * Add validation to integer values for patron block limits. Refs UIU-1675.
 * Increase limits for `ChargeFeesFines`. Refs UIU-1722.
+* Fix Custom Fields related error toast notification in User Details page. Fixes UIU-1736.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -72,7 +72,10 @@
           "users.item.get",
           "usergroups.collection.get",
           "login.item.get",
-          "configuration.entries.collection.get"
+          "configuration.entries.collection.get",
+          "user-settings.custom-fields.collection.get",
+          "user-settings.custom-fields.item.get",
+          "user-settings.custom-fields.item.stats.get"
         ],
         "visible": true
       },
@@ -256,9 +259,6 @@
         "permissionName": "ui-users.settings.customfields.view",
         "displayName": "Settings (Users): Can view custom fields",
         "subPermissions": [
-          "user-settings.custom-fields.collection.get",
-          "user-settings.custom-fields.item.get",
-          "user-settings.custom-fields.item.stats.get",
           "settings.users.enabled",
           "configuration.entries.collection.get"
         ],

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -104,7 +104,6 @@ class LoanDetails extends React.Component {
       nonRenewedLoanItems: [],
       nonRenewedLoansModalOpen: false,
       changeDueDateDialogOpen: false,
-      feesFines: {},
       patronBlockedModal: false,
     };
   }


### PR DESCRIPTION
## Purpose
* Fix permissions so that get Custom Fields requests are allowed for users who don't have Settings permissions, but have view user details permissions

## Issue
[UIU-1736](https://issues.folio.org/browse/UIU-1736)