### PR TITLE
UIU-1932, UIU-1935 correctly retrieve related requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix incorrect display of the header for `Contributors` column in `Overdue loans report`. Fixes UIU-1937.
 * Fix filtering by tags. Fixes UITAG-34.
 * Manual patron block not fully going away after expired. Refs UIU-1943.
+* Increment `@folio/stripes` to `^5.0.2`. Refs UIU-1932, UIU-1935.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -777,7 +777,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^5.0.0",
+    "@folio/stripes": "^5.0.2",
     "react": "*",
     "react-intl": "^5.8.0",
     "react-router": "^5.2.0",


### PR DESCRIPTION
Requests related to open loans were incorrectly retrieved in the
`<ChangeDueDateDialog>` component. This was fixed in
`stripes-smart-components` `v5.0.1`, available in `stripes` `v5.0.2`.

Refs [UIU-1932](https://issues.folio.org/browse/UIU-1932), [UIU-1935](https://issues.folio.org/browse/UIU-1935), [STSMACOM-452](https://issues.folio.org/browse/STSMACOM-452)