### PR TITLE
Fix servicePointUserId local resource setup

### DIFF
--- a/src/components/Wrappers/withServicePoints.js
+++ b/src/components/Wrappers/withServicePoints.js
@@ -26,7 +26,7 @@ const withServicePoints = WrappedComponent => class WithServicePointsComponent e
         accumulate: true,
         fetch: false,
       },
-      servicePointUserId: '',
+      servicePointUserId: { initialValue: '' },
       servicePointsUsers: {
         type: 'okapi',
         path: `service-points-users?query=(userId==:{id})&limit=${MAX_RECORDS}`,


### PR DESCRIPTION
This change allows for https://github.com/folio-org/stripes-connect/pull/113 to work as expected 

and the code which checks for loaded resources:

https://github.com/folio-org/ui-users/blob/master/src/views/UserEdit/UserEdit.js#L24-L42

to execute correctly.

Perhaps a better approach to cover this is to change:

https://github.com/folio-org/stripes-connect/pull/113/files#diff-4a49d72d6938725655f6ba90769adc2fR190

from default value for local resource from `null` to `{}` which will actually match with what the local resource reducer does by default:

https://github.com/folio-org/stripes-connect/blob/master/LocalResource.js#L39

I will go ahead and change that in stripes-connect and create a new PR.
