### PR TITLE
UIU-1369: Assign permissions more efficiently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Add missing permission `departments.collection.get` permission. Fixes UIU-1812.
 * Prevent UI crashing when loading loan with deleted item. Fixes UIU-1819.
 * Remove user count from patron groups. Fixes UIU-1562.
+* Assign user permissions more efficiently. Fixes UIU-1369.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -15,11 +15,6 @@ export function getFullName(user) {
   return `${lastName}${firstName ? ', ' : ' '}${firstName}${middleName ? ' ' : ''}${middleName}`;
 }
 
-export function eachPromise(arr, fn) {
-  if (!Array.isArray(arr)) return Promise.reject(new Error('Array not found'));
-  return arr.reduce((prev, cur) => (prev.then(() => fn(cur))), Promise.resolve());
-}
-
 export function validate(item, index, items, field, label) {
   const error = {};
   for (let i = 0; i < items.length; i++) {

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -16,6 +16,7 @@ import { MAX_RECORDS } from '../constants';
 class UserRecordContainer extends React.Component {
   static manifest = Object.freeze({
     query: {},
+    permUserId: {},   // ID of the current permissions user record (see UserEdit.js)
     selUser: {
       type: 'okapi',
       path: 'users/:{id}',
@@ -83,8 +84,12 @@ class UserRecordContainer extends React.Component {
     },
     perms: {
       type: 'okapi',
-      path: 'perms/users',
-      fetch: false,
+      throwErrors: false,
+      POST: {
+        path: 'perms/users',
+      },
+      path: 'perms/users/:{id}',
+      params: { full: 'true', indexField: 'userId' },
     },
     // NOTE: 'indexField', used as a parameter in the userPermissions paths,
     // modifies the API call so that the :{userid} parameter is actually
@@ -102,6 +107,9 @@ class UserRecordContainer extends React.Component {
       GET: {
         path: 'perms/users/:{id}/permissions',
         params: { full: 'true', indexField: 'userId' },
+      },
+      PUT: {
+        path: 'perms/users/%{permUserId}',
       },
       path: 'perms/users/:{id}/permissions',
       params: { indexField: 'userId' },
@@ -151,6 +159,9 @@ class UserRecordContainer extends React.Component {
       permissions: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
       }),
+      perms: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
       query: PropTypes.object,
       patronGroups: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
@@ -167,8 +178,11 @@ class UserRecordContainer extends React.Component {
         PUT: PropTypes.func.isRequired,
       }),
       permissions: PropTypes.shape({
-        POST: PropTypes.func.isRequired,
+        PUT: PropTypes.func.isRequired,
         DELETE: PropTypes.func.isRequired,
+      }),
+      perms: PropTypes.shape({
+        POST: PropTypes.func.isRequired,
       }),
       uniquenessValidator: PropTypes.shape({
         reset: PropTypes.func.isRequired,

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -285,11 +285,10 @@ class UserEdit extends React.Component {
       // user record!
       permUserId.replace(record.id);
       record.permissions = permissionNames;
-      await permissionsMutator.PUT(record);
-    }
-    else {
+      permissionsMutator.PUT(record);
+    } else {
       // Create a new permissions user record first
-      await permUserMutator.POST({ userId: userId }).then(record => {
+      await permUserMutator.POST({ userId }).then(record => {
         record.permissions = permissionNames;
         permissionsMutator.PUT(record);
       });

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -8,14 +8,13 @@ import {
   cloneDeep,
   find,
   omit,
-  differenceBy,
   get,
   compact,
 } from 'lodash';
 
 import { LoadingView } from '@folio/stripes/components';
 
-import { eachPromise, getRecordObject } from '../../components/util';
+import { getRecordObject } from '../../components/util';
 
 import UserForm from './UserForm';
 import { toUserAddresses, getFormAddressList } from '../../components/data/converters/address';
@@ -231,7 +230,7 @@ class UserEdit extends React.Component {
     }
 
     if (permissions) {
-      this.updatePermissions(permissions);
+      this.updatePermissions(user.id, permissions);
     }
 
     if (servicePoints && stripes.hasPerm('inventory-storage.service-points-users.item.post,inventory-storage.service-points-users.item.put')) {
@@ -264,14 +263,37 @@ class UserEdit extends React.Component {
     });
   }
 
-  async updatePermissions(perms) {
-    const mutator = this.props.mutator.permissions;
-    const prevPerms = (this.props.resources.permissions || {}).records || [];
-    const removedPerms = differenceBy(prevPerms, perms, 'id');
-    const addedPerms = differenceBy(perms, prevPerms, 'id');
+  async updatePermissions(userId, perms) {
+    const {
+      permissions: permissionsMutator,
+      perms: permUserMutator,
+      permUserId,
+    } = this.props.mutator;
 
-    await eachPromise(removedPerms, mutator.DELETE);
-    await eachPromise(addedPerms, mutator.POST);
+    const { perms: permUserRecords } = this.props.resources;
+    // the perms parameter is an array of permission objects, but the permissions API
+    // wants an array of permission names.
+    const permissionNames = Object.values(perms).map(p => p.permissionName);
+
+    // If the user record has never had any associated permissions, a user permissions
+    // record may not exist. The PUT operation will fail if that's the case; thus,
+    // if no record is found, one has to be created before we assign the permissions
+    // as the last step.
+    if (permUserRecords.records.length === 1) {
+      const record = permUserRecords.records[0];
+      // N.B. permUserId is the id of the *permissions user* record, not the regular
+      // user record!
+      permUserId.replace(record.id);
+      record.permissions = permissionNames;
+      await permissionsMutator.PUT(record);
+    }
+    else {
+      // Create a new permissions user record first
+      await permUserMutator.POST({ userId: userId }).then(record => {
+        record.permissions = permissionNames;
+        permissionsMutator.PUT(record);
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1369

This PR replaces the one-by-one permissions assignments with an all-in-one assignment, thanks to the API that Julian pointed out. For the case of assigning all available permissions to a user, that means a reduction from 200+ API requests down to one, or at most two. Hooray!