### PR TITLE
UIU-1793: Fee/fines refactoring

### DIFF
--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -403,7 +403,6 @@ class Actions extends React.Component {
     body.amount = values.amount;
     body.paymentMethod = values.method;
     body.notifyPatron = values.notify;
-    body.transactionInfo = values.transaction || '-';
     body.comments = this.assembleTagInfo(values);
     body.servicePointId = servicePointId;
     body.userName = `${lastName}, ${firstName}`;
@@ -420,6 +419,10 @@ class Actions extends React.Component {
     const account = _.head(accounts) || {};
     mutator.activeRecord.update({ id: account.id });
     const payload = this.buildActionBody(values);
+
+    if (action === 'payment') {
+      payload.transactionInfo = values.transaction || '-';
+    }
 
     mutator[this.actionToEndpointMapping[action]].POST(_.omit(payload, ['id']))
       .then(() => this.props.handleEdit(1))

--- a/src/routes/AccountDetailsContainer.js
+++ b/src/routes/AccountDetailsContainer.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { first } from 'lodash';
+import {
+  first,
+  isEmpty,
+} from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
 import { stripesConnect } from '@folio/stripes/core';
@@ -151,9 +154,13 @@ class AccountDetailsContainer extends React.Component {
       updateInstanceId({ instanceId: account.instanceId });
     }
 
-    const instance = first(resources?.instance?.records || []) || { contributors: [] };
+    const instance = account?.instanceId
+      ? first(resources?.instance?.records)
+      : [];
     const loanRecords = resources?.loans?.records ?? [];
-    const contributors = instance.contributors.map(({ name }) => name.split(',').reverse().join(', '));
+    const contributors = !isEmpty(instance)
+      ? instance.contributors.map(({ name }) => name.split(',').reverse().join(', '))
+      : [];
     const loanId = account?.loanId;
 
     if (loanId === '0') return { contributors };


### PR DESCRIPTION
# Description
Added fixes of:
- `transactionInfo` field accepted for `payment` action only
- `contributor` record should be shown for fee/fines associated with `item` only 
# In scope of story
https://issues.folio.org/browse/UIU-1793