### PR TITLE
UIU-1938 - 'Transaction information' not saved/displaying when 1 fee/fine paid

### DIFF
--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -396,7 +396,7 @@ class Actions extends React.Component {
     mutator.activeRecord.update({ id: account.id });
     const payload = this.buildActionBody(values);
 
-    if (action === 'payment') {
+    if (action === 'pay') {
       payload.transactionInfo = values.transaction || '-';
     }
 


### PR DESCRIPTION
# Purpose
Fix sending of transactionInfo field to BE for pay action.

# Link
https://issues.folio.org/browse/UIU-1938

# Screenshot
<img width="1669" alt="Screen Shot 2020-11-05 at 12 35 07" src="https://user-images.githubusercontent.com/43472449/98230045-5bf5f080-1f63-11eb-9679-6317ab309c77.png">
