### PR TITLE
UIU-1858: Hide Overdue loans report when no view loan permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Correctly handle permissions modal display over edit pane. Fixes UIU-1857.
 * Adding of `refund` fee/fine single action. Refs UIU-1850.
 * Refactor actions for single list item. Refs UIU-1797.
+* Hide the Overdue loans report option when user doesn't have view loans permissions. Refs UIU-1858.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -190,16 +190,18 @@ class UserSearch extends React.Component {
           </FormattedMessage>
         </PaneMenu>
       </IfPermission>
-      <Button
-        buttonStyle="dropdownItem"
-        id="export-overdue-loan-report"
-        onClick={() => {
-          onToggle();
-          this.generateReport(this.props, 'overdue');
-        }}
-      >
-        <FormattedMessage id="ui-users.reports.overdue.label" />
-      </Button>
+      <IfPermission perm="ui-users.loans.view">
+        <Button
+          buttonStyle="dropdownItem"
+          id="export-overdue-loan-report"
+          onClick={() => {
+            onToggle();
+            this.generateReport(this.props, 'overdue');
+          }}
+        >
+          <FormattedMessage id="ui-users.reports.overdue.label" />
+        </Button>
+      </IfPermission>
       <Button
         buttonStyle="dropdownItem"
         id="export-claimed-returned-loan-report"

--- a/test/bigtest/interactors/users.js
+++ b/test/bigtest/interactors/users.js
@@ -21,6 +21,7 @@ import {
 @interactor class HeaderDropdownMenu {
   clickExportToCSV = clickable('#export-overdue-loan-report');
   exportBtnIsVisible = isVisible('#export-overdue-loan-report');
+  isExportBtnPresent = isPresent('#export-overdue-loan-report');
 }
 
 @interactor class SearchFieldInteractor {

--- a/test/bigtest/tests/overdue-loan-report-test.js
+++ b/test/bigtest/tests/overdue-loan-report-test.js
@@ -60,4 +60,43 @@ describe('OverdueLoanReport', () => {
       });
     });
   });
+
+  describe('When patron has view loans permissions', () => {
+    setupApplication({
+      hasAllPerms: false,
+      permissions: {
+        'module.users.enabled': true,
+        'ui-users.loans.view': true,
+      },
+    });
+
+    beforeEach(async function () {
+      this.visit('/users?sort=Name');
+      await users.whenLoaded();
+      await users.headerDropdown.click();
+    });
+
+    it('Overdue loans report button should be present', () => {
+      expect(users.headerDropdownMenu.isExportBtnPresent).to.be.true;
+    });
+  });
+
+  describe('When patron does not have view loans permissions', () => {
+    setupApplication({
+      hasAllPerms: false,
+      permissions: {
+        'module.users.enabled': true,
+      },
+    });
+
+    beforeEach(async function () {
+      this.visit('/users?sort=Name');
+      await users.whenLoaded();
+      await users.headerDropdown.click();
+    });
+
+    it('Overdue loans report button should not be present', () => {
+      expect(users.headerDropdownMenu.isExportBtnPresent).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1858

### Purpose
Prevent access to the Overdue loans report option if the user doesn't have view loan permissions.