### PR TITLE
UIU-1791 handle known/unknown loan action values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Add permission to anonymize manually closed loans. Fixes UIU-1757.
 * Include tag-related permissions in `ui-users.edit` permission. Refs UITAG-29.
 * Increment `@folio/stripes` to `v5.0`, `react-router` to `v5.2`.
+* Handle display of loan details for `Aged to lost`, and for unknown statuses as well. Refs UIU-1791.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/data/static/loanActionMap.js
+++ b/src/components/data/static/loanActionMap.js
@@ -14,4 +14,6 @@ export default {
   'closedLoan': 'ui-users.data.loanActionMap.closedLoan',
   'checkedInReturnedByPatron': 'ui-users.data.loanActionMap.checkedInReturnedByPatron',
   'checkedInFoundByLibrary': 'ui-users.data.loanActionMap.checkedInFoundByLibrary',
+  'itemAgedToLost': 'ui-users.data.loanActionMap.itemAgedToLost',
+  'unknownAction': 'ui-users.data.loanActionMap.unknownAction',
 };

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -323,7 +323,7 @@ class LoanDetails extends React.Component {
 
     const { nonRenewedLoanItems } = this.state;
     const loanActionsFormatter = {
-      action: la => <FormattedMessage id={loanActionMap[la.action]} />,
+      action: la => <FormattedMessage id={loanActionMap[la.action] ?? loanActionMap.unknownAction} />,
       actionDate: la => <FormattedTime value={get(la, ['metadata', 'updatedDate'], '-')} day="numeric" month="numeric" year="numeric" />,
       dueDate: la => <FormattedTime value={la.dueDate} day="numeric" month="numeric" year="numeric" />,
       itemStatus: la => la.itemStatus,

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -41,6 +41,8 @@
   "data.loanActionMap.closedLoan": "Closed loan",
   "data.loanActionMap.checkedInReturnedByPatron": "Checked in (returned by patron)",
   "data.loanActionMap.checkedInFoundByLibrary": "Checked in (found by library)",
+  "data.loanActionMap.itemAgedToLost": "Aged to lost",
+  "data.loanActionMap.unknownAction": "Unknown action",
   "action": "Action",
   "dueDate": "Due date",
   "loanDate": "Loan date",


### PR DESCRIPTION
Add handling for the loan action `itemAgedToLost`, and add handling if
new, as of yet unknown statuses, are added so the UI can display
`unknown action` instead of exploding with a stacktrace when they do.

Refs [UIU-1791](https://issues.folio.org/browse/UIU-1791)