### PR TITLE
UIU-1712: Add servicePointId property when overriding a loan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix Custom Fields related error toast notification in User Details page. Fixes UIU-1736.
 * Generate overdue loans report via pagination. Fixes UIU-1747.
 * Prevent declaring an item lost if it is already lost. Fixes UIU-1714.
+* Add `servicePointId` property when overriding a loan. Refs UIU-1712.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/BulkOverrideDialog/BulkOverrideInfo.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideInfo.js
@@ -134,6 +134,13 @@ class BulkOverrideInfo extends React.Component {
       user: {
         barcode: userBarcode
       },
+      stripes: {
+        user: {
+          user: {
+            curServicePoint,
+          },
+        },
+      },
       onCancel,
       onCloseRenewModal,
     } = this.props;
@@ -149,7 +156,8 @@ class BulkOverrideInfo extends React.Component {
             userBarcode,
             itemBarcode: barcode,
             comment: additionalInfo,
-            ...(datetime && { dueDate: datetime })
+            servicePointId: curServicePoint?.id,
+            ...(datetime && { dueDate: datetime }),
           }
         );
       }


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1712

### Purpose
Add `servicePointId` property to the request when the user overrides a loan.