### PR TITLE
UIU-1773: Make fee/fine not allowed to be created without required information (itemId)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Add permission to anonymize manually closed loans. Fixes UIU-1757.
 * Include tag-related permissions in `ui-users.edit` permission. Refs UITAG-29.
 * Increment `@folio/stripes` to `v5.0`, `react-router` to `v5.2`.
+* Make fee/fine not allowed to be created without required information (itemId). Refs UIU-1773.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -129,7 +129,7 @@ class ChargeFeeFine extends React.Component {
     type.id = uuid();
     type.loanId = selectedLoan.id || '0';
     type.userId = this.props.user.id;
-    type.itemId = this.item.id || '0';
+    type.itemId = this.item.id;
     let commentInfo = '';
     const tagStaff = formatMessage({ id: 'ui-users.accounts.actions.tag.staff' });
     const tagPatron = formatMessage({ id: 'ui-users.accounts.actions.tag.patron' });

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -193,6 +193,7 @@ class ChargeForm extends React.Component {
       type: ((selectedLoan.item || {}).materialType || {}).name
     };
     const item = (editable) ? this.props.item : itemLoan;
+    const isDisabled = this.props.pristine || this.props.submitting || this.props.invalid || !item?.id;
     const feefineList = [];
     const ownerOptions = [];
 
@@ -219,7 +220,7 @@ class ChargeForm extends React.Component {
         </Button>
         <Button
           id="chargeAndPay"
-          disabled={this.props.pristine || this.props.submitting || this.props.invalid}
+          disabled={isDisabled}
           onClick={this.props.handleSubmit(data => this.props.onSubmit({ ...data, pay: true, notify }))}
           marginBottom0
         >
@@ -227,7 +228,7 @@ class ChargeForm extends React.Component {
         </Button>
         <Button
           id="chargeOnly"
-          disabled={this.props.pristine || this.props.submitting || this.props.invalid}
+          disabled={isDisabled}
           onClick={this.props.handleSubmit(data => this.props.onSubmit({ ...data, pay: false, notify }))}
           marginBottom0
         >

--- a/src/components/Accounts/ChargeFeeFine/ItemInfo.js
+++ b/src/components/Accounts/ChargeFeeFine/ItemInfo.js
@@ -59,6 +59,7 @@ class ItemInfo extends React.Component {
             <FormattedMessage id="ui-users.charge.item.placeholder">
               {placeholder => (
                 <TextField
+                  data-test-fee-fine-barcode
                   placeholder={placeholder}
                   disabled={!this.props.editable}
                   onChange={this.onChangeSelectItem}
@@ -68,6 +69,7 @@ class ItemInfo extends React.Component {
           </Col>
           <Col xs={2}>
             <Button
+              data-test-enter-barcode
               buttonStyle="primary"
               onClick={this.onClickSelectItem}
               disabled={!this.props.editable}

--- a/test/bigtest/interactors/charge-fee-fine.js
+++ b/test/bigtest/interactors/charge-fee-fine.js
@@ -6,8 +6,8 @@ import {
   fillable,
   clickable,
   Interactor,
+  property,
 } from '@bigtest/interactor';
-
 
 @interactor class SelectInteractor {
   selectOption = selectable();
@@ -34,8 +34,12 @@ export default @interactor class ChargeFeeFineInteractor {
   ownerSelect = new SelectInteractor('#ownerId');
   typeSelect = new SelectInteractor('#feeFineType');
   amountField = new TextFieldInteractor('#amount');
+  barcodeField = new TextFieldInteractor('[data-test-fee-fine-barcode]');
   clickCancel = clickable('#cancelCharge');
   clickSubmitChargeAndPay = clickable('#chargeAndPay');
+  submitChargeAndPayIsDisabled = property('#chargeAndPay', 'disabled');
   clickSubmitCharge = clickable('#chargeOnly');
+  submitChargeIsDisabled = property('#chargeOnly', 'disabled');
   clickConfirmCancel = clickable('[data-test-confirmation-modal-cancel-button]');
+  clickEnterBarcode = clickable('[data-test-enter-barcode]');
 }

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -658,4 +658,22 @@ export default function config() {
     automatedPatronBlocks: [],
     totalRecords: 0,
   });
+
+  this.get('/inventory/items/:barcode', ({ items }, request) => {
+    const url = new URL(request.url);
+    const cqlQuery = url.searchParams.get('query');
+
+    if (cqlQuery != null) {
+      const cqlParser = new CQLParser();
+      cqlParser.parse(cqlQuery);
+
+      if (cqlParser.tree.term) {
+        return items.where({
+          barcode: cqlParser.tree.term
+        });
+      }
+    }
+
+    return items.all();
+  });
 }

--- a/test/bigtest/network/factories/item.js
+++ b/test/bigtest/network/factories/item.js
@@ -1,0 +1,12 @@
+import { Factory } from 'miragejs';
+import faker from 'faker';
+
+export default Factory.extend({
+  barcode: () => faker.random.number(),
+  id: () => faker.random.uuid(),
+  title:() => faker.random.words(),
+  metadata: {
+    createdDate: () => faker.date.past(0.1, faker.date.past(0.1)).toString(),
+    updatedDate: () => faker.date.past(0.1).toString(),
+  },
+});

--- a/test/bigtest/network/models/item.js
+++ b/test/bigtest/network/models/item.js
@@ -1,0 +1,3 @@
+import { Model } from 'miragejs';
+
+export default Model.extend({});

--- a/test/bigtest/network/serializers/item.js
+++ b/test/bigtest/network/serializers/item.js
@@ -1,0 +1,16 @@
+import ApplicationSerializer from './application';
+
+const { isArray } = Array;
+
+export default ApplicationSerializer.extend({
+
+  serialize(...args) {
+    const json = ApplicationSerializer.prototype.serialize.apply(this, args);
+
+    if (isArray(json.items)) {
+      return { ...json, totalRecords: json.items.length };
+    }
+
+    return json.items;
+  }
+});

--- a/test/bigtest/tests/charge-fee-fine-test.js
+++ b/test/bigtest/tests/charge-fee-fine-test.js
@@ -68,6 +68,18 @@ describe('Charge fee/fine', () => {
             expect(chargeForm.amountField.value).to.equal('500.00');
           });
 
+          describe('fill item barcode', () => {
+            beforeEach(async () => {
+              await chargeForm.barcodeField.fillAndBlur('123');
+              await chargeForm.clickEnterBarcode();
+            });
+
+            it('charge buttons should be disabled', () => {
+              expect(chargeForm.submitChargeAndPayIsDisabled).to.be.true;
+              expect(chargeForm.submitChargeIsDisabled).to.be.true;
+            });
+          });
+
           describe('cancel the charge', () => {
             beforeEach(async () => {
               await chargeForm.clickCancel();


### PR DESCRIPTION
# Description
Buttons `Charge & pay now` and `Charge only` are disabled until will not inut valid item to the `Item information` field. 
# Issue
https://issues.folio.org/browse/UIU-1773
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/88088951-e9b7f680-cb93-11ea-8842-56a13f707f35.png)

**After**
![image](https://user-images.githubusercontent.com/55694637/88089037-094f1f00-cb94-11ea-859a-43ea031cd8cb.png)
![image](https://user-images.githubusercontent.com/55694637/88089333-7a8ed200-cb94-11ea-8231-893862c1dbf7.png)
