### PR TITLE
Always disable refund button

### DIFF
--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -121,9 +121,13 @@ export function accountRefundInfo(account) {
   return { hasBeenPaid, paidAmount };
 }
 
-export function isRefundAllowed(account) {
-  const { hasBeenPaid, paidAmount } = accountRefundInfo(account);
-  return false; // hasBeenPaid && paidAmount > 0;
+// export function isRefundAllowed(account) {
+//   const { hasBeenPaid, paidAmount } = accountRefundInfo(account);
+//   return hasBeenPaid && paidAmount > 0;
+// }
+
+export function isRefundAllowed() {
+  return false;
 }
 
 export function calculateTotalPaymentAmount(accounts = []) {

--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -123,7 +123,7 @@ export function accountRefundInfo(account) {
 
 export function isRefundAllowed(account) {
   const { hasBeenPaid, paidAmount } = accountRefundInfo(account);
-  return hasBeenPaid && paidAmount > 0;
+  return false; // hasBeenPaid && paidAmount > 0;
 }
 
 export function calculateTotalPaymentAmount(accounts = []) {

--- a/test/bigtest/tests/fee-fine-details-test.js
+++ b/test/bigtest/tests/fee-fine-details-test.js
@@ -235,7 +235,7 @@ describe('Test Fee/Fine details', () => {
       });
     });
 
-    describe('Refund fee/fine', () => {
+    describe.skip('Refund fee/fine', () => {
       beforeEach(async () => {
         await FeeFineDetails.refundButton.click();
       });


### PR DESCRIPTION
# Description
Because of `refund` functionality does not finish yet, lets always show `refund` button disabled, and release refactoring fees/fines without refunding. 