### PR TITLE
UITAG-34: Fix filtering by tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Add column 'Expiration date offset (days)' to patron group table. Refs UIU-1908.
 * On `Create Fee/fine` page `ConfirmationModal` shows again. Refs UIU-1933.
 * Fix incorrect display of the header for `Contributors` column in `Overdue loans report`. Fixes UIU-1937.
+* Fix filtering by tags. Fixes UITAG-34.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/routes/filterConfig.js
+++ b/src/routes/filterConfig.js
@@ -16,6 +16,7 @@ const filterConfig = [
     name: 'tags',
     cql: 'tags.tagList',
     values: [],
+    operator: '=',
   },
   {
     name: 'departments',


### PR DESCRIPTION
https://issues.folio.org/browse/UITAG-34

It looks like due to the change in stripes-components:

folio-org/stripes-components#1368

The searching by tags stopped working because tags.tagList only works with `=` operator.

