### PR TITLE
UIU-1853: Allow overrides for renewals where due date doesn't change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Adding of `refund` fee/fine single action. Refs UIU-1850.
 * Refactor actions for single list item. Refs UIU-1797.
 * Hide the Overdue loans report option when user doesn't have view loans permissions. Refs UIU-1858.
+* Allow renewal override if due date isn't changed. Refs UIU-1853.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
+++ b/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
@@ -31,4 +31,8 @@ export default [
     message: 'renewal date falls outside of date ranges in the loan policy',
     showDueDatePicker: true,
   },
+  {
+    message: 'renewal would not change the due date',
+    showDueDatePicker: true,
+  },
 ];

--- a/test/bigtest/tests/open-loan-renew-test.js
+++ b/test/bigtest/tests/open-loan-renew-test.js
@@ -78,6 +78,28 @@ describe('Renew loan', () => {
             expect(OpenLoansInteractor.patronBlockModal.modalContent(0).text).to.be.equal(blockReason);
           });
         });
+
+        describe("overriding when renew won't change due date", () => {
+          beforeEach(async function() {
+            server.post('/circulation/renew-by-barcode', {
+              'errors' : [{
+                'message' : 'renewal would not change the due date',
+                'parameters' : [{
+                  'key' : 'request id',
+                  'value' : 'b67e73a8-b6b7-46fd-a918-77ce907dd3aa'
+                }]
+              }]
+            }, 422);
+            this.visit(`/users/${userId}/loans/open?query=%20&sort=requests`);
+
+            await OpenLoansInteractor.actionDropdowns(0).click('button');
+          });
+
+          it('allows an override', () => {
+            expect(OpenLoansInteractor.actionDropdownRenewButton.isPresent).to.be.true;
+          });
+        });
+   
       });
 
       describe('loan detail page', () => {

--- a/test/bigtest/tests/open-loan-renew-test.js
+++ b/test/bigtest/tests/open-loan-renew-test.js
@@ -80,8 +80,8 @@ describe('Renew loan', () => {
         });
 
         describe("overriding when renew won't change due date", () => {
-          beforeEach(async function() {
-            server.post('/circulation/renew-by-barcode', {
+          beforeEach(async function () {
+            this.server.post('/circulation/renew-by-barcode', {
               'errors' : [{
                 'message' : 'renewal would not change the due date',
                 'parameters' : [{
@@ -99,7 +99,6 @@ describe('Renew loan', () => {
             expect(OpenLoansInteractor.actionDropdownRenewButton.isPresent).to.be.true;
           });
         });
-   
       });
 
       describe('loan detail page', () => {


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1853

The infrastructure was already in place to enable overrides for loan actions that result in various error conditions, so this was just a matter of adding one more condition to the list.

<img width="1193" alt="Screen Shot 2020-10-07 at 4 01 06 PM" src="https://user-images.githubusercontent.com/1322242/95382873-4e900c80-08b8-11eb-9c06-c9a43dbf8d80.png">
<img width="1142" alt="Screen Shot 2020-10-07 at 4 02 08 PM" src="https://user-images.githubusercontent.com/1322242/95382876-4fc13980-08b8-11eb-9f54-d0e5bf7ff61e.png">
