### PR TITLE
UIU-1757: Add permission to anonymize manually closed loans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fix buttons layout in `Warning modal`. Refs UIU-1756.
 * Change `-` to `Default` if default notice exists at Fee/Fine: Manual Charges. Refs UIU-1755.
 * `Fee/fines details` not always include `Service Point` as `Created at`. Refs UIU-1725.
+* Add permission to anonymize manually closed loans. Fixes UIU-1757.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -579,6 +579,7 @@
           "circulation.loans.declare-item-lost.post",
           "circulation.loans.claim-item-returned.post",
           "circulation.loans.declare-claimed-returned-item-as-missing.post",
+          "circulation.loans.collection.anonymize.user.post",
           "ui-users.loans.renew-override",
           "circulation.loans.item.put",
           "circulation.renew-by-barcode.post",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1757

### Purpose
Add permission to anonymize manually closed loans.