### PR TITLE
UIU-1706: Search index last name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix bug showing duplicated service points in add service point dialog. Fixes UIU-1892.
 * Add report icon for report menu items. Refs UIU-1505.
 * Allow search by username. Refs UIU-1707.
+* Allow search by last name. Refs UIU-1706.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -384,6 +384,7 @@ class UserSearch extends React.Component {
             queryGetter={queryGetter}
             onComponentWillUnmount={onComponentWillUnmount}
             initialSearch={initialSearch}
+            initialSearchState={{ query: '' }}
           >
             {
               ({

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -43,6 +43,7 @@ function getFullName(user) {
 const rawSearchableIndexes = [
   { label: 'ui-users.index.all', value: '' },
   { label: 'ui-users.index.username', value: 'username' },
+  { label: 'ui-users.index.lastName', value: 'personal.lastName' },
 ];
 let searchableIndexes;
 

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -177,10 +177,7 @@ export default function config() {
       }
       if (field === lastNameField) {
         return users.where(u => {
-          if (u.personal.lastName === term.replace('*', '')) {
-            return true;
-          }
-          return false;
+          return (u.personal.lastName === term.replace('*', ''));
         });
       }
     }

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -147,6 +147,7 @@ export default function config() {
       const filterField = 'active';
       const departmentsField = 'departments';
       const usernameField = 'username';
+      const lastNameField = 'personal.lastName';
       if (/^%28/.test(query)) {
         query = decodeURIComponent(query);
       }
@@ -172,6 +173,14 @@ export default function config() {
       if (field === usernameField) {
         return users.where({
           [usernameField]: term.replace('*', '')
+        });
+      }
+      if (field === lastNameField) {
+        return users.where(u => {
+          if (u.personal.lastName === term.replace('*', '')) {
+            return true;
+          }
+          return false;
         });
       }
     }

--- a/test/bigtest/tests/users-show-all-test.js
+++ b/test/bigtest/tests/users-show-all-test.js
@@ -78,6 +78,19 @@ describe('Users', () => {
       });
     });
 
+    describe('search by last name index', function () {
+      beforeEach(async function () {
+        const userItem = users[0];
+        await usersInteractor.chooseSearchOption('Last name');
+        await usersInteractor.searchField.fill(userItem.personal.lastName);
+        await usersInteractor.searchButton.click();
+      });
+
+      it('should find user with given last name', () => {
+        expect(usersInteractor.instances().length).to.be.equal(1);
+      });
+    });
+
     describe('click clear status filter', () => {
       beforeEach(async function () {
         await usersInteractor.clearStatusFilter();

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -815,6 +815,7 @@
   "bulkClaimReturned.items.notOk": "{numItems} item(s) <strong>not</strong> claimed returned.",
   "bulkClaimReturned.moreInfoPlaceholder": "Enter more information about the claim (required)",
 
+  "index.lastName": "Last name",
   "index.username": "Username",
   "index.all": "Keyword (name, email, identifier)"
 }


### PR DESCRIPTION
This PR adds support for searching on the `personal.lastName` field of a user explicitly.
It adds `personal.lastName` to the `rawSearchableIndexes` of `UserSearch.js`. 

Refs https://issues.folio.org/browse/UIU-1706


