### PR TITLE
include MAX_RECORDS constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 4.0.3 (IN PROGRESS)
+
+* Include `MAX_RECORDS` constant, used by `ChargeFeesFinesContainer`.
+
 ## [4.0.2](https://github.com/folio-org/ui-users/tree/v4.0.2) (2020-07-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v4.0.1...v4.0.2)
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -52,3 +52,7 @@ export const statusFilter = [
  All conditions (thare are 6 of them) are always present on BE
  with hardcoded ids for now. */
 export const feeFineBalanceId = 'cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a';
+
+/* how many records to retrieve, instead of the default 10, form an API endpoint */
+export const MAX_RECORDS = '10000';
+


### PR DESCRIPTION
`MAX_RECORDS` was added to `master` in a PR separate to those that were cherry-picked onto the `b4.0` branch, but we need it here as `ChargeFeesFinesContainer` makes use of it.