### PR TITLE
UIU-1708: Search index barcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Use more efficient queries for `accounts` records. Refs UIU-1913.
 * Relocate the username/password in the create/edit and detail view screens. Refs UIU-1035.
 * Allow search by last name. Refs UIU-1706.
+* Allow search by barcode. Refs UIU-1708.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -44,6 +44,7 @@ const rawSearchableIndexes = [
   { label: 'ui-users.index.all', value: '' },
   { label: 'ui-users.index.username', value: 'username' },
   { label: 'ui-users.index.lastName', value: 'personal.lastName' },
+  { label: 'ui-users.index.barcode', value: 'barcode' },
 ];
 let searchableIndexes;
 
@@ -338,7 +339,12 @@ class UserSearch extends React.Component {
     if (!searchableIndexes) {
       searchableIndexes = rawSearchableIndexes.map(x => (
         { value: x.value, label: this.props.intl.formatMessage({ id: x.label }) }
-      ));
+      )).sort((a, b) => a.label.localeCompare(b.label));
+      // searchableIndexes is sorted now, but we need to keep the default value (no explicit index) at the beginning of the array
+      searchableIndexes = [
+        ...searchableIndexes.filter(({ value }) => !value || value.length === 0),
+        ...searchableIndexes.filter(({ value }) => value)
+      ];
     }
 
     const users = get(resources, 'records.records', []);

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -148,6 +148,7 @@ export default function config() {
       const departmentsField = 'departments';
       const usernameField = 'username';
       const lastNameField = 'personal.lastName';
+      const barcodeField = 'barcode';
       if (/^%28/.test(query)) {
         query = decodeURIComponent(query);
       }
@@ -178,6 +179,11 @@ export default function config() {
       if (field === lastNameField) {
         return users.where(u => {
           return (u.personal.lastName === term.replace('*', ''));
+        });
+      }
+      if (field === barcodeField) {
+        return users.where({
+          [barcodeField]: term.replace('*', '')
         });
       }
     }

--- a/test/bigtest/tests/users-show-all-test.js
+++ b/test/bigtest/tests/users-show-all-test.js
@@ -91,6 +91,19 @@ describe('Users', () => {
       });
     });
 
+    describe('search by barcode index', function () {
+      beforeEach(async function () {
+        const userItem = users[0];
+        await usersInteractor.chooseSearchOption('Barcode');
+        await usersInteractor.searchField.fill(userItem.barcode);
+        await usersInteractor.searchButton.click();
+      });
+
+      it('should find user with given barcode', () => {
+        expect(usersInteractor.instances().length).to.be.equal(1);
+      });
+    });
+
     describe('click clear status filter', () => {
       beforeEach(async function () {
         await usersInteractor.clearStatusFilter();

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -815,6 +815,7 @@
   "bulkClaimReturned.items.notOk": "{numItems} item(s) <strong>not</strong> claimed returned.",
   "bulkClaimReturned.moreInfoPlaceholder": "Enter more information about the claim (required)",
 
+  "index.barcode": "Barcode",
   "index.lastName": "Last name",
   "index.username": "Username",
   "index.all": "Keyword (name, email, identifier)"


### PR DESCRIPTION
This PR adds support for searching on the `barcode` field of a user explicitly.
It adds `barcode` to the rawSearchableIndexes of UserSearch.js.

Refs https://issues.folio.org/browse/UIU-1708