### PR TITLE
UIU-1464: Enable renewal override for Aged to lost items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Reorder volume/enum/chron fields in loans export (CSV). Refs UIU-1504.
 * Use item id instead of barcode for links to `ui-requests` module. Fixes UIU-1727.
 * Add departments to User crate/edit/view pages. Refs UIU-1224.
+* Enable renewal override for Aged to lost items. Refs UIU-1464.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
+++ b/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
@@ -12,6 +12,10 @@ export default [
     showDueDatePicker: false,
   },
   {
+    message: 'item is Aged to lost',
+    showDueDatePicker: false,
+  },
+  {
     message: 'renewal date falls outside of date ranges in fixed loan policy',
     showDueDatePicker: true,
   },


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1464

Have you ever wanted to renew an item that had been aged to lost, but found yourself stymied by the rigid rules of circulation? Well, now you can! Sometimes. With the right power. If you really think it's a good idea.

<img width="1180" alt="Screen Shot 2020-09-01 at 4 28 52 PM" src="https://user-images.githubusercontent.com/1322242/91903062-9b0c7a80-ec70-11ea-8aac-97df0dbacfb8.png">
