### PR TITLE
Additional adjustments accompanying #1477

### DIFF
--- a/src/components/Accounts/ChargeFeeFine/UserInfo.js
+++ b/src/components/Accounts/ChargeFeeFine/UserInfo.js
@@ -20,7 +20,7 @@ const UserInfo = (props) => {
         </Col>
         <Col className={css.userInfoLink}>
           <FormattedMessage id="ui-users.charge.barcode" />
-          {': '}
+          :
           <Link to={`/users/view/${user.id}`}>
             {user.barcode}
           </Link>

--- a/src/components/Loans/ClosedLoans/ClosedLoans.js
+++ b/src/components/Loans/ClosedLoans/ClosedLoans.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   FormattedMessage,
   FormattedTime,
+  FormattedDate,
   injectIntl,
 } from 'react-intl';
 import PropTypes from 'prop-types';
@@ -183,14 +184,12 @@ class ClosedLoans extends React.Component {
   getLoansFormatter() {
     return {
       'title': loan => _.get(loan, ['item', 'title'], ''),
-      'dueDate': loan => {
-        return <FormattedTime
-          value={loan.dueDate}
-          day="numeric"
-          month="numeric"
-          year="numeric"
-        />;
-      },
+      'dueDate': loan => (
+        <div>
+          <div><FormattedDate tagName="div" value={loan.dueDate} /></div>
+          <div><FormattedTime tagName="div" value={loan.dueDate} /></div>
+        </div>
+      ),
       'barcode': loan => _.get(loan, ['item', 'barcode'], ''),
       'Fee/Fine': loan => this.getFeeFine(loan),
       'callNumber': loan => (<div data-test-list-call-numbers>{effectiveCallNumber(loan)}</div>),
@@ -388,7 +387,19 @@ class ClosedLoans extends React.Component {
       loans,
     } = this.props;
 
-    const visibleColumns = ['title', 'dueDate', 'barcode', 'Fee/Fine', 'callNumber', 'Contributors', 'renewals', 'loanDate', 'returnDate', 'checkinServicePoint', ' '];
+    const visibleColumns = [
+      'title',
+      'dueDate',
+      'barcode',
+      'Fee/Fine',
+      'callNumber',
+      // 'Contributors',
+      'renewals',
+      // 'loanDate',
+      'returnDate',
+      'checkinServicePoint',
+      ' '
+    ];
     const anonymizeString = <FormattedMessage id="ui-users.anonymize" />;
     const loansSorted = _.orderBy(loans,
       [this.sortMap[sortOrder[0]], this.sortMap[sortOrder[1]]], sortDirection);

--- a/src/components/Loans/OpenLoans/OpenLoans.js
+++ b/src/components/Loans/OpenLoans/OpenLoans.js
@@ -40,9 +40,9 @@ class OpenLoans extends React.Component {
 
     this.columnWidths = {
       '  ': { max: 35 },
-      'title': { max: 150 },
+      'title': { max: 200 },
       'itemStatus': { max: 100 },
-      'dueDate': { max: 140 },
+      'dueDate': { max: 120 },
       'requests': { max: 90 },
       'barcode': { max: 135 },
       'Fee/Fine': { max: 100 },

--- a/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
+++ b/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
@@ -106,12 +106,10 @@ export default function getListDataFormatter(
       key:'dueDate',
       view: formatMessage({ id: 'ui-users.loans.columns.dueDate' }),
       formatter: loan => (
-        <FormattedTime
-          value={get(loan, ['dueDate'])}
-          day="numeric"
-          month="numeric"
-          year="numeric"
-        />
+        <div>
+          <div><FormattedDate tagName="div" value={loan.dueDate} /></div>
+          <div><FormattedTime tagName="div" value={loan.dueDate} /></div>
+        </div>
       ),
       sorter: loan => loan.dueDate,
     },

--- a/translations/ui-users/ca.json
+++ b/translations/ui-users/ca.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/da.json
+++ b/translations/ui-users/da.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/de.json
+++ b/translations/ui-users/de.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -158,7 +158,7 @@
   "loans.details.location": "Location",
   "loans.details.requestQueue": "Request queue",
   "loans.details.requests": "Requests",
-  "loans.details.effectiveCallNumber": "Effective call number string",
+  "loans.details.effectiveCallNumber": "Effective call number",
   "loans.details.claimedReturned": "Claimed returned",
   "loans.details.loanPolicy": "Loan policy",
   "loans.details.lost": "Lost",

--- a/translations/ui-users/en_GB.json
+++ b/translations/ui-users/en_GB.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/en_SE.json
+++ b/translations/ui-users/en_SE.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/en_US.json
+++ b/translations/ui-users/en_US.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/es.json
+++ b/translations/ui-users/es.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/es_419.json
+++ b/translations/ui-users/es_419.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Sufijo del número de clasificación",
     "reports.overdue.item.enumeration": "Enumeración",
     "reports.overdue.item.volume": "Volumen",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/es_ES.json
+++ b/translations/ui-users/es_ES.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/fr.json
+++ b/translations/ui-users/fr.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/he.json
+++ b/translations/ui-users/he.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/hu.json
+++ b/translations/ui-users/hu.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/ja.json
+++ b/translations/ui-users/ja.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "巻",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "カスタムフィールド",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/pt_PT.json
+++ b/translations/ui-users/pt_PT.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/ur.json
+++ b/translations/ui-users/ur.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "کال نمبر لاحقہ",
     "reports.overdue.item.enumeration": "شمار",
     "reports.overdue.item.volume": "جلد",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "Instance (Material type)",

--- a/translations/ui-users/zh_TW.json
+++ b/translations/ui-users/zh_TW.json
@@ -609,7 +609,7 @@
     "reports.overdue.item.callNumberComponents.suffix": "Call number suffix",
     "reports.overdue.item.enumeration": "Enumeration",
     "reports.overdue.item.volume": "Volume",
-    "loans.details.effectiveCallNumber": "Effective call number string",
+    "loans.details.effectiveCallNumber": "Effective call number",
     "settings.customFields": "Custom fields",
     "details.field.instance.type": "Instance (Material type)",
     "accounts.history.columns.instance": "實例（資料類型）",


### PR DESCRIPTION
In #1477, the columnWidth API was applied to the Loans listing....

This PR consists of more aesthetic adjustments passed along from the PO level - 
- increasing the width of the "Title" column
- Adjusting the 'dueDate' formatter so that the time wraps to the next line.
- hiding the same columns in the Closed loans list... 

One item for future development is to have these column UI's behave the same way with both views using show/hide column functionality...