### PR TITLE
UIU-1773: Omit optional fields without values when Fee/Fine is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Allow cancel fee/fine as error only if any 'actions' has not been applied. Refs UIU-1894.
 * Allow search by barcode. Refs UIU-1708.
 * Show the number of open requests in `LoanActionDialog`. Refs UIU-1890.
+* Remove optional `action` fields if no value was setted. Refs UIU-1773.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -65,7 +65,7 @@ class ChargeFeeFine extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      ownerId: '',
+      ownerId: '0',
       feeFineTypeId: null,
       lookup: false,
       pay: false,
@@ -243,7 +243,7 @@ class ChargeFeeFine extends React.Component {
 
     if (_.get(resources, ['activeRecord', 'shared']) === undefined) {
       const owners = _.get(resources, ['owners', 'records'], []);
-      const shared = (owners.find(o => o.owner === 'Shared') || {}).id || '';
+      const shared = (owners.find(o => o.owner === 'Shared') || {}).id || '0';
       mutator.activeRecord.update({ shared });
     }
     mutator.activeRecord.update({ ownerId });
@@ -438,7 +438,7 @@ class ChargeFeeFine extends React.Component {
         if (owner !== undefined) { list.push(owner); }
       }
     });
-    const feefines = (this.state.ownerId !== '') ? (resources.feefines || {}).records || [] : [];
+    const feefines = (this.state.ownerId !== '0') ? (resources.feefines || {}).records || [] : [];
     const payments = _.get(resources, ['payments', 'records'], []).filter(p => p.ownerId === this.state.ownerId);
     const accounts = _.get(resources, ['accounts', 'records'], []);
     const settings = _.get(resources, ['commentRequired', 'records', 0], {});
@@ -472,7 +472,7 @@ class ChargeFeeFine extends React.Component {
 
     const items = _.get(resources, ['items', 'records'], []);
     const servicePointOwnerId = loadServicePoints({ owners: (shared ? owners : list), defaultServicePointId, servicePointsIds });
-    const initialOwnerId = ownerId !== '' ? ownerId : servicePointOwnerId;
+    const initialOwnerId = ownerId !== '0' ? ownerId : servicePointOwnerId;
     const selectedFeeFine = feefines.find(f => f.id === feeFineTypeId);
     const selectedOwner = owners.find(o => o.id === initialOwnerId);
     const initialChargeValues = {

--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -146,3 +146,7 @@ export function calculateOwedFeeFines(accounts = []) {
 export function isCancelAllowed(account) {
   return account.paymentStatus.name === 'Outstanding';
 }
+
+export function deleteOptionalActionFields(actionData, ...fields) {
+  fields.map((field) => (!actionData[field] ? delete actionData[field] : null));
+}

--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -137,5 +137,5 @@ export function isCancelAllowed(account) {
 }
 
 export function deleteOptionalActionFields(actionData, ...fields) {
-  fields.map((field) => (!actionData[field] ? delete actionData[field] : null));
+  fields.forEach((field) => (!actionData[field] ? delete actionData[field] : null));
 }

--- a/test/bigtest/interactors/user-form-page.js
+++ b/test/bigtest/interactors/user-form-page.js
@@ -22,7 +22,6 @@ import PermissionsModal from './permissions-modal';
 import ServicePointsModal from './service-points-modal';
 import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.css';
 
-
 @interactor class InputFieldInteractor {
   clickInput = clickable();
   fillInput = fillable();
@@ -86,7 +85,7 @@ import proxyEditItemCSS from '../../../src/components/ProxyGroup/ProxyEditItem/P
           .blurInput();
       }
     }),
-    popoverIsPresent: isPresent('[class^=popoverTarget---]'),
+    popoverIsPresent: isPresent('[class^=infoPopover---]'),
     validationMessage: text('[class^=feedbackError---]'),
   });
 

--- a/test/bigtest/tests/user-edit-page-test.js
+++ b/test/bigtest/tests/user-edit-page-test.js
@@ -194,7 +194,7 @@ describe('User Edit Page', () => {
         expect(UserFormPage.customFieldsSection.fields().length).to.equal(3);
       });
 
-      it.skip('should display popover for the first field', () => {
+      it('should display popover for the first field', () => {
         expect(UserFormPage.customFieldsSection.fields(0).popoverIsPresent).to.be.true;
       });
 


### PR DESCRIPTION
# Description
Manual `fee/fine` can be created `with` associated item or `without` (more often).
**Before:**
When `fee/fine` is not related to any `item`, in POST to `account` we sent such fields (`itemID`,  `loanId`, `materialTypeId`, `materialType`) with value `"0"` - because they were `required`
**Now:**
If no value for  (`itemID`,  `loanId`, `materialTypeId`, `materialType`) - we do not send them. Now these fields became `optional` [(MODFEE-88)](https://issues.folio.org/browse/MODFEE-88) 

Also in previous [PR](https://github.com/folio-org/ui-users/pull/1539), the failing test was skipped. In current PR was changed `Popover` interactor for fixing skipped test.
# Task
https://issues.folio.org/browse/UIU-1773
