### PR TITLE
UIU-1857 do not report Paneset's size in modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Clean up invalid fee/fine type-popover code.
 * Consistent spacing around barcode link.
 * Refactoring of `charge & pay` fee/fine form. Refs UIU-1836.
+* Correctly handle permissions modal display over edit pane. Fixes UIU-1857.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -275,7 +275,7 @@ class PermissionsModal extends React.Component {
         }
       >
         <div>
-          <Paneset>
+          <Paneset isRoot>
             {filterPaneIsVisible &&
               <Pane
                 defaultWidth="30%"


### PR DESCRIPTION
`<Paneset>`s contained in `<Modal>`s in layers [should not report their
size back to their ancestors](/folio-org/stripes-components/tree/master/lib/Paneset/#panesets-within-layers).

h/t @NikitaSedyx from [UIPFU-31](/folio-org/ui-plugin-find-user/pull/151/)

Refs [UIU-1857](https://issues.folio.org/browse/UIU-1857)