### PR TITLE
UIU-1803: Include Aged to lost in loan details action history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Add departments to User crate/edit/view pages. Refs UIU-1224.
 * Enable renewal override for Aged to lost items. Refs UIU-1464.
 * Handle Aged to lost items in bulk due date change. Refs UIU-1495.
+* Include Aged to lost in loan details action history. Refs UIU-1803.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Reorder volume/enum/chron fields in loans export (CSV). Refs UIU-1504.
 * Use item id instead of barcode for links to `ui-requests` module. Fixes UIU-1727.
 * Add departments to User crate/edit/view pages. Refs UIU-1224.
+* Enable renewal override for Aged to lost items. Refs UIU-1464.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
+++ b/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
@@ -12,6 +12,10 @@ export default [
     showDueDatePicker: false,
   },
   {
+    message: 'item is Aged to lost',
+    showDueDatePicker: false,
+  },
+  {
     message: 'renewal date falls outside of date ranges in fixed loan policy',
     showDueDatePicker: true,
   },

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -328,7 +328,11 @@ class LoanDetails extends React.Component {
       actionDate: la => <FormattedTime value={get(la, ['metadata', 'updatedDate'], '-')} day="numeric" month="numeric" year="numeric" />,
       dueDate: la => <FormattedTime value={la.dueDate} day="numeric" month="numeric" year="numeric" />,
       itemStatus: la => la.itemStatus,
-      source: la => { return la.user ? <Link to={`/users/view/${la.user?.id}`}>{getFullName(la.user)}</Link> : 'System'; },
+      source: la => {
+        return la.user ?
+          <Link to={`/users/view/${la.user?.id}`}>{getFullName(la.user)}</Link> :
+          <FormattedMessage id="ui-users.loans.action.source.system" />;
+      },
       comments: ({ actionComment }) => (actionComment || '-'),
     };
 

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -328,7 +328,7 @@ class LoanDetails extends React.Component {
       actionDate: la => <FormattedTime value={get(la, ['metadata', 'updatedDate'], '-')} day="numeric" month="numeric" year="numeric" />,
       dueDate: la => <FormattedTime value={la.dueDate} day="numeric" month="numeric" year="numeric" />,
       itemStatus: la => la.itemStatus,
-      source: la => <Link to={`/users/view/${la.user?.id}`}>{getFullName(la.user)}</Link>,
+      source: la => { return la.user ? <Link to={`/users/view/${la.user?.id}`}>{getFullName(la.user)}</Link> : 'System'; },
       comments: ({ actionComment }) => (actionComment || '-'),
     };
 

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -90,6 +90,7 @@
   "loans.feeFineDetails": "Fee/fine details",
   "loans.history": "Loan action history",
   "loans.resolveClaim": "Resolve claim",
+  "loans.action.source.system": "System",
 
   "settings.label": "Users",
   "settings.general": "General",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1803

This is to ensure that Aged to lost actions are properly represented in the loan details action history table. Most of the work for this is done automatically on the backend. The one UI change needed is to insert "System" into the source column whenever it's blank in the original.

<img width="1045" alt="Screen Shot 2020-09-02 at 1 04 05 PM" src="https://user-images.githubusercontent.com/1322242/92014674-9baf1a80-ed1d-11ea-847f-efdd92c9b923.png">
