### PR TITLE
UIU-1727: Use item id instead of barcode for links to ui-requests module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Handle display of loan details for `Aged to lost`, and for unknown statuses as well. Refs UIU-1791.
 * Settings > Users > Departments CRUD. Refs UIU-1211.
 * Reorder volume/enum/chron fields in loans export (CSV). Refs UIU-1504.
+* Use item id instead of barcode for links to `ui-requests` module. Fixes UIU-1727.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -157,7 +157,7 @@ class ActionsDropdown extends React.Component {
           <Button
             buttonStyle="dropdownItem"
             data-test-dropdown-content-request-queue
-            to={getOpenRequestsPath(loan?.item?.barcode)}
+            to={getOpenRequestsPath(loan?.itemId)}
           >
             <FormattedMessage id="ui-users.loans.details.requestQueue" />
           </Button>

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -82,10 +82,10 @@ export function getOpenRequestStatusesFilterString() {
   return getFilterStatusesString(openStatusesArr);
 }
 
-export function getOpenRequestsPath(barcode) {
+export function getOpenRequestsPath(itemId) {
   const filterString = getOpenRequestStatusesFilterString();
 
-  return `/requests?filters=${filterString}&query=${barcode}&sort=Request Date`;
+  return `/requests?filters=${filterString}&query=${itemId}&sort=Request Date`;
 }
 
 export function getChargeFineToLoanPath(userId, loanId) {

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -334,7 +334,7 @@ class LoanDetails extends React.Component {
 
     const itemRequestCount = requestCounts[this.props.loan.itemId] || 0;
     const requestQueueValue = (itemRequestCount && stripes.hasPerm('ui-users.requests.all,ui-requests.all'))
-      ? (<Link to={getOpenRequestsPath(loan.item.barcode)}>{itemRequestCount}</Link>)
+      ? (<Link to={getOpenRequestsPath(loan.itemId)}>{itemRequestCount}</Link>)
       : itemRequestCount;
     const contributorsList = this.getContributorslist(loan);
     const contributorsListString = contributorsList.join(' ');


### PR DESCRIPTION
Use item id instead of barcode for links to ui-requests module.

https://issues.folio.org/browse/UIU-1727