### PR TITLE
UIU-1760: Change capitalization of sections in User Information

### DIFF
--- a/src/components/EditSections/EditProxy/EditProxy.js
+++ b/src/components/EditSections/EditProxy/EditProxy.js
@@ -28,7 +28,7 @@ const EditProxy = (props) => {
     getWarning,
   } = props;
 
-  const proxySponsor = <FormattedMessage id="ui-users.permissions.proxySponsor" />;
+  const proxySponsor = <FormattedMessage id="ui-users.permissions.proxy.sponsor" />;
 
   return (
     <IfPermission perm="ui-users.editproxies">

--- a/src/components/UserDetailSections/ProxyPermissions/ProxyPermissions.js
+++ b/src/components/UserDetailSections/ProxyPermissions/ProxyPermissions.js
@@ -25,7 +25,7 @@ const ProxyPermissions = (props) => {
 
   const isProxyFor = <FormattedMessage id="ui-users.permissions.isProxyFor" values={{ name: fullName }} />;
   const isSponsorOf = <FormattedMessage id="ui-users.permissions.isSponsorOf" values={{ name: fullName }} />;
-  const proxySponsor = <FormattedMessage id="ui-users.permissions.proxySponsor" />;
+  const proxySponsor = <FormattedMessage id="ui-users.permissions.proxy.sponsor" />;
 
   return (
     <Accordion

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -150,7 +150,7 @@ class UserAccounts extends React.Component {
         open={expanded}
         id={accordionId}
         onToggle={onToggle}
-        label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.accounts.title" /></Headline>}
+        label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.accounts.title.feeFine" /></Headline>}
         displayWhenClosed={displayWhenClosed}
         displayWhenOpen={displayWhenOpen}
       >

--- a/src/views/AccountsListing/AccountsListing.js
+++ b/src/views/AccountsListing/AccountsListing.js
@@ -487,7 +487,7 @@ class AccountsHistory extends React.Component {
           padContent={false}
           onClose={() => { history.push(`/users/preview/${params.id}`); }}
           paneTitle={(
-            <FormattedMessage id="ui-users.accounts.title">
+            <FormattedMessage id="ui-users.accounts.title.feeFine">
               {(title) => (
                 `${title} - ${getFullName(user)} ${patronGroup ? '(' + _.upperFirst(patronGroup.group) + ')' : ''}`
               )}

--- a/test/bigtest/tests/fee-fine-history-test.js
+++ b/test/bigtest/tests/fee-fine-history-test.js
@@ -17,7 +17,7 @@ describe('Test Fee/Fine History', () => {
     });
 
     it('displays label section Fees/Fines', () => {
-      expect(FeeFineHistoryInteractor.section).to.equal('Fees/Fines');
+      expect(FeeFineHistoryInteractor.section).to.equal('Fees/fines');
     });
 
     describe('displays section Fees/Fines', () => {
@@ -37,7 +37,7 @@ describe('Test Fee/Fine History', () => {
         });
 
         it('displays the pane title menu', () => {
-          expect(FeeFineHistoryInteractor.paneTitle).to.string('Fees/Fines -');
+          expect(FeeFineHistoryInteractor.paneTitle).to.string('Fees/fines -');
           expect(FeeFineHistoryInteractor.paneSub).to.string('Outstanding Balance');
           expect(FeeFineHistoryInteractor.labelMenu).to.string('Open fees/fines for');
           expect(FeeFineHistoryInteractor.outstandingMenu).to.string('Outstanding Balance');

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -184,7 +184,7 @@
   "permissions.userPermissions": "User permissions",
   "permissions.isProxyFor": "Sponsors ({name} can borrow on behalf of these people)",
   "permissions.isSponsorOf": "Proxies (these people can borrow on behalf of {name})",
-  "permissions.proxySponsor": "Proxy/Sponsor",
+  "permissions.proxy.sponsor": "Proxy/sponsor",
   "permissions.assignedPermissions": "Assigned permissions",
   "permissions.untitledPermissionSet": "Untitled permission set",
   "permissions.closePermissionSetDialog": "Close permission set dialog",
@@ -312,7 +312,7 @@
   "status": "Status",
   "selectColumns": "Select Columns",
 
-  "accounts.title": "Fees/Fines",
+  "accounts.title.feeFine": "Fees/fines",
   "accounts.outstandingBalance": "Outstanding Balance: ",
   "accounts.header": "Fee/fine details - {userName} ({patronGroup})",
   "accounts.outstanding": "Outstanding Balance: {amount}",


### PR DESCRIPTION
# Description
Change capitalization of sections in User Information:

`Proxy/Sponsor` changed to `Proxy/sponsor`
`Fees/Fines` changed to `Fees/fines`
# Task
https://issues.folio.org/browse/UIU-1760