### PR TITLE
UIU-1714: Prevent declaring an item lost if it is already lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Increase limits for `ChargeFeesFines`. Refs UIU-1722.
 * Fix Custom Fields related error toast notification in User Details page. Fixes UIU-1736.
 * Generate overdue loans report via pagination. Fixes UIU-1747.
+* Prevent declaring an item lost if it is already lost. Fixes UIU-1714.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/LoanActionDialog/LoanActionDialog.js
+++ b/src/components/LoanActionDialog/LoanActionDialog.js
@@ -12,6 +12,7 @@ class LoanActionDialog extends React.Component {
     loan: PropTypes.object.isRequired,
     loanAction: PropTypes.string.isRequired,
     modalLabel: PropTypes.object.isRequired,
+    disableButton: PropTypes.func,
   };
 
   render() {
@@ -21,6 +22,7 @@ class LoanActionDialog extends React.Component {
       loan,
       loanAction,
       modalLabel,
+      disableButton,
     } = this.props;
 
     if (!loan) return null;
@@ -39,6 +41,7 @@ class LoanActionDialog extends React.Component {
           loanAction={loanAction}
           loan={loan}
           onClose={onClose}
+          disableButton={disableButton}
         />
       </Modal>
     );

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -61,6 +61,11 @@ class ModalContent extends React.Component {
     loanAction: PropTypes.string.isRequired,
     loan: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
+    disableButton: PropTypes.func,
+  };
+
+  static defaultProps = {
+    disableButton: () => {},
   };
 
   constructor(props) {
@@ -96,6 +101,7 @@ class ModalContent extends React.Component {
         },
       },
       onClose,
+      disableButton,
     } = this.props;
 
     const requestData = { comment: additionalInfo };
@@ -108,6 +114,8 @@ class ModalContent extends React.Component {
       requestData.servicePointId = curServicePoint?.id;
       requestData.declaredLostDateTime = new Date().toISOString();
     }
+
+    disableButton();
 
     await POST(requestData);
 

--- a/src/components/Wrappers/withDeclareLost.js
+++ b/src/components/Wrappers/withDeclareLost.js
@@ -12,6 +12,7 @@ const withDeclareLost = WrappedComponent => class WithDeclareLost extends React.
     this.state = {
       declareLostDialogOpen: false,
       loan: null,
+      declarationInProgress: false,
     };
   }
 
@@ -26,9 +27,18 @@ const withDeclareLost = WrappedComponent => class WithDeclareLost extends React.
     this.setState({ declareLostDialogOpen: false });
   }
 
+  disableButton = () => {
+    this.setState({ declarationInProgress: true });
+  }
+
+  enableButton = () => {
+    this.setState({ declarationInProgress: false });
+  }
+
   render() {
     const {
       declareLostDialogOpen,
+      declarationInProgress,
       loan,
     } = this.state;
 
@@ -38,6 +48,8 @@ const withDeclareLost = WrappedComponent => class WithDeclareLost extends React.
       <>
         <WrappedComponent
           declareLost={this.declareLost}
+          declarationInProgress={declarationInProgress}
+          enableButton={this.enableButton}
           {...this.props}
         />
         { loan &&
@@ -47,6 +59,7 @@ const withDeclareLost = WrappedComponent => class WithDeclareLost extends React.
             modalLabel={modalLabel}
             open={declareLostDialogOpen}
             onClose={this.hideDeclareLostDialog}
+            disableButton={this.disableButton}
           />
         }
       </>

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -81,11 +81,17 @@ class LoanDetails extends React.Component {
     declareLost: PropTypes.func,
     markAsMissing: PropTypes.func,
     claimReturned: PropTypes.func,
+    enableButton: PropTypes.func,
+    declarationInProgress: PropTypes.bool,
     patronBlocks: PropTypes.arrayOf(PropTypes.object),
     intl: PropTypes.object.isRequired,
     match: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
+  };
+
+  static defaultProps = {
+    enableButton: () => {},
   };
 
   constructor(props) {
@@ -106,6 +112,15 @@ class LoanDetails extends React.Component {
       changeDueDateDialogOpen: false,
       patronBlockedModal: false,
     };
+  }
+
+  componentDidUpdate(prevProps) {
+    const prevItemStatus = prevProps.loan?.item.status?.name;
+    const thistItemStatus = this.props.loan?.item.status?.name;
+
+    if (prevItemStatus && prevItemStatus !== thistItemStatus) {
+      this.props.enableButton();
+    }
   }
 
   getContributorslist(loan) {
@@ -281,6 +296,7 @@ class LoanDetails extends React.Component {
       declareLost,
       markAsMissing,
       claimReturned,
+      declarationInProgress,
     } = this.props;
 
     const {
@@ -433,7 +449,7 @@ class LoanDetails extends React.Component {
                 <IfPermission perm="ui-users.loans.declare-item-lost">
                   <Button
                     data-test-declare-lost-button
-                    disabled={buttonDisabled || isDeclaredLostItem}
+                    disabled={declarationInProgress || buttonDisabled || isDeclaredLostItem}
                     buttonStyle="primary"
                     onClick={() => declareLost(loan)}
                   >

--- a/test/bigtest/tests/declare-lost-test.js
+++ b/test/bigtest/tests/declare-lost-test.js
@@ -271,4 +271,37 @@ describe('Declare Lost', () => {
       expect(LoanActionsHistory.lostDate.value.text).to.not.equal('-');
     });
   });
+
+  describe('Visiting loan details page with checked out item', () => {
+    beforeEach(async function () {
+      const loan = this.server.create('loan', {
+        status: { name: 'Open' },
+        loanPolicyId: 'test',
+        action: 'checkedOut',
+        actionComment: 'Checked out confirmation',
+        item: { status: { name: 'Checked out' } },
+        itemStatus: 'Checked out',
+      });
+
+      this.visit(`/users/${loan.userId}/loans/view/${loan.id}`);
+    });
+
+    describe('clicking on declare lost button twice', () => {
+      beforeEach(async function () {
+        await LoanActionsHistory.declareLostButton.click();
+        await OpenLoansInteractor.declareLostDialog.additionalInfoTextArea.focus();
+        await OpenLoansInteractor.declareLostDialog.additionalInfoTextArea.fill('some text');
+        await OpenLoansInteractor.declareLostDialog.confirmButton.click();
+        await LoanActionsHistory.declareLostButton.click();
+      });
+
+      it('should display disabled declare lost button', () => {
+        expect(LoanActionsHistory.isDeclareLostButtonDisabled).to.be.true;
+      });
+
+      it('should not display declare lost dialog', () => {
+        expect(OpenLoansInteractor.declareLostDialog.isPresent).to.be.false;
+      });
+    });
+  });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1714

### Purpose
The purpose of this PR is to make it impossible to declare an item lost more than once in a row.

### Approach
The `Declare lost` button was disabled for the duration of the previous `declare lost` action.

### Demo
![prevent_declare_lost_twice](https://user-images.githubusercontent.com/49517355/86394437-4320ba00-bca7-11ea-89b2-53ce358b8afd.gif)
