### PR TITLE
UIU-1750: Filter users by tags does not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* changed user search to filter based on tag name rather than ID.  Fixes UIU-1750
 * Trim email address in user record to remove blanks. Fixes UIU-1528.
 * `withRenew` should include in-transit items when calculating the open-request-count. Fixes UIU-1254.
 * Restore `CommandList`, `HasCommand` wrappers now that they don't leak memory. Refs UIU-1457.

--- a/src/views/UserSearch/Filters.js
+++ b/src/views/UserSearch/Filters.js
@@ -42,7 +42,7 @@ export default class Filters extends React.Component {
 
   getValuesFromResources = (type, key) => {
     const items = get(this.props.resources, `${type}.records`, [])
-      .map(item => ({ label: item[key], value: item.id }));
+      .map(item => ({ label: item[key], value: item[key] }));
     return sortBy(items, 'label');
   };
 


### PR DESCRIPTION
The source of this problem was that the tags filter in the user search 
was set to use tag ID when filtering by tag. This does not work because 
the 'tags' smart component does not store tag IDs in entity records. It 
stores the tag names as a list.  So the only way to filter for any entity,
including users, is to filter by tag name.  Changing this would require 
reworking a fairly substantial portion of the tags smart component, so I
simply changed the search in ui-users back to filtering by tag name.

refs: https://issues.folio.org/browse/UIU-1750