### PR TITLE
UITAG-29 provide tag-related permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Change `-` to `Default` if default notice exists at Fee/Fine: Manual Charges. Refs UIU-1755.
 * `Fee/fines details` not always include `Service Point` as `Created at`. Refs UIU-1725.
 * Add permission to anonymize manually closed loans. Fixes UIU-1757.
+* Include tag-related permissions in `ui-users.edit` permission. Refs UITAG-29.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -87,7 +87,9 @@
           "ui-users.view",
           "users-bl.item.put",
           "users.item.put",
-          "login.item.put"
+          "login.item.put",
+          "tags.collection.get",
+          "tags.item.post"
         ],
         "visible": true
       },


### PR DESCRIPTION
The tag-management component would display but throw errors because
there was no way to assign tag-related permissions in the UI. The
interaction between tag-CRUD permissions and entity-CRUD permissions can
be confusing and the `<Tags>` component does not, at present, handle
discrepancies between them.

Refs [UITAG-29](https://issues.folio.org/browse/UITAG-29)