### PR TITLE
UIU-1930: Allow override for not loanable items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Manual patron block expiration date changing when patron block viewed. Refs UIU-1942.
 * Case-insensitive sort of filter options. Refs UIIN-1948.
 * Increment `@folio/stripes` to `^5.0.2`. Refs UIU-1932, UIU-1935.
+* Allow override for not loanable items when loan policy is not recognised. Fixes UIU-1930.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
+++ b/src/components/Loans/OpenLoans/helpers/isOverridePossible/overridePossibleMessages.js
@@ -35,4 +35,8 @@ export default [
     message: 'renewal would not change the due date',
     showDueDatePicker: true,
   },
+  {
+    message: 'profile "" in the loan policy is not recognised',
+    showDueDatePicker: true,
+  },
 ];

--- a/test/bigtest/network/scenarios/request-related-failure-multiple-errors.js
+++ b/test/bigtest/network/scenarios/request-related-failure-multiple-errors.js
@@ -16,6 +16,13 @@ export default (server) => {
         'value' : 'b67e73a8-b6b7-46fd-a918-77ce907dd3aa'
       }]
     },
+    {
+      'message' : 'profile "" in the loan policy is not recognised',
+      'parameters' : [{
+        'key' : 'request id',
+        'value' : 'b67e73a8-b6b7-46fd-a918-77ce907dd3aa'
+      }]
+    },
     ]
   }, 422);
 };


### PR DESCRIPTION
Allow override for not loanable items when loan policy is not recognized.

https://issues.folio.org/browse/UIU-1930

It looks like we need to handle one more additional error coming from the server in order to allow for override.

