### PR TITLE
UIU-1755: Change '-' to 'Default' if default notice exists at Fee/Fine: Manual Charges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Prevent declaring an item lost if it is already lost. Fixes UIU-1714.
 * Add `servicePointId` property when overriding a loan. Refs UIU-1712.
 * Change capitalization of sections in User Information. Refs UIU-1754.
+* Change `-` to `Default` if default notice exists at Fee/Fine: Manual Charges. Refs UIU-1755.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -93,7 +93,7 @@ class FeeFineSettings extends React.Component {
     this.state = {
       ownerId: '',
       owners: [],
-      templates: []
+      templates: [],
     };
 
     this.connectedControlledVocab = props.stripes.connect(ControlledVocab);
@@ -221,6 +221,16 @@ class FeeFineSettings extends React.Component {
     return filterOwners;
   }
 
+  getDefaultNotices = () => {
+    const { owners, ownerId } = this.state;
+    const { defaultActionNoticeId, defaultChargeNoticeId } = owners.find(o => o.id === ownerId) || {};
+
+    return {
+      defaultChargeNoticeId,
+      defaultActionNoticeId,
+    };
+  }
+
   onUpdateOwner(item) {
     const { owners, ownerId } = this.state;
     const owner = owners.find(o => o.id === ownerId) || {};
@@ -228,6 +238,24 @@ class FeeFineSettings extends React.Component {
     owner.defaultActionNoticeId = item.defaultActionNoticeId;
     this.props.mutator.activeRecord.update({ ownerId });
     return this.props.mutator.owners.PUT(owner);
+  }
+
+  getNotice = (noticeTypeId, noticeType) => {
+    const { templates } = this.state;
+    const defaultNotices = this.getDefaultNotices();
+    const defaultNoticeId = defaultNotices[`default${noticeType}NoticeId`];
+    const defaultMessage = <FormattedMessage id="ui-users.settings.default" />;
+    let templateName = templates.find(t => t.id === noticeTypeId) || {};
+
+    if (noticeTypeId) {
+      templateName = templateName?.name;
+    } else if (!noticeTypeId && defaultNoticeId) {
+      templateName = defaultMessage;
+    } else {
+      templateName = '-';
+    }
+
+    return templateName;
   }
 
   render() {
@@ -263,8 +291,8 @@ class FeeFineSettings extends React.Component {
 
     const formatter = {
       'defaultAmount': (value) => (value.defaultAmount ? parseFloat(value.defaultAmount).toFixed(2) : '-'),
-      'chargeNoticeId': (value) => (value.chargeNoticeId ? ((templates.find(t => t.id === value.chargeNoticeId) || {}).name) : '-'),
-      'actionNoticeId': (value) => (value.actionNoticeId ? ((templates.find(t => t.id === value.actionNoticeId) || {}).name) : '-'),
+      'chargeNoticeId': ({ chargeNoticeId }) => this.getNotice(chargeNoticeId, 'Charge'),
+      'actionNoticeId': ({ actionNoticeId }) => this.getNotice(actionNoticeId, 'Action'),
     };
 
 

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -9,6 +9,7 @@ import { Field } from 'redux-form';
 import {
   Select,
   Label,
+  NoValue,
 } from '@folio/stripes/components';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { stripesConnect, withStripes } from '@folio/stripes/core';
@@ -252,7 +253,7 @@ class FeeFineSettings extends React.Component {
     } else if (!noticeTypeId && defaultNoticeId) {
       templateName = defaultMessage;
     } else {
-      templateName = '-';
+      templateName = <NoValue />;
     }
 
     return templateName;
@@ -290,7 +291,7 @@ class FeeFineSettings extends React.Component {
     };
 
     const formatter = {
-      'defaultAmount': (value) => (value.defaultAmount ? parseFloat(value.defaultAmount).toFixed(2) : '-'),
+      'defaultAmount': (value) => (value.defaultAmount ? parseFloat(value.defaultAmount).toFixed(2) : <NoValue />),
       'chargeNoticeId': ({ chargeNoticeId }) => this.getNotice(chargeNoticeId, 'Charge'),
       'actionNoticeId': ({ actionNoticeId }) => this.getNotice(actionNoticeId, 'Action'),
     };

--- a/test/bigtest/tests/settings-manual-charges-test.js
+++ b/test/bigtest/tests/settings-manual-charges-test.js
@@ -6,6 +6,8 @@ import {
   it,
 } from '@bigtest/mocha';
 
+import translations from '../../../translations/ui-users/en';
+
 import setupApplication from '../helpers/setup-application';
 import FeeFineInteractor from '../interactors/settings-feefine';
 
@@ -167,8 +169,12 @@ describe('Manual charges', () => {
       });
 
       it('renders proper values after update', () => {
+        const lastRow = FeeFineInteractor.list.rows(1);
+
         expect(FeeFineInteractor.notice.ownerChargeNoticeValue).to.equal('Template 3');
         expect(FeeFineInteractor.notice.ownerActionNoticeValue).to.equal('Template 2');
+        expect(lastRow.cells(2).text).to.equal(translations['settings.default']);
+        expect(lastRow.cells(3).text).to.equal(translations['settings.default']);
       });
     });
 

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -115,6 +115,7 @@
   "settings.limits.callout.message": "The patron block limit for patron group <strong>{patronGroup}</strong> has been successfully <strong>updated</strong>.",
   "settings.limits.callout.error": "Something went wrong",
   "settings.limits.validation.message": "Must be blank or a number from {min, number} to {max, number}",
+  "settings.default": "Default",
 
   "loans.columns.title": "Item title",
   "loans.columns.itemStatus": "Item status",


### PR DESCRIPTION
# Description
We need to differ when there was not setted `charge/action notices` and display `-`, from when there was not setted `charge/action notices` but there are exist `charge/action notices` by default and display `Default`. 
 # Task
https://issues.folio.org/browse/UIU-1755
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/86949374-385a9f00-c157-11ea-96a6-6dd7f277a63d.png)

**After**
![image](https://user-images.githubusercontent.com/55694637/86949439-4f00f600-c157-11ea-80ef-501e124b7663.png)
