### PR TITLE
UIU-1560: Make assigned service points checked in Add service points …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * Search translations of permission names. Refs UIU-1859.
 * Hide the Overdue loans report option when user doesn't have view loans permissions. Refs UIU-1858.
 * Allow renewal override if due date isn't changed. Refs UIU-1853.
+* Make the assigned service points for the user have been checked in the Add service points modal. Fixes UIU-1560.
 
 ## [4.0.0](https://github.com/folio-org/ui-users/tree/v4.0.0) (2020-06-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v3.0.0...v4.0.0)

--- a/src/components/EditSections/EditServicePoints/EditServicePoints.js
+++ b/src/components/EditSections/EditServicePoints/EditServicePoints.js
@@ -64,7 +64,10 @@ class EditServicePoints extends React.Component {
     const sp = this.userServicePoints.get(index);
 
     return (
-      <li key={sp.id}>
+      <li
+        data-test-service-point={sp.id}
+        key={sp.id}
+      >
         {sp.name}
         <FormattedMessage id="ui-users.sp.removeServicePoint">
           {aria => (
@@ -171,14 +174,20 @@ class EditServicePoints extends React.Component {
   }
 
   renderAddServicePointModal() {
+    const {
+      addingServicePoint,
+      userServicePoints,
+    } = this.state;
+
     const servicePoints = get(this.props.formData, 'servicePoints', []);
 
     return (
       <AddServicePointModal
         onClose={() => this.setState({ addingServicePoint: false })}
         onSave={this.onAddServicePoints}
-        open={this.state.addingServicePoint}
+        open={addingServicePoint}
         servicePoints={servicePoints}
+        assignedServicePoints={userServicePoints}
       />
     );
   }

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -32,6 +32,7 @@ export default function setupApplication({
         'feesfines': '15.3',
         'users': '15.2',
         'loan-policy-storage':'1.0',
+        'service-points-users': '1.0',
       },
     },
   };

--- a/test/bigtest/helpers/setup-application.js
+++ b/test/bigtest/helpers/setup-application.js
@@ -10,6 +10,7 @@ export default function setupApplication({
   modules,
   translations,
   currentUser,
+  interfaces = {},
 } = {}) {
   const initialState = {
     discovery: {
@@ -32,7 +33,7 @@ export default function setupApplication({
         'feesfines': '15.3',
         'users': '15.2',
         'loan-policy-storage':'1.0',
-        'service-points-users': '1.0',
+        ...interfaces,
       },
     },
   };

--- a/test/bigtest/interactors/service-points-modal.js
+++ b/test/bigtest/interactors/service-points-modal.js
@@ -1,0 +1,16 @@
+import {
+  interactor,
+  scoped,
+  collection
+} from '@bigtest/interactor';
+
+import CheckboxInteractor from '@folio/stripes-components/lib/Checkbox/tests/interactor';
+
+@interactor class ServicePointsModal {
+  static defaultScope = '#service-points-modal';
+
+  saveButton = scoped('#save-service-point-btn');
+  checkBoxes = collection('[data-test-checkbox]', CheckboxInteractor);
+}
+
+export default ServicePointsModal;

--- a/test/bigtest/interactors/user-form-page.js
+++ b/test/bigtest/interactors/user-form-page.js
@@ -19,6 +19,7 @@ import RepeatableFieldInteractor from '@folio/stripes-components/lib/RepeatableF
 import ModalInteractor from '@folio/stripes-components/lib/Modal/tests/interactor'; // eslint-disable-line
 import SelectInteractor from '@folio/stripes-components/lib/Select/tests/interactor'; // eslint-disable-line
 import PermissionsModal from './permissions-modal';
+import ServicePointsModal from './service-points-modal';
 import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.css';
 
 
@@ -92,6 +93,10 @@ import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/P
   label = text('[class*="labelArea---"]');
 }
 
+@interactor class ServicePointInteractor {
+  deleteServicePoint = clickable('[id*=clickable-remove-service-point-]')
+}
+
 @interactor class UserFormPage {
   // isLoaded = isPresent('[class*=paneTitleLabel---]');
 
@@ -112,6 +117,12 @@ import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/P
   cancelButton = new ButtonInteractor('[data-test-user-form-cancel-button]');
   submitButton = new ButtonInteractor('[data-test-user-form-submit-button]');
   submitButtonIsDisabled = property('[data-test-user-form-submit-button]', 'disabled');
+
+  toggleSPAccordionButton = scoped('#accordion-toggle-button-servicePoints');
+  addServicePointButton = scoped('#add-service-point-btn');
+  servicePoints = collection('[data-test-service-point]', ServicePointInteractor);
+  servicePointsModal = new ServicePointsModal();
+
   togglePermissionAccordionButton = scoped('#accordion-toggle-button-permissions');
   addPermissionButton = scoped('#clickable-add-permission');
   permissionsModal = new PermissionsModal();

--- a/test/bigtest/tests/service-points-modal-test.js
+++ b/test/bigtest/tests/service-points-modal-test.js
@@ -1,0 +1,91 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import UserFormPage from '../interactors/user-form-page';
+
+describe('Service points modal', () => {
+  setupApplication();
+
+  describe('visit user edit page', () => {
+    beforeEach(async function () {
+      const user = this.server.create('user');
+      const sp = this.server.create('service-point');
+      this.server.create('service-point');
+      this.server.create('service-points-user', {
+        userId: user.id,
+        servicePointsIds: [sp.id],
+      });
+      this.visit(`/users/${user.id}/edit`);
+      await UserFormPage.whenLoaded();
+    });
+
+    describe('when expanding the service points accordion', () => {
+      beforeEach(async () => {
+        await UserFormPage.toggleSPAccordionButton.click();
+      });
+
+      it('1 service point should be displayed', () => {
+        expect(UserFormPage.servicePoints().length).to.equal(1);
+      });
+
+      it('add service points button should be present', () => {
+        expect(UserFormPage.addServicePointButton.isPresent).to.be.true;
+      });
+
+      describe('clicking the add service points button', () => {
+        beforeEach(async function () {
+          await UserFormPage.addServicePointButton.click();
+        });
+
+        it('service point modal should be present', () => {
+          expect(UserFormPage.servicePointsModal.isPresent).to.be.true;
+        });
+
+        it('1 service point should be checked', () => {
+          expect(UserFormPage.servicePointsModal.checkBoxes(0).isChecked).to.be.false;
+          expect(UserFormPage.servicePointsModal.checkBoxes(1).isChecked).to.be.true;
+          expect(UserFormPage.servicePointsModal.checkBoxes(2).isChecked).to.be.false;
+        });
+
+        describe('when adding all service points', () => {
+          beforeEach(async function () {
+            await UserFormPage.servicePointsModal.checkBoxes(0).clickInput();
+            await UserFormPage.servicePointsModal.saveButton.click();
+          });
+
+          it('2 service points should be displayed', () => {
+            expect(UserFormPage.servicePoints().length).to.equal(2);
+          });
+
+          describe('when deleting all service points', () => {
+            beforeEach(async function () {
+              await UserFormPage.servicePoints(1).deleteServicePoint();
+              await UserFormPage.servicePoints(0).deleteServicePoint();
+            });
+
+            it('service points should not be displayed', () => {
+              expect(UserFormPage.servicePoints().length).to.equal(0);
+            });
+
+            describe('when opening service points modal', () => {
+              beforeEach(async function () {
+                await UserFormPage.addServicePointButton.click();
+              });
+
+              it('service points should not be checked', () => {
+                expect(UserFormPage.servicePointsModal.checkBoxes(0).isChecked).to.be.false;
+                expect(UserFormPage.servicePointsModal.checkBoxes(1).isChecked).to.be.false;
+                expect(UserFormPage.servicePointsModal.checkBoxes(2).isChecked).to.be.false;
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/bigtest/tests/service-points-modal-test.js
+++ b/test/bigtest/tests/service-points-modal-test.js
@@ -9,7 +9,11 @@ import setupApplication from '../helpers/setup-application';
 import UserFormPage from '../interactors/user-form-page';
 
 describe('Service points modal', () => {
-  setupApplication();
+  setupApplication({
+    interfaces: {
+      'service-points-users': '1.0',
+    }
+  });
 
   describe('visit user edit page', () => {
     beforeEach(async function () {


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1560

### Purpose
Make the assigned service points for the user have been checked in the Add service points modal similar to how it works when assigning permissions.

### Approach
1. An array of assigned service points was passed to the modal and used as initial values.
2. When adding new service points, the concatenation of the initial and added service points was used to update the state.
    When the service points were deleted, the updated array of assigned service points was used.
3. Created some tests for the `Add service points` modal.
4. For testing, it was set `interfaces = {}` as an argument to the `setupApplication` function to be able to add interfaces to existing ones.

A bug about doubling the quantity of the service points was also identified and filed [UIU-1892](https://issues.folio.org/browse/UIU-1892).