### PR TITLE
UIU-1851 react-intl v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Remove user count from patron groups. Fixes UIU-1562.
 * Assign user permissions more efficiently. Fixes UIU-1369.
 * Filter out blank actions on loan details UI. Fixes UIU-1820.
+* Increment `react-intl` to `v5` for `@folio/stripes` `v5` compatibility. Refs STRIPES-694.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -746,7 +746,7 @@
     "mocha": "^5.2.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.8.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
@@ -769,7 +769,7 @@
   "peerDependencies": {
     "@folio/stripes": "^5.0.0",
     "react": "*",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.8.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
   },


### PR DESCRIPTION
Upgrade `react-intl` to `v5` since that is part of `@folio/stripes`
`v5`.

Refs [UIU-1851](https://issues.folio.org/browse/UIU-1851), [STRIPES-694](https://issues.folio.org/browse/STRIPES-694)