### PR TITLE
UIU-1937: Fix incorrect label for Contributors column in Overdue loan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Show the number of open requests in the Claim returned bulk action modal. Refs UIU-1891.
 * Add column 'Expiration date offset (days)' to patron group table. Refs UIU-1908.
 * On `Create Fee/fine` page `ConfirmationModal` shows again. Refs UIU-1933.
+* Fix incorrect display of the header for `Contributors` column in `Overdue loans report`. Fixes UIU-1937.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -722,6 +722,7 @@
   "reports.item.chronology": "Chronology",
   "reports.item.copyNumber": "Copy number",
   "reports.item.volume": "Volume",
+  "reports.item.contributors": "Contributors",
   "reports.overdue.item.contributors": "Contributors",
   "reports.item.location.name": "Location",
   "reports.item.instanceId": "Instance ID",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1937

### Purpose
Due to refactoring in `constants` and `translations` via #1498, the reference to `Contributors` was accidentally changed, it had to be added to the `translations` file as a separate entry so as not to break the code dependency on the already existing one.