### PR TITLE
UIU-1892: Fix bug in display of add service point dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 6.0.0 (IN PROGRESS)
+
+* Fix bug showing duplicated service points in add service point dialog. Fixes UIU-1892.
+
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)
 

--- a/src/components/EditSections/EditServicePoints/EditServicePoints.js
+++ b/src/components/EditSections/EditServicePoints/EditServicePoints.js
@@ -179,7 +179,7 @@ class EditServicePoints extends React.Component {
       userServicePoints,
     } = this.state;
 
-    const servicePoints = get(this.props.formData, 'servicePoints', []);
+    const servicePoints = uniqBy(this.props.formData?.servicePoints, 'id');
 
     return (
       <AddServicePointModal


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1892

This is a bit of an odd one. It seems that if the editing window is invoked too quickly after saving, somehow the resources for service points are duplicated. I haven't been able to trace the exact cause, but it turns out that it's easy enough to filter out the duplicates if that happens. 