### PR TITLE
UIU-1756: fix buttons layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Prevent declaring an item lost if it is already lost. Fixes UIU-1714.
 * Add `servicePointId` property when overriding a loan. Refs UIU-1712.
 * Change capitalization of sections in User Information. Refs UIU-1754.
+* Fix buttons layout in `Warning modal`. Refs UIU-1756. 
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/Accounts/Actions/WarningModal.js
+++ b/src/components/Accounts/Actions/WarningModal.js
@@ -218,7 +218,10 @@ class WarningModal extends React.Component {
             />
           </Col>
         </Row>
-        <Row end="xs">
+        <Row
+          end="xs"
+          className={css.lastRow}
+        >
           <Col xs>
             <Button id="warningTransferCancel" onClick={this.props.onClose}><FormattedMessage id="ui-users.feefines.modal.cancel" /></Button>
             <Button id="warningTransferContinue" disabled={hasClosedAccounts || values.length === 0} buttonStyle="primary" onClick={this.onClickContinue}><FormattedMessage id="ui-users.feefines.modal.submit" /></Button>

--- a/src/components/Accounts/Actions/modal.css
+++ b/src/components/Accounts/Actions/modal.css
@@ -8,3 +8,7 @@
 .alertDetails {
   color: var(--error);
 }
+
+.lastRow {
+  padding-top: var(--gutter-static-two-thirds);
+}


### PR DESCRIPTION
# Description
Fix button placement in pay/waive/transfer fees/fines 'deselect' modal (the buttons should not be so close to the last row of the table).
# Issue
https://issues.folio.org/browse/UIU-1756
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/86897559-3e795d00-c110-11ea-9d57-b42df3224166.png)
**After**
![image](https://user-images.githubusercontent.com/55694637/86897596-4e913c80-c110-11ea-9269-59e1f1475293.png)
