### PR TITLE
Update module version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-users
 
-## 5.1.0 (IN PROGRESS)
+## 6.0.0 (IN PROGRESS)
 
 * Fix bug showing duplicated service points in add service point dialog. Fixes UIU-1892.
 * Add report icon for report menu items. Refs UIU-1505.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/users",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "User management",
   "repository": "folio-org/ui-users",
   "publishConfig": {


### PR DESCRIPTION
After update version of `feesfines okapi interface` [here](https://github.com/folio-org/ui-users/pull/1544), major version of `ui-users` should be bumped as well