### PR TITLE
consistent spacing around the colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Filter out blank actions on loan details UI. Fixes UIU-1820.
 * Increment `react-intl` to `v5` for `@folio/stripes` `v5` compatibility. Refs STRIPES-694.
 * Only set `servicePointUserId` when it's present. Fixes UIU-1849.
+* Consistent spacing around barcode link. 
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/Accounts/ChargeFeeFine/UserInfo.js
+++ b/src/components/Accounts/ChargeFeeFine/UserInfo.js
@@ -20,6 +20,7 @@ const UserInfo = (props) => {
         </Col>
         <Col className={css.userInfoLink}>
           <FormattedMessage id="ui-users.charge.barcode" />
+          {': '}
           <Link to={`/users/view/${user.id}`}>
             {user.barcode}
           </Link>

--- a/translations/ui-users/ar.json
+++ b/translations/ui-users/ar.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "نوع الغرامة/الرسم*",
     "charge.amount.label": "مبلغ الرسم/الغرامة*",
     "charge.patron": "المستفيد",
-    "charge.barcode": "الباركود:",
+    "charge.barcode": "الباركود",
     "charge.title": "غرامة/رسم جديد",
     "charge.onlyCharge": "فرض فقط",
     "charge.comment": "تعليقات",

--- a/translations/ui-users/ca.json
+++ b/translations/ui-users/ca.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Fee/fine type*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "Patron",
-    "charge.barcode": "Barcode: ",
+    "charge.barcode": "Barcode",
     "charge.title": "New fee/fine",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Additional information for staff",

--- a/translations/ui-users/da.json
+++ b/translations/ui-users/da.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Fee/fine type*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "Patron",
-    "charge.barcode": "Barcode: ",
+    "charge.barcode": "Barcode",
     "charge.title": "New fee/fine",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Additional information for staff",

--- a/translations/ui-users/de.json
+++ b/translations/ui-users/de.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Fee/fine type*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "Patron",
-    "charge.barcode": "Barcode: ",
+    "charge.barcode": "Barcode",
     "charge.title": "New fee/fine",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Additional information for staff",

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -429,7 +429,7 @@
   "charge.feefine.label": "Fee/fine type*",
   "charge.amount.label": "Fee/fine amount*",
   "charge.patron": "Patron",
-  "charge.barcode": "Barcode: ",
+  "charge.barcode": "Barcode",
   "charge.title": "New fee/fine",
   "charge.Pay": "Charge & pay now",
   "charge.onlyCharge": "Charge only",

--- a/translations/ui-users/en_GB.json
+++ b/translations/ui-users/en_GB.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Fee/fine type*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "Patron",
-    "charge.barcode": "Barcode: ",
+    "charge.barcode": "Barcode",
     "charge.title": "New fee/fine",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Additional information for staff",

--- a/translations/ui-users/en_SE.json
+++ b/translations/ui-users/en_SE.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Fee/fine type*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "Patron",
-    "charge.barcode": "Barcode: ",
+    "charge.barcode": "Barcode",
     "charge.title": "New fee/fine",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Additional information for staff",

--- a/translations/ui-users/en_US.json
+++ b/translations/ui-users/en_US.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Fee/fine type*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "Patron",
-    "charge.barcode": "Barcode:",
+    "charge.barcode": "Barcode",
     "charge.title": "New fee/fine",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Additional information for staff",

--- a/translations/ui-users/es.json
+++ b/translations/ui-users/es.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Tipo de tarifa/multa*",
     "charge.amount.label": "Cantidad de la tarifa/multa*",
     "charge.patron": "Patrón",
-    "charge.barcode": "Código de barras:",
+    "charge.barcode": "Código de barras",
     "charge.title": "Nueva tarifa/multa",
     "charge.onlyCharge": "Cargar solamente",
     "charge.comment": "Comentarios",

--- a/translations/ui-users/es_419.json
+++ b/translations/ui-users/es_419.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Tipo de tarifa/multa*",
     "charge.amount.label": "Cantidad de la tarifa/multa*",
     "charge.patron": "Patrón",
-    "charge.barcode": "Código de barras:",
+    "charge.barcode": "Código de barras",
     "charge.title": "Nueva tarifa/multa",
     "charge.onlyCharge": "Cargar solamente",
     "charge.comment": "Comentarios",

--- a/translations/ui-users/es_ES.json
+++ b/translations/ui-users/es_ES.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Tipo de tarifa/multa*",
     "charge.amount.label": "Cantidad de la tarifa/multa*",
     "charge.patron": "Patrón",
-    "charge.barcode": "Código de barras:",
+    "charge.barcode": "Código de barras",
     "charge.title": "Nueva tarifa/multa",
     "charge.onlyCharge": "Cargar solamente",
     "charge.comment": "Comentarios",

--- a/translations/ui-users/fr.json
+++ b/translations/ui-users/fr.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Fee/fine type*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "Patron",
-    "charge.barcode": "Barcode: ",
+    "charge.barcode": "Barcode",
     "charge.title": "New fee/fine",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Additional information for staff",

--- a/translations/ui-users/fr_FR.json
+++ b/translations/ui-users/fr_FR.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Type de frais/amende*",
     "charge.amount.label": "Montant des frais / amende *",
     "charge.patron": "Utilisateur",
-    "charge.barcode": "Code-barres:",
+    "charge.barcode": "Code-barres",
     "charge.title": "Nouveaux frais / amende",
     "charge.onlyCharge": "Frais seulement",
     "charge.comment": "Informations complémentaires pour le personnel",

--- a/translations/ui-users/he.json
+++ b/translations/ui-users/he.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Fee/fine type*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "Patron",
-    "charge.barcode": "Barcode: ",
+    "charge.barcode": "Barcode",
     "charge.title": "New fee/fine",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Additional information for staff",

--- a/translations/ui-users/it_IT.json
+++ b/translations/ui-users/it_IT.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Tipologia tariffa/multa*",
     "charge.amount.label": "Importo tariffa/multa*",
     "charge.patron": "Utente",
-    "charge.barcode": "Barcode: ",
+    "charge.barcode": "Barcode",
     "charge.title": "Nuova tariffa/multa",
     "charge.onlyCharge": "Solo addebito",
     "charge.comment": "Ulteriori informazioni per lo staff",

--- a/translations/ui-users/ja.json
+++ b/translations/ui-users/ja.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Fee/fine type*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "利用者",
-    "charge.barcode": "バーコード：",
+    "charge.barcode": "バーコード",
     "charge.title": "New fee/fine",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Additional information for staff",

--- a/translations/ui-users/pt_BR.json
+++ b/translations/ui-users/pt_BR.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Tipo de taxa/multa*",
     "charge.amount.label": "Valor da taxa/multa*",
     "charge.patron": "Usuário",
-    "charge.barcode": "Código de barras: ",
+    "charge.barcode": "Código de barras",
     "charge.title": "Nova taxa/multa",
     "charge.onlyCharge": "Cobrar apenas",
     "charge.comment": "Informações adicionais para a equipe",

--- a/translations/ui-users/pt_PT.json
+++ b/translations/ui-users/pt_PT.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Tipo de taxa/multa*",
     "charge.amount.label": "Montante da taxa/multa*",
     "charge.patron": "Utilizador",
-    "charge.barcode": "Código de barras:",
+    "charge.barcode": "Código de barras",
     "charge.title": "Nova taxa / multa",
     "charge.onlyCharge": "Cobrar apenas",
     "charge.comment": "Informações adicionais para os funcionários",

--- a/translations/ui-users/ru.json
+++ b/translations/ui-users/ru.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Тип оплаты*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "Читатель",
-    "charge.barcode": "Штрихкод: ",
+    "charge.barcode": "Штрихкод",
     "charge.title": " Новая оплата",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Дополнительная информация для персонала",

--- a/translations/ui-users/ur.json
+++ b/translations/ui-users/ur.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "Fee/fine type*",
     "charge.amount.label": "Fee/fine amount*",
     "charge.patron": "Patron",
-    "charge.barcode": "Barcode: ",
+    "charge.barcode": "Barcode",
     "charge.title": "New fee/fine",
     "charge.onlyCharge": "Charge only",
     "charge.comment": "Additional information for staff",

--- a/translations/ui-users/zh_CN.json
+++ b/translations/ui-users/zh_CN.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "费用/罚款类型*",
     "charge.amount.label": "费用/罚款金额*",
     "charge.patron": "读者",
-    "charge.barcode": "条码：",
+    "charge.barcode": "条码",
     "charge.title": "新增费用/罚款",
     "charge.onlyCharge": "仅收费",
     "charge.comment": "员工附加信息",

--- a/translations/ui-users/zh_TW.json
+++ b/translations/ui-users/zh_TW.json
@@ -215,7 +215,7 @@
     "charge.feefine.label": "費用 / 罰款 類型 *",
     "charge.amount.label": "費用 / 罰款 金額 *",
     "charge.patron": "讀者",
-    "charge.barcode": "條碼：",
+    "charge.barcode": "條碼",
     "charge.title": "新增 費用 / 罰款",
     "charge.onlyCharge": "仅收费",
     "charge.comment": "员工附加信息",


### PR DESCRIPTION
The output we are after here is something like this:
```
Barcode: <a href="">1234</a>
```
but the way it was coded, the translation value needed to contain
`Barcode: ` (note the trailing space). Sometimes it did, sometimes it
didn't, sometimes it didn't have the colon either. It was amazing how
much inconsistency there was, and how much that one space bugged the
crap outta me. No longer. No whitespace and no punctuation in the
translation should bring more consistent results.