### PR TITLE
UIU-1035 relocate username password in edit create detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add report icon for report menu items. Refs UIU-1505.
 * Allow search by username. Refs UIU-1707.
 * Use more efficient queries for `accounts` records. Refs UIU-1913.
+* Relocate the username/password in the create/edit and detail view screens. Refs UIU-1035.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -125,33 +125,6 @@ class EditExtendedInfo extends Component {
             md={6}
           >
             <Row>
-              <Col
-                xs={12}
-                md={6}
-              >
-                <Field
-                  label={<FormattedMessage id="ui-users.information.username" />}
-                  name="username"
-                  id="adduser_username"
-                  component={TextField}
-                  fullWidth
-                  validStylesEnabled
-                />
-              </Col>
-              <IfPermission perm="ui-users.reset.password">
-                {isEditForm && username &&
-                  (
-                    <CreateResetPasswordControl
-                      userId={userId}
-                      email={userEmail}
-                      name={userFirstName}
-                      username={username}
-                    />
-                  )
-                }
-              </IfPermission>
-            </Row>
-            <Row>
               <RequestPreferencesEdit addressTypes={addressTypes} />
             </Row>
           </Col>
@@ -161,6 +134,33 @@ class EditExtendedInfo extends Component {
           >
             <DepartmentsNameEdit departments={departments} />
           </Col>
+        </Row>
+        <Row>
+          <Col
+            xs={12}
+            md={3}
+          >
+            <Field
+              label={<FormattedMessage id="ui-users.information.username" />}
+              name="username"
+              id="adduser_username"
+              component={TextField}
+              fullWidth
+              validStylesEnabled
+            />
+          </Col>
+          <IfPermission perm="ui-users.reset.password">
+            {isEditForm && username &&
+              (
+                <CreateResetPasswordControl
+                  userId={userId}
+                  email={userEmail}
+                  name={userFirstName}
+                  username={username}
+                />
+              )
+            }
+          </IfPermission>
         </Row>
         <br />
       </Accordion>

--- a/src/components/UserDetailSections/ExtendedInfo/ExtendedInfo.js
+++ b/src/components/UserDetailSections/ExtendedInfo/ExtendedInfo.js
@@ -62,12 +62,7 @@ const ExtendedInfo = (props) => {
         </Col>
       </Row>
       <Row>
-        <Col xs={3}>
-          <KeyValue label={<FormattedMessage id="ui-users.information.username" />}>
-            {get(user, ['username'], '')}
-          </KeyValue>
-        </Col>
-        <Col xs={9}>
+        <Col xs={12} md={9}>
           <RequestPreferencesView
             requestPreferences={requestPreferences}
             defaultServicePointName={defaultServicePointName}
@@ -84,6 +79,13 @@ const ExtendedInfo = (props) => {
             <span data-test-department-name>
               {departments.length ? departments.join(', ') : <NoValue />}
             </span>
+          </KeyValue>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={12} md={6}>
+          <KeyValue label={<FormattedMessage id="ui-users.information.username" />}>
+            {get(user, ['username'], '')}
           </KeyValue>
         </Col>
       </Row>


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1035

Relocate the username/password in the create/edit and detail view screens