### PR TITLE
UIU-1894: Allow cancel fee/fine as error only if any 'actions' has not been applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Qualify queries to `feefineactions`, `feefines` from "Open fee/fine" page. Refs UIU-1895.
 * Use more efficient queries for `accounts` records. Refs UIU-1913.
+* Allow cancel fee/fine as error only if any 'actions' has not been applied. Refs UIU-1894.
 
 ## [5.0.4](https://github.com/folio-org/ui-users/tree/v5.0.4) (2020-11-09)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.3...v5.0.4)

--- a/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
+++ b/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
@@ -20,7 +20,10 @@ import {
   nav,
 } from '../../util';
 
-import { isRefundAllowed } from '../accountFunctions';
+import {
+  isRefundAllowed,
+  isCancelAllowed,
+} from '../accountFunctions';
 
 class ViewFeesFines extends React.Component {
   static propTypes = {
@@ -318,7 +321,7 @@ class ViewFeesFines extends React.Component {
       pay: disabled,
       waive: disabled,
       transfer: disabled,
-      error: disabled,
+      error: disabled || !isCancelAllowed(a),
       loan: (a.loanId === '0' || !a.loanId),
       refund: !isRefundAllowed(a),
     };

--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -142,3 +142,7 @@ export function calculateOwedFeeFines(accounts = []) {
     return account?.status?.name === 'Open' ? parseFloat(owed + account.remaining) : owed;
   }, 0);
 }
