### PR TITLE
UIU-1891: Show number of open requests in  Claim returned bulk action…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Allow search by barcode. Refs UIU-1708.
 * Work with multiple and single `refund` action. Refs UIU-1897.
 * Show the number of open requests in `LoanActionDialog`. Refs UIU-1890.
+* Show the number of open requests in the Claim returned bulk action modal. Refs UIU-1891.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/Loans/OpenLoans/components/BulkClaimReturnedModal/BulkClaimReturnedModal.js
+++ b/src/components/Loans/OpenLoans/components/BulkClaimReturnedModal/BulkClaimReturnedModal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedDate, injectIntl } from 'react-intl';
+import { Link } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 import moment from 'moment';
 
@@ -15,6 +16,8 @@ import {
   TextArea,
 } from '@folio/stripes-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
+
+import { getOpenRequestsPath } from '../../../../util';
 
 import css from '../../../../ModalContent';
 
@@ -32,6 +35,7 @@ class BulkClaimReturnedModal extends React.Component {
   });
 
   static propTypes = {
+    stripes: PropTypes.object.isRequired,
     checkedLoansIndex: PropTypes.object.isRequired,
     intl: PropTypes.object.isRequired,
     mutator: PropTypes.shape({
@@ -61,7 +65,26 @@ class BulkClaimReturnedModal extends React.Component {
   // requestCounts is an object of the form {<item id>: <number of requests>},
   // with keys present only if the item in question has >0 requests. Thus, if
   // none of the selected items have any requests on them, requestCounts === {}.
-  getRequestCountForItem = id => this.props.requestCounts[id] || 0;
+  getRequestCountForItem = id => {
+    const {
+      requestCounts,
+      stripes,
+    } = this.props;
+
+    const itemRequestCount = requestCounts[id] || 0;
+
+    if (itemRequestCount && stripes.hasPerm('ui-users.requests.all')) {
+      return (
+        <Link
+          data-test-item-request-count
+          to={getOpenRequestsPath(id)}
+        >
+          {itemRequestCount}
+        </Link>);
+    }
+
+    return itemRequestCount;
+  }
 
   handleAdditionalInfoChange = e => {
     this.setState({ additionalInfo: e.target.value });

--- a/src/components/Loans/OpenLoans/components/Modals/Modals.js
+++ b/src/components/Loans/OpenLoans/components/Modals/Modals.js
@@ -77,6 +77,7 @@ class Modals extends React.Component {
           viewUserPath={`/users/view/${(user || {}).id}?filters=pg.${patronGroup.group}&sort=name`}
         />
         <this.connectedBulkClaimReturnedDialog
+          stripes={stripes}
           checkedLoansIndex={checkedLoans}
           requestCounts={requestCounts}
           open={showBulkClaimReturnedModal}

--- a/test/bigtest/interactors/open-loans.js
+++ b/test/bigtest/interactors/open-loans.js
@@ -48,6 +48,7 @@ import DialogInteractor from './dialog';
 @interactor class BulkClaimReturnedModal {
   static defaultScope = '[data-test-bulk-claim-returned-modal]';
 
+  openRequestsNumber = new Interactor('[data-test-item-request-count]');
   cancelButton = clickable('[data-test-bulk-cr-cancel-button]');
   confirmButton = clickable('[data-test-bulk-cr-continue-button]');
 }

--- a/test/bigtest/tests/bulk-claim-returned-test.js
+++ b/test/bigtest/tests/bulk-claim-returned-test.js
@@ -6,12 +6,26 @@ import {
 import { expect } from 'chai';
 
 import setupApplication from '../helpers/setup-application';
+import DummyComponent from '../helpers/DummyComponent';
 import LoansInteractor from '../interactors/open-loans';
 
 describe('Bulk claim returned modal', () => {
+  const requestsPath = '/requests';
+  const requestsAmount = 2;
+
   setupApplication({
     permissions: {
-      'circulation.loans.collection.get': true
+      'circulation.loans.collection.get': true,
+    },
+    modules: [{
+      type: 'app',
+      name: '@folio/ui-requests',
+      displayName: 'requests',
+      route: requestsPath,
+      module: DummyComponent,
+    }],
+    translations: {
+      'requests': 'Requests'
     },
   });
 
@@ -28,22 +42,46 @@ describe('Bulk claim returned modal', () => {
     it('Disables the button if no items are selected', () => {
       expect(LoansInteractor.isBulkClaimReturnedDisabled).to.be.true;
     });
+
+    describe('Working with checked out items', () => {
+      beforeEach(async function () {
+        await LoansInteractor.selectAllCheckboxes();
+        await LoansInteractor.clickClaimReturned();
+      });
+
+      it('shows the bulk claim returned modal', () => {
+        expect(LoansInteractor.bulkClaimReturnedModal.isPresent).to.be.true;
+      });
+    });
   });
 
-  describe('Working with checked out items', () => {
-    beforeEach(async function () {
-      const user = this.server.create('user');
+  describe('clicking bulk claim returned button', () => {
+    let loan;
 
-      this.server.createList('loan', 3, { status: { name: 'Open' }, userId: user.id });
-      this.visit(`/users/${user.id}/loans/open`);
+    beforeEach(async function () {
+      loan = this.server.create('loan', { status: { name: 'Open' } });
+
+      this.server.createList('request', requestsAmount, { itemId: loan.item.id });
+      this.visit(`/users/${loan.userId}/loans/open`);
 
       await LoansInteractor.whenLoaded();
       await LoansInteractor.selectAllCheckboxes();
       await LoansInteractor.clickClaimReturned();
     });
 
-    it('shows the bulk claim returned modal', () => {
-      expect(LoansInteractor.bulkClaimReturnedModal.isPresent).to.be.true;
+    it('should display open requests number', () => {
+      expect(LoansInteractor.bulkClaimReturnedModal.openRequestsNumber.text).to.equal(requestsAmount.toString());
+    });
+
+    describe('clicking on the open requests number link', () => {
+      beforeEach(async () => {
+        await LoansInteractor.bulkClaimReturnedModal.openRequestsNumber.click();
+      });
+
+      it('should redirect to "requests"', function () {
+        expect(this.location.pathname).to.equal(requestsPath);
+        expect(this.location.search).includes(loan.item.id);
+      });
     });
   });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1891

### Purpose
This PR is essentially a sequel of https://github.com/folio-org/ui-users/pull/1536 and uses the same approach to display the number of open requests in the Claim returned bulk action modal.

**Screenshot**
![Screen Shot 2020-10-28 at 16 37 22](https://user-images.githubusercontent.com/49517355/97451026-048cca80-193c-11eb-86ee-26093c798cd4.png)
