### PR TITLE
Fix: Breaking tests in Ui-Users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.0 (IN PROGRESS)
 
+* Fixing breaking tests.  
 * Adding fix for UIU-1801.  Removing temporary fixes to tests.
 * Temporary fix for broken tests relating to UIU-1801.  Does not resolve that issue.
 * changed user search to filter based on tag name rather than ID.  Fixes UIU-1750

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -11,6 +11,30 @@ export default function setupApplication({
   translations,
   currentUser,
 } = {}) {
+  const initialState = {
+    discovery: {
+      modules: {
+        'mod-circulation-16.0.0-SNAPSHOT.253': 'Circulation Module',
+        'mod-users-16.0.1-SNAPSHOT.121': 'users',
+        'mod-feesfines-15.8.0-SNAPSHOT.73': 'feesfines',
+        'mod-configuration-5.5.0-SNAPSHOT.80': 'configurations',
+      },
+      interfaces: {
+        'circulation-event-handlers': '0.1',
+        'circulation-rules-storage': '1.0',
+        'circulation-rules': '1.1',
+        'circulation': '9.4',
+        'configuration.prefixes': '1.1',
+        'configuration.reasons-for-closure': '1.0',
+        'configuration.suffixes': '1.1',
+        'configuration': '2.0',
+        'custom-fields': '2.0',
+        'feesfines': '15.3',
+        'users': '15.2',
+        'loan-policy-storage':'1.0',
+      },
+    },
+  };
   setupStripesCore({
     mirageOptions,
     scenarios,
@@ -21,5 +45,6 @@ export default function setupApplication({
       hasAllPerms,
     },
     currentUser,
+    initialState,
   });
 }


### PR DESCRIPTION
We determined that tests in UI-users were failing because
The discovery part of the store is now only populated after a successful
login.This caused some tests to fail because the discovery information
was missing, especially data on interfaces and modules needed for some
pages to load/ behave properly.

Refs:
https://github.com/folio-org/stripes-core/pull/907
https://github.com/folio-org/stripes-core/pull/893/files