### PR TITLE
UIU-1754: Change capitalization of sections in User Information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix Custom Fields related error toast notification in User Details page. Fixes UIU-1736.
 * Generate overdue loans report via pagination. Fixes UIU-1747.
 * Prevent declaring an item lost if it is already lost. Fixes UIU-1714.
+* Change capitalization of sections in User Information. Refs UIU-1754.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.js
@@ -50,7 +50,7 @@ const EditContactInfo = ({
       open={expanded}
       id={accordionId}
       onToggle={onToggle}
-      label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.contact.contactInformation" /></Headline>}
+      label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.contact.contactInfo" /></Headline>}
     >
       <Row>
         <Col xs={12} md={3}>

--- a/src/components/UserDetailSections/ContactInfo/ContactInfo.js
+++ b/src/components/UserDetailSections/ContactInfo/ContactInfo.js
@@ -28,7 +28,7 @@ const ContactInfo = ({
       open={expanded}
       id={accordionId}
       onToggle={onToggle}
-      label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.contact.contactInformation" /></Headline>}
+      label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.contact.contactInfo" /></Headline>}
     >
       <Row>
         <Col xs={3}>

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.js
@@ -249,7 +249,7 @@ class PatronBlock extends React.Component {
       />;
     const title =
       <Headline size="large" tag="h3">
-        <FormattedMessage id="ui-users.blocks.label" />
+        <FormattedMessage id="ui-users.settings.patronBlocks" />
         {(hasPatronBlocks) ? <Icon size="medium" icon="exclamation-circle" status="error" /> : ''}
       </Headline>;
 

--- a/test/bigtest/tests/patron-blocks-test.js
+++ b/test/bigtest/tests/patron-blocks-test.js
@@ -27,7 +27,7 @@ describe('Test Patron Blocks section', () => {
       });
 
       it('displays Patron Blocks label section', () => {
-        expect(PatronBlocksInteractor.label).to.equal(translations['blocks.label']);
+        expect(PatronBlocksInteractor.label).to.equal(translations['settings.patronBlocks']);
       });
 
       it('renders proper amount of rows', () => {
@@ -166,11 +166,11 @@ describe('Test Patron Blocks section', () => {
         await PatronBlocksInteractor.whenBlocksLoaded();
       });
 
-      it('displays Patron Blocks label section', () => {
-        expect(PatronBlocksInteractor.label).to.equal(translations['blocks.label']);
+      it('displays Patron blocks label section', () => {
+        expect(PatronBlocksInteractor.label).to.equal(translations['settings.patronBlocks']);
       });
 
-      it('displays Patron Blocks banner', () => {
+      it('displays Patron blocks banner', () => {
         expect(PatronBlocksInteractor.patronBlockMessage.isPresent).to.be.true;
       });
 

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -218,7 +218,7 @@
   "extended.createPasswordModal.linkWasSent": "A create password link was sent to:",
   "extended.createPasswordModal.linkInstructions": "The following link can be sent if the email was not received",
 
-  "contact.contactInformation": "Contact Information",
+  "contact.contactInfo": "Contact information",
   "contact.email": "Email",
   "contact.phone": "Phone",
   "contact.mobilePhone": "Mobile phone",
@@ -589,7 +589,6 @@
   "blocks.columns.requests": "Requests",
   "blocks.columns.renewals": "Renewals",
   "blocks.buttons.add": "Create block",
-  "blocks.label": "Patron Blocks",
   "blocks.reason": "Reason for block",
   "blocks.modal.header": "Patron blocked from renewing",
   "blocks.detailsButton": "View block details",


### PR DESCRIPTION
# Description
Change capitalization of sections in User Information:

`Patron Blocks` section should be `Patron blocks`
`Contact Information` section should be `Contract information`
# Task
https://issues.folio.org/browse/UIU-1754