### PR TITLE
UIU-1913 use more efficient queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 5.1.0 IN PROGRESS
+
+* Use more efficient queries for `accounts` records. Refs UIU-1913.
+
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)
 

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.js
@@ -103,7 +103,7 @@ class PatronBlock extends React.Component {
       accordionId,
       automatedPatronBlocks,
     } = this.props;
-    const query = `userId=${user.id}`;
+    const query = `userId==${user.id}`;
 
     manualPatronBlocks.reset();
     manualPatronBlocks.GET({ params: { query } })

--- a/src/routes/AccountDetailsContainer.js
+++ b/src/routes/AccountDetailsContainer.js
@@ -38,7 +38,7 @@ class AccountDetailsContainer extends React.Component {
       records: 'accounts',
       path: 'accounts',
       params: {
-        query: 'userId=:{id}',
+        query: 'userId==:{id}',
         limit: '1000',
       },
     },

--- a/src/routes/LoanDetailContainer.js
+++ b/src/routes/LoanDetailContainer.js
@@ -70,7 +70,7 @@ class LoanDetailContainer extends React.Component {
     loanAccountsActions: {
       type: 'okapi',
       records: 'accounts',
-      path: 'accounts?query=(loanId=:{loanid})&limit=1000',
+      path: 'accounts?query=(loanId==:{loanid})&limit=1000',
       resourceShouldRefresh: true,
       shouldRefresh: (_, action, refresh) => refresh || (action?.meta?.path ?? '').match(/circulation/),
     },


### PR DESCRIPTION
When searching by `id`, use a field-level match (`==`) rather than a
word-match (`=`).

Refs [UIU-1913](https://issues.folio.org/browse/UIU-1913)