### PR TITLE
UIU-1948 ignore case when sorting filter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix incorrect display of the header for `Contributors` column in `Overdue loans report`. Fixes UIU-1937.
 * Fix filtering by tags. Fixes UITAG-34.
 * Manual patron block not fully going away after expired. Refs UIU-1943.
+* Case-insensitive sort of filter options. Refs UIIN-1948.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/views/UserSearch/Filters.js
+++ b/src/views/UserSearch/Filters.js
@@ -6,7 +6,6 @@ import {
 } from 'react-intl';
 import {
   get,
-  sortBy,
 } from 'lodash';
 
 import {
@@ -58,7 +57,7 @@ class Filters extends React.Component {
   getValuesFromResources = (type, labelKey, valueKey) => {
     const items = get(this.props.resources, `${type}.records`, [])
       .map(item => ({ label: item[labelKey], value: item[valueKey] }));
-    return sortBy(items, 'label');
+    return items.sort((a, b) => a.label.localeCompare((b.label)));
   };
 
   handleFilterChange = (filter) => {


### PR DESCRIPTION
Use `Array.sort()` and `String.localeCompare()` when sorting values for
filters to handle the sort in a case-insensitive manner.

Refs [UIU-1948](https://issues.folio.org/browse/UIU-1948)