### PR TITLE
UIU-1968: Show default fee/fine types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Allow override for not loanable items when loan policy is not recognised. Fixes UIU-1930.
 * Show correct number of due date changes. Fixes UIU-1952.
 * Add "Users: User loans anonymize" permission. Refs UIU-1535.
+* New Fee/Fine page not listing Fee/Fine Types for selected Fee/Fine Owner. Refs UIU-1968.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -437,7 +437,7 @@ class ChargeFeeFine extends React.Component {
         if (owner !== undefined) { list.push(owner); }
       }
     });
-    const feefines = (this.state.ownerId !== '0') ? (resources.feefines || {}).records || [] : [];
+    const feefines = _.get(resources, ['allfeefines', 'records'], []);
     const payments = _.get(resources, ['payments', 'records'], []).filter(p => p.ownerId === this.state.ownerId);
     const accounts = _.get(resources, ['accounts', 'records'], []);
     const settings = _.get(resources, ['commentRequired', 'records', 0], {});
@@ -473,6 +473,7 @@ class ChargeFeeFine extends React.Component {
     const servicePointOwnerId = loadServicePoints({ owners: (shared ? owners : list), defaultServicePointId, servicePointsIds });
     const initialOwnerId = ownerId !== '0' ? ownerId : servicePointOwnerId;
     const selectedFeeFine = feefines.find(f => f.id === feeFineTypeId);
+    const currentOwnerFeeFineTypes = feefines.filter(f => f.ownerId === resources.activeRecord.ownerId);
     const selectedOwner = owners.find(o => o.id === initialOwnerId);
     const initialChargeValues = {
       ownerId: resources.activeRecord.ownerId || '',
@@ -493,6 +494,7 @@ class ChargeFeeFine extends React.Component {
           form="feeFineChargeForm"
           initialValues={initialChargeValues}
           defaultServicePointId={defaultServicePointId}
+          feeFineTypeOptions={currentOwnerFeeFineTypes}
           servicePointsIds={servicePointsIds}
           onSubmit={this.onSubmitCharge}
           user={user}

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -73,6 +73,7 @@ class ChargeForm extends React.Component {
     history: PropTypes.object,
     initialValues: PropTypes.object,
     match: PropTypes.object,
+    feeFineTypeOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   }
 
   constructor(props) {
@@ -97,7 +98,7 @@ class ChargeForm extends React.Component {
     }
   }
 
-  onChangeFeeFine(e) {
+  async onChangeFeeFine(e) {
     const {
       feefines,
       form: { change },
@@ -105,7 +106,7 @@ class ChargeForm extends React.Component {
 
     if (e?.target?.value) {
       const feeFineId = e.target.value;
-      this.props.onChangeFeeFine(e);
+      await this.props.onChangeFeeFine(e);
       const feefine = feefines.find(f => f.id === feeFineId) || {};
       change('feeFineId', feefine.id);
       this.amount = feefine.defaultAmount || 0;
@@ -142,6 +143,7 @@ class ChargeForm extends React.Component {
       onSubmit,
       handleSubmit,
       initialValues,
+      feeFineTypeOptions,
       form,
       form : {
         getState,
@@ -180,7 +182,7 @@ class ChargeForm extends React.Component {
       if (own.owner !== 'Shared') ownerOptions.push({ label: own.owner, value: own.id });
     });
 
-    this.props.feefines.forEach((feefineItem) => {
+    feeFineTypeOptions.forEach((feefineItem) => {
       const fee = {};
       fee.label = feefineItem.feeFineType;
       fee.value = feefineItem.id;
@@ -252,7 +254,6 @@ class ChargeForm extends React.Component {
               isPending={isPending}
               onChangeOwner={this.onChangeOwner}
               onChangeFeeFine={this.onChangeFeeFine}
-              feefines={this.props.feefines}
               feefineList={feefineList}
             />
             <br />

--- a/src/components/Accounts/ChargeFeeFine/FeeFineInfo.js
+++ b/src/components/Accounts/ChargeFeeFine/FeeFineInfo.js
@@ -17,7 +17,6 @@ class FeeFineInfo extends React.Component {
     onChangeOwner: PropTypes.func,
     ownerOptions: PropTypes.arrayOf(PropTypes.object),
     onChangeFeeFine: PropTypes.func,
-    feefines: PropTypes.arrayOf(PropTypes.object),
     isPending: PropTypes.object,
   };
 

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -455,6 +455,8 @@ export default function config() {
     return server.create('feefineaction', ffAction);
   });
 
+  this.get('/feefines');
+
   this.get('/owners', ({ owners }) => {
     return this.serializerOrRegistry.serialize(owners.all());
   });


### PR DESCRIPTION
# Description
New Fee/Fine page not listing Fee/Fine Types for predefined selected Fee/Fine Owner
# Approach
Since `ChargeFeeFine` form was migrated to `react-final-form` this issue with selects of `Fee/Fine Owner` and `Fee/Fine Type` appeared, because for proper work of this related to each other selects we should pass `Fee/Fine Owner` in initial values. Accordingly appears the problem that  `Fee/Fine Owner` exists but `Fee/Fine Type` does not show any options, so now `Fee/Fine Types` for initial `Fee/Fine Owner` is passing in prop as `dataOptions` for `Fee/Fine Type` select.
Also to get proper `Fee/Fine Type` select value, we should `await` while parent's `onChange` handler will update the `state`.
# Issue
https://issues.folio.org/browse/UIU-1968
# Screenshots
**Before**
![1968-before](https://user-images.githubusercontent.com/55694637/99268206-82524080-282d-11eb-9694-5f09689dfc43.png)
**After**
![1968-after](https://user-images.githubusercontent.com/55694637/99268222-87af8b00-282d-11eb-8aee-e9b1c8dffd8b.png)


