### PR TITLE
UIU-1849: Only set servicePointUserId when it's present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Assign user permissions more efficiently. Fixes UIU-1369.
 * Filter out blank actions on loan details UI. Fixes UIU-1820.
 * Increment `react-intl` to `v5` for `@folio/stripes` `v5` compatibility. Refs STRIPES-694.
+* Only set `servicePointUserId` when it's present. Fixes UIU-1849.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/Wrappers/withServicePoints.js
+++ b/src/components/Wrappers/withServicePoints.js
@@ -84,7 +84,7 @@ const withServicePoints = WrappedComponent => class WithServicePointsComponent e
       // Save the id of the record in the service-points-users table for later use when mutating it.
       const servicePointUserId = get(nextProps.resources.servicePointsUsers, ['records', 0, 'id'], '');
       const localServicePointUserId = nextProps.resources.servicePointUserId;
-      if (servicePointUserId !== localServicePointUserId) {
+      if (servicePointUserId && servicePointUserId !== localServicePointUserId) {
         nextProps.mutator.servicePointUserId.replace(servicePointUserId);
       }
 


### PR DESCRIPTION
This took a while to find.

the `nextProps.mutator.servicePointUserId.replace` was called multiple times when navigating away and back to users module causing:

````
 Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
````

https://issues.folio.org/browse/UIU-1849