### PR TITLE
UIU-1895 - "Open fee/fine" page retrieves feefineactions and feefines records without qualifier

### DIFF
--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -46,7 +46,7 @@ class Actions extends React.Component {
     feefineactions: {
       type: 'okapi',
       records: 'feefineactions',
-      path: `feefineactions?limit=${MAX_RECORDS}`,
+      path: `feefineactions?query=(userId==%{user.id})&limit=${MAX_RECORDS}`,
       shouldRefresh: (resource, action, refresh) => {
         return refresh || action.meta.path === 'accounts';
       },

--- a/src/routes/ChargeFeesFinesContainer.js
+++ b/src/routes/ChargeFeesFinesContainer.js
@@ -74,7 +74,7 @@ class ChargeFeesFinesContainer extends React.Component {
     feefineactions: {
       type: 'okapi',
       records: 'feefineactions',
-      path: `feefineactions?limit=${MAX_RECORDS}`,
+      path: `feefineactions?query=(userId==%{user.id})&limit=${MAX_RECORDS}`,
     },
     accounts: {
       type: 'okapi',


### PR DESCRIPTION
# Purpose
Filter feefineactions by userId

# Link
https://issues.folio.org/browse/UIU-1895

# Screenshots
<img width="913" alt="Screen Shot 2020-10-20 at 16 03 38" src="https://user-images.githubusercontent.com/43472449/96596970-f57f9a00-12f5-11eb-90f1-0813b6766434.png">
<img width="910" alt="Screen Shot 2020-10-20 at 16 38 41" src="https://user-images.githubusercontent.com/43472449/96596976-f7495d80-12f5-11eb-97a7-cc6c9b08f4bf.png">
