### PR TITLE
add space after checkbox

### DIFF
--- a/src/components/Accounts/Actions/ActionModal.js
+++ b/src/components/Accounts/Actions/ActionModal.js
@@ -344,6 +344,7 @@ class ActionModal extends React.Component {
                     checked={notify}
                     inline
                   />
+                  {' '}
                   <FormattedMessage id="ui-users.accounts.notifyPatron" />
                 </Col>
               </Row>


### PR DESCRIPTION
Use FIVE characters to display one space because ESLint is awesome and
makes everything easier. **sigh** Well, the code may not look better,
but hopefully the UI does.