### PR TITLE
Add null checks to prior to `status` property

### DIFF
--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -116,8 +116,8 @@ class LoanDetails extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const prevItemStatus = prevProps.loan?.item.status?.name;
-    const thistItemStatus = this.props.loan?.item.status?.name;
+    const prevItemStatus = prevProps.loan?.item?.status?.name;
+    const thistItemStatus = this.props.loan?.item?.status?.name;
 
     if (prevItemStatus && prevItemStatus !== thistItemStatus) {
       this.props.enableButton();
@@ -190,7 +190,7 @@ class LoanDetails extends React.Component {
     if (accounts.length === 1) {
       nav.onClickViewAccountActionsHistory(e, { id: accounts[0].id }, history, params);
     } else if (accounts.length > 1) {
-      const open = accounts.filter(a => a.status.name === 'Open') || [];
+      const open = accounts.filter(a => a?.status?.name === 'Open') || [];
       if (open.length === accounts.length) {
         nav.onClickViewOpenAccounts(e, loan, history, params);
       } else if (open.length === 0) {
@@ -275,7 +275,7 @@ class LoanDetails extends React.Component {
       history.push(`/users/${params.id}/accounts/view/${params.accountid}`);
     }
 
-    const loanStatus = loan.status ? loan.status.name.toLowerCase() : 'open';
+    const loanStatus = loan?.status ? loan.status?.name?.toLowerCase() : 'open';
 
     history.push({
       pathname: `/users/${params.id}/loans/${loanStatus}`,


### PR DESCRIPTION
- Fixes [UIU-1802](https://issues.folio.org/browse/UIU-1802).
- Handles network failures on the loan details screen.
- Instead of the page crashing, now network errors pop up on the screen for Back-End devs to debug:

![Screen Shot 2020-09-02 at 9 55 15 AM](https://user-images.githubusercontent.com/28395235/92021741-36145b80-ed28-11ea-93c0-1133081c1567.png)
