### PR TITLE
UIU-1901 update plugins for stripes v5 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 5.0.1 IN PROGRESS
+
+* Update plugins to `stripes v5`-compatible versions. Refs UIU-1901.
+
 ## [5.0.0](https://github.com/folio-org/ui-users/tree/v5.0.0) (2020-10-14)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v4.0.0...v5.0.0)
 

--- a/package.json
+++ b/package.json
@@ -775,7 +775,7 @@
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^3.0.0"
+    "@folio/plugin-find-user": "^4.0.0"
   },
   "resolutions": {
     "moment": "~2.24.0"


### PR DESCRIPTION
Apps and plugins must depend on the same versions of peer dependencies.

Refs [UIU-1901](https://issues.folio.org/browse/UIU-1901)