### PR TITLE
Added space between open loan and claim return number

### DIFF
--- a/src/components/UserDetailSections/UserLoans/UserLoans.js
+++ b/src/components/UserDetailSections/UserLoans/UserLoans.js
@@ -161,7 +161,7 @@ class UserLoans extends React.Component {
                 </Link>
                 {item.claimedReturnedCount > 0 &&
                   <span id="claimed-returned-count">
-                    <FormattedMessage id="ui-users.loans.numClaimedReturnedLoans" values={{ count: item.claimedReturnedCount }} />
+                  {' '}<FormattedMessage id="ui-users.loans.numClaimedReturnedLoans" values={{ count: item.claimedReturnedCount }} />
                   </span>
                 }
               </li>)}


### PR DESCRIPTION
the loans accordion will have spacing between the number of open loans and claimed-returned loans

Ticket

https://issues.folio.org/browse/UIU-1665

Changes

Added {' '} to the front of claimed-returned loans to create a space. See commit for more detail.