### PR TITLE
UIU-1850: Refund fee/fines

### DIFF
--- a/src/components/Accounts/Actions/ActionModal.js
+++ b/src/components/Accounts/Actions/ActionModal.js
@@ -19,7 +19,7 @@ import {
   Select,
 } from '@folio/stripes/components';
 
-import { calculateSelectedAmount } from '../accountFunctions';
+import { calculateRefundSelectedAmount } from '../accountFunctions';
 
 import css from './PayWaive.css';
 
@@ -30,6 +30,7 @@ class ActionModal extends React.Component {
     handleSubmit: PropTypes.func,
     open: PropTypes.bool,
     accounts: PropTypes.arrayOf(PropTypes.object),
+    feeFineActions: PropTypes.arrayOf(PropTypes.object),
     data: PropTypes.arrayOf(PropTypes.object),
     balance: PropTypes.string,
     totalPaidAmount: PropTypes.string,
@@ -84,14 +85,14 @@ class ActionModal extends React.Component {
   renderModalLabel() {
     const {
       accounts = [],
+      feeFineActions = [],
       action,
       form: { getState },
       intl: { formatMessage },
     } = this.props;
 
     const { values: { amount } } = getState();
-
-    const selected = calculateSelectedAmount(accounts, this.isRefundAction(action));
+    const selected = calculateRefundSelectedAmount(feeFineActions);
     const type = parseFloat(amount) < parseFloat(selected)
       ? formatMessage({ id: `ui-users.accounts.${action}.summary.partially` })
       : formatMessage({ id: `ui-users.accounts.${action}.summary.fully` });
@@ -261,6 +262,7 @@ class ActionModal extends React.Component {
   render() {
     const {
       accounts,
+      feeFineActions,
       action,
       balance,
       initialValues,
@@ -277,7 +279,6 @@ class ActionModal extends React.Component {
       pristine,
       submitting,
     } = this.props;
-
     const { accountRemainingAmount } = this.state;
 
     const {
@@ -288,7 +289,7 @@ class ActionModal extends React.Component {
       }
     } = getState();
 
-    const selected = calculateSelectedAmount(accounts, this.isRefundAction(action));
+    const selected = calculateRefundSelectedAmount(feeFineActions);
     const ownerOptions = owners.filter(o => o.owner !== 'Shared').map(o => ({ value: o.id, label: o.owner }));
 
     let options = (this.isPaymentAction(action)) ? data.filter(d => (d.ownerId === (accounts.length > 1 ? ownerId : (accounts[0] || {}).ownerId))) : data;

--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -24,6 +24,7 @@ import { MAX_RECORDS } from '../../../constants';
 import { getFullName } from '../../util';
 import {
   calculateSelectedAmount,
+  calculateRefundSelectedAmount,
   isRefundAllowed,
   loadServicePoints,
 } from '../accountFunctions';
@@ -679,6 +680,8 @@ class Actions extends React.Component {
     } = this.state;
 
     const account = this.props.accounts[0] || {};
+    const feeFineActions = _.get(resources, ['feefineactions', 'records'], [])
+      .filter(({ accountId }) => account.id === accountId);
     const defaultServicePointId = _.get(resources, ['curUserServicePoint', 'records', 0, 'defaultServicePointId'], '-');
     const servicePointsIds = _.get(resources, ['curUserServicePoint', 'records', 0, 'servicePointsIds'], []);
     const payments = _.get(resources, ['payments', 'records'], []);
@@ -762,7 +765,7 @@ class Actions extends React.Component {
         data: refunds,
         comment: 'refunded',
         open: actions.refundModal || (actions.refundMany && !isWarning),
-        initialValues: { ...initialValues, amount: calculateSelectedAmount(this.props.accounts, true) }
+        initialValues: { ...initialValues, amount: calculateRefundSelectedAmount(feeFineActions) }
       },
     ];
 

--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -807,6 +807,7 @@ class Actions extends React.Component {
                 onSubmit={(values) => { this.showConfirmDialog(values); }}
                 owners={owners}
                 feefines={feefines}
+                feeFineActions={feeFineActions}
                 okapi={this.props.okapi}
                 totalPaidAmount={parseFloat(this.props.totalPaidAmount).toFixed(2)}
                 owedAmount={parseFloat(this.props.owedAmount).toFixed(2)}

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -465,7 +465,7 @@ class ChargeFeeFine extends React.Component {
     const selectedFeeFine = feefines.find(f => f.id === feeFineTypeId);
     const selectedOwner = owners.find(o => o.id === initialOwnerId);
     const initialChargeValues = {
-      ownerId: initialOwnerId,
+      ownerId: '',
       notify: !!(selectedFeeFine?.chargeNoticeId || selectedOwner?.defaultChargeNoticeId),
       feeFineId: '',
       amount: ''

--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash';
 import { paymentStatusesAllowedToRefund } from '../../constants';
 
 export function count(array) {
@@ -49,6 +50,23 @@ export function calculateSelectedAmount(accounts, isRefundAction = false) {
   }, 0);
 
   return parseFloat(selected / 100).toFixed(2);
+}
+
+function getPaidActions(feeFineActions) {
+  return feeFineActions.filter(({ typeAction }) => paymentStatusesAllowedToRefund.includes(typeAction));
+}
+
+export function calculateRefundSelectedAmount(feeFineActions) {
+  const paidActions = getPaidActions(feeFineActions);
+  const selected = paidActions.reduce((s, { amountAction }) => {
+    return s + parseFloat((amountAction) * 100);
+  }, 0);
+
+  return parseFloat(selected / 100).toFixed(2);
+}
+
+export function isPaymentOccured(feeFineActions) {
+  return !isEmpty(getPaidActions(feeFineActions));
 }
 
 export function calculateRemainingAmount(amount, balance, selected, action) {

--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -42,17 +42,15 @@ export function handleFilterClear(name) {
   return state;
 }
 
-export function calculateSelectedAmount(accounts, isRefundAction = false) {
-  const selected = accounts.reduce((s, { amount, remaining }) => {
-    return isRefundAction
-      ? s + parseFloat((amount - remaining) * 100)
-      : s + parseFloat(remaining * 100);
+export function calculateSelectedAmount(accounts) {
+  const selected = accounts.reduce((s, { remaining }) => {
+    return s + parseFloat(remaining * 100);
   }, 0);
 
   return parseFloat(selected / 100).toFixed(2);
 }
 
-function getPaidActions(feeFineActions) {
+function getPaidActions(feeFineActions = []) {
   return feeFineActions.filter(({ typeAction }) => paymentStatusesAllowedToRefund.includes(typeAction));
 }
 

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -24,7 +24,10 @@ import {
   calculateSortParams,
 } from '../../components/util';
 
-import { calculateTotalPaymentAmount } from '../../components/Accounts/accountFunctions';
+import {
+  calculateTotalPaymentAmount,
+  isPaymentOccured,
+} from '../../components/Accounts/accountFunctions';
 
 import css from './AccountDetails.css';
 
@@ -291,7 +294,7 @@ class AccountDetails extends React.Component {
     const contributors = itemDetails?.contributors.join(', ');
 
     const totalPaidAmount = calculateTotalPaymentAmount(resources?.accounts?.records);
-    const refundAllowed = totalPaidAmount > 0;
+    const refundAllowed = isPaymentOccured(resources?.accountActions?.records);
 
     return (
       <Paneset isRoot>

--- a/test/bigtest/network/scenarios/fee-fine-details.js
+++ b/test/bigtest/network/scenarios/fee-fine-details.js
@@ -58,10 +58,10 @@ export default (server) => {
   });
   server.create('feefineaction', {
     accountId: openAccount.id,
-    amountAction: 500,
+    amountAction: 100,
     balance: 500,
     userId: user.id,
-    typeAction: feeFine.feeFineType,
+    typeAction: openAccount.paymentStatus.name,
   });
   server.create('check-pay', {
     accountId: openAccount.id,


### PR DESCRIPTION
# Description
Add fixes of refund functionality:
- `Refund` button should be active only if actions `payment` or `transfer` were occured
- `Refund amount` should include `payment` or/and  `transfer` already payed `amount` (not `waive` amount) 
# In scope of story
https://issues.folio.org/browse/UIU-1850
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/95604741-aff2df80-0a60-11eb-83b3-7a5cdef21d80.png)
**After**
![image](https://user-images.githubusercontent.com/55694637/95604802-c1d48280-0a60-11eb-8f01-07c3fe92aeb2.png)

**Before**
![image](https://user-images.githubusercontent.com/55694637/95604878-da449d00-0a60-11eb-9432-cab3b5c0b881.png)

**After**
![image](https://user-images.githubusercontent.com/55694637/95604937-ed576d00-0a60-11eb-93ce-a6f996349ebc.png)
