### PR TITLE
UIU-1975: Fix empty payments select

### DIFF
--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -438,7 +438,6 @@ class ChargeFeeFine extends React.Component {
       }
     });
     const feefines = _.get(resources, ['allfeefines', 'records'], []);
-    const payments = _.get(resources, ['payments', 'records'], []).filter(p => p.ownerId === this.state.ownerId);
     const accounts = _.get(resources, ['accounts', 'records'], []);
     const settings = _.get(resources, ['commentRequired', 'records', 0], {});
     const barcode = _.get(resources, 'activeRecord.barcode');
@@ -475,6 +474,10 @@ class ChargeFeeFine extends React.Component {
     const selectedFeeFine = feefines.find(f => f.id === feeFineTypeId);
     const currentOwnerFeeFineTypes = feefines.filter(f => f.ownerId === resources.activeRecord.ownerId);
     const selectedOwner = owners.find(o => o.id === initialOwnerId);
+    const payments = _.get(resources, ['payments', 'records'], []).filter(
+      p => p.ownerId === this.state.ownerId || resources.activeRecord.ownerId
+    );
+
     const initialChargeValues = {
       ownerId: resources.activeRecord.ownerId || '',
       notify: !!(selectedFeeFine?.chargeNoticeId || selectedOwner?.defaultChargeNoticeId),

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -438,6 +438,7 @@ class ChargeFeeFine extends React.Component {
       }
     });
     const feefines = _.get(resources, ['allfeefines', 'records'], []);
+    const payments = _.get(resources, ['payments', 'records'], []);
     const accounts = _.get(resources, ['accounts', 'records'], []);
     const settings = _.get(resources, ['commentRequired', 'records', 0], {});
     const barcode = _.get(resources, 'activeRecord.barcode');
@@ -474,9 +475,6 @@ class ChargeFeeFine extends React.Component {
     const selectedFeeFine = feefines.find(f => f.id === feeFineTypeId);
     const currentOwnerFeeFineTypes = feefines.filter(f => f.ownerId === resources.activeRecord.ownerId);
     const selectedOwner = owners.find(o => o.id === initialOwnerId);
-    const payments = _.get(resources, ['payments', 'records'], []).filter(
-      p => p.ownerId === this.state.ownerId || resources.activeRecord.ownerId
-    );
 
     const initialChargeValues = {
       ownerId: resources.activeRecord.ownerId || '',


### PR DESCRIPTION
# Description
'Payment methods' not always appearing for 'Charge & pay now' option of New fee/fine for predefined Owner
# Issue
https://issues.folio.org/browse/UIU-1975
# Screenshot
![image](https://user-images.githubusercontent.com/55694637/100004304-fb263f00-2dcf-11eb-9b97-3fd84e698b0a.png)
