### PR TITLE
UIU-1942: Manual block expiration date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix incorrect display of the header for `Contributors` column in `Overdue loans report`. Fixes UIU-1937.
 * Fix filtering by tags. Fixes UITAG-34.
 * Manual patron block not fully going away after expired. Refs UIU-1943.
+* Manual patron block expiration date changing when patron block viewed. Refs UIU-1942.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -231,6 +231,7 @@ class PatronBlockForm extends React.Component {
                         dateFormat="YYYY-MM-DD"
                         label={<FormattedMessage id="ui-users.blocks.form.label.date" />}
                         backendDateStandard="YYYY-MM-DD"
+                        timeZone="UTC"
                       />
                     </Col>
                   </Row>

--- a/src/components/PatronBlock/PatronBlockLayer.js
+++ b/src/components/PatronBlock/PatronBlockLayer.js
@@ -56,7 +56,7 @@ class PatronBlockLayer extends React.Component {
     item.type = 'Manual';
     item.userId = (params.id);
     if (item.expirationDate) {
-      item.expirationDate = moment(item.expirationDate).endOf('day');
+      item.expirationDate = moment.utc(item.expirationDate).startOf('day');
     }
     return this.props.mutator.manualPatronBlocks.POST(item).then(() => {
       this.props.mutator.activeRecord.update({ blockid: item.userId });
@@ -81,7 +81,7 @@ class PatronBlockLayer extends React.Component {
 
   onUpdateItem = (item) => {
     if (item.expirationDate) {
-      item.expirationDate = moment(item.expirationDate).endOf('day');
+      item.expirationDate = moment.utc(item.expirationDate).startOf('day');
     }
     delete item.metadata;
     this.props.mutator.activeRecord.update({ blockid: item.id });


### PR DESCRIPTION
# Description
- The next day after manual patron block was created, after view block the date was changed to the next or previous date, which should not be changed
- The manual block should be expired on the `00:00 am` at expirated date 
# Issue
https://issues.folio.org/browse/UIU-1942
# Screenshots
**Before**
![bef1](https://user-images.githubusercontent.com/55694637/98258208-4398cc80-1f89-11eb-94a5-430c413576c3.png)
![bef2](https://user-images.githubusercontent.com/55694637/98258232-4b587100-1f89-11eb-8609-12170ddc6837.png)

**After**
![aft](https://user-images.githubusercontent.com/55694637/98258248-501d2500-1f89-11eb-8baf-a44447dfec1d.png)