+
+export function isCancelAllowed(account) {
+  return account.paymentStatus.name === 'Outstanding';
+}

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -27,6 +27,7 @@ import {
 import {
   calculateTotalPaymentAmount,
   isRefundAllowed,
+  isCancelAllowed,
 } from '../../components/Accounts/accountFunctions';
 
 import css from './AccountDetails.css';
@@ -295,6 +296,7 @@ class AccountDetails extends React.Component {
 
     const totalPaidAmount = calculateTotalPaymentAmount(resources?.accounts?.records);
     const refundAllowed = isRefundAllowed(account);
+    const cancelAllowed = isCancelAllowed(account);
 
     return (
       <Paneset isRoot>
@@ -346,7 +348,7 @@ class AccountDetails extends React.Component {
               </Button>
               <Button
                 id="errorAccountActionsHistory"
-                disabled={disabled || buttonDisabled || isActionsPending || isAccountsPending}
+                disabled={disabled || buttonDisabled || isActionsPending || isAccountsPending || !cancelAllowed}
                 buttonStyle="primary"
                 onClick={this.error}
               >

--- a/test/bigtest/interactors/fee-fine-details.js
+++ b/test/bigtest/interactors/fee-fine-details.js
@@ -62,6 +62,7 @@ import KeyValue from './KeyValue';
   transferButton = new ButtonInteractor('#transferAccountActionsHistory');
   refundButton = new ButtonInteractor('#refundAccountActionsHistory');
   errorButton = new ButtonInteractor('#errorAccountActionsHistory');
+  errorButtonIsDisabled = is('#errorAccountActionsHistory[disabled]');
   errorModal = new ModalInteractor('#error-modal');
   errorComment = new TextAreaInteractor('[class*=textArea---]');
   errorModalSubmit = new ButtonInteractor('[data-test-error-submit]');

--- a/test/bigtest/tests/fee-fine-cancel-test.js
+++ b/test/bigtest/tests/fee-fine-cancel-test.js
@@ -1,0 +1,109 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import FeeFineHistoryInteractor from '../interactors/fee-fine-history';
+import FeeFineDetails from '../interactors/fee-fine-details';
+
+describe('Cancel fee/fine', () => {
+  setupApplication({
+    currentUser: {
+      curServicePoint: { id: 1 },
+    },
+  });
+
+  let user;
+  beforeEach(async function () {
+    const owner = this.server.create('owner', {
+      owner: 'testOwner',
+      id: 'testOwner'
+    });
+    const feeFine = this.server.create('feefine', {
+      feeFineType: 'testFineType',
+      id: 'testFineType',
+      ownerId: owner.id,
+      defaultAmount: 500
+    });
+    user = this.server.create('user');
+    const account = this.server.create('account', { userId: user.id });
+    this.server.create('feefineaction', {
+      accountId: account.id,
+      amountAction: 500,
+      balance: 500,
+      userId: user.id,
+      typeAction: feeFine.feeFineType,
+    });
+    this.server.get('/accounts');
+    this.server.get('/accounts/:id', (schema, request) => {
+      return schema.accounts.find(request.params.id).attrs;
+    });
+    this.server.get('/feefines');
+
+    this.visit(`/users/preview/${user.id}`);
+  });
+
+  beforeEach(async () => {
+    await FeeFineHistoryInteractor.whenSectionLoaded();
+    await FeeFineHistoryInteractor.sectionFeesFinesSection.click();
+    await FeeFineHistoryInteractor.openAccounts.click();
+    await FeeFineHistoryInteractor.rows(0).click();
+    await FeeFineDetails.whenLoaded();
+  });
+
+  it('displays account actions section', () => {
+    expect(FeeFineDetails.isPresent).to.be.true;
+  });
+
+  it('displays error button active', () => {
+    expect(FeeFineDetails.errorButtonIsDisabled).to.be.false;
+  }).timeout(2000);
+
+  describe('Click error button', () => {
+    beforeEach(async () => {
+      await FeeFineDetails.errorButton.click();
+    });
+
+    it('displays error modal', () => {
+      expect(FeeFineDetails.errorModal.isPresent).to.be.true;
+    });
+
+    it('displays error modal submit button', () => {
+      expect(FeeFineDetails.errorModalSubmit.isPresent).to.be.true;
+    });
+
+    it('displays error modal comment field', () => {
+      expect(FeeFineDetails.errorComment.isPresent).to.be.true;
+    });
+
+    describe('Fill cancel reason', () => {
+      beforeEach(async () => {
+        await FeeFineDetails.errorComment.focusTextArea();
+        await FeeFineDetails.errorComment.fillAndBlur('Cancellation reason');
+      });
+
+      it('displays cancel reason value', () => {
+        expect(FeeFineDetails.errorComment.val)
+          .to
+          .equal('Cancellation reason');
+      });
+
+      it('displays active submit cancel button', () => {
+        expect(FeeFineDetails.errorModalSubmitIsDisabled).to.be.false;
+      });
+
+      describe('cancel fine', () => {
+        beforeEach(async () => {
+          await FeeFineDetails.errorModalSubmit.click();
+        });
+
+        it('show successfull callout', () => {
+          expect(FeeFineDetails.callout.successCalloutIsPresent).to.be.true;
+        });
+      });
+    });
+  });
+});

--- a/test/bigtest/tests/fee-fine-details-test.js
+++ b/test/bigtest/tests/fee-fine-details-test.js
@@ -85,10 +85,6 @@ describe('Test Fee/Fine details', () => {
       expect(FeeFineDetails.isPresent).to.be.true;
     });
 
-    it('displays error button active', () => {
-      expect(FeeFineDetails.errorButtonIsDisabled).to.be.true;
-    }).timeout(2000);
-
     describe('Pay fee/fine', () => {
       beforeEach(async () => {
         await FeeFineDetails.payButton.click();

--- a/test/bigtest/tests/fee-fine-details-test.js
+++ b/test/bigtest/tests/fee-fine-details-test.js
@@ -85,6 +85,10 @@ describe('Test Fee/Fine details', () => {
       expect(FeeFineDetails.isPresent).to.be.true;
     });
 
+    it('displays error button active', () => {
+      expect(FeeFineDetails.errorButtonIsDisabled).to.be.true;
+    }).timeout(2000);
+
     describe('Pay fee/fine', () => {
       beforeEach(async () => {
         await FeeFineDetails.payButton.click();
@@ -280,49 +284,6 @@ describe('Test Fee/Fine details', () => {
             it('show successfull callout', () => {
               expect(FeeFineDetails.callout.successCalloutIsPresent).to.be.true;
             });
-          });
-        });
-      });
-    });
-
-    describe('Cancel fee/fine', () => {
-      beforeEach(async () => {
-        await FeeFineDetails.errorButton.click();
-      });
-
-      it('displays error modal', () => {
-        expect(FeeFineDetails.errorModal.isPresent).to.be.true;
-      });
-
-      it('displays error modal submit button', () => {
-        expect(FeeFineDetails.errorModalSubmit.isPresent).to.be.true;
-      });
-
-      it('displays error modal comment field', () => {
-        expect(FeeFineDetails.errorComment.isPresent).to.be.true;
-      });
-
-      describe('Fill cancel reason', () => {
-        beforeEach(async () => {
-          await FeeFineDetails.errorComment.focusTextArea();
-          await FeeFineDetails.errorComment.fillAndBlur('Cancellation reason');
-        });
-
-        it('displays cancel reason value', () => {
-          expect(FeeFineDetails.errorComment.val).to.equal('Cancellation reason');
-        });
-
-        it('displays active submit cancel button', () => {
-          expect(FeeFineDetails.errorModalSubmitIsDisabled).to.be.false;
-        });
-
-        describe('cancel fine', () => {
-          beforeEach(async () => {
-            await FeeFineDetails.errorModalSubmit.click();
-          });
-
-          it('show successfull callout', () => {
-            expect(FeeFineDetails.callout.successCalloutIsPresent).to.be.true;
           });
         });
       });


### PR DESCRIPTION
# Description
Allow `cancel` fee/fine as `error ` only if any actions has not been applied and disabled `error` button if any actions were occured.
# Story
https://issues.folio.org/browse/UIU-1894
# Screenshots
![image](https://user-images.githubusercontent.com/55694637/96734051-cd11a180-13c2-11eb-98a8-0bbf43744881.png)
![image](https://user-images.githubusercontent.com/55694637/96734108-dbf85400-13c2-11eb-9957-3a5364692201.png)
