### PR TITLE
UIU-1045 show "awol loan" when loan is ... awol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * New Fee/Fine page not listing Fee/Fine Types for selected Fee/Fine Owner. Refs UIU-1968.
 * Validate 'Expiration date offset (days)' of patron groups. Refs UIU-1951.
 * Create manual patron block templates in settings. Refs UIU-1909.
+* Show an error message, not a spinner, when a loan is missing. Refs UIU-1045.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/routes/LoanDetailContainer.js
+++ b/src/routes/LoanDetailContainer.js
@@ -108,6 +108,7 @@ class LoanDetailContainer extends React.Component {
     resources: PropTypes.shape({
       loanHistory: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
+        hasLoaded: PropTypes.bool.isRequired,
       }),
       hasManualPatronBlocks: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
@@ -187,6 +188,7 @@ class LoanDetailContainer extends React.Component {
     const {
       resources : {
         loanActions,
+        loanHistory,
         users,
       }
     } = this.props;
@@ -202,6 +204,7 @@ class LoanDetailContainer extends React.Component {
         loans={isEmpty(loan) ? [] : [loan]}
         loanActionsWithUser={loanActionsWithUser}
         loan={loan}
+        loanIsMissing={isEmpty(loan) && loanHistory.hasLoaded}
         user={this.getUser()}
         patronGroup={this.getPatronGroup()}
         patronBlocks={this.getPatronBlocks()}

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -73,6 +73,7 @@ class LoanDetails extends React.Component {
       }),
     }).isRequired,
     loan: PropTypes.object,
+    loanIsMissing: PropTypes.bool,
     patronGroup: PropTypes.object,
     user: PropTypes.object,
     loanActionsWithUser: PropTypes.arrayOf(PropTypes.object),
@@ -301,11 +302,33 @@ class LoanDetails extends React.Component {
       markAsMissing,
       claimReturned,
       declarationInProgress,
+      loanIsMissing,
     } = this.props;
 
     const {
       patronBlockedModal,
     } = this.state;
+
+    if (loanIsMissing) {
+      return (
+        <Paneset isRoot>
+          <Pane
+            id="pane-loandetails-404"
+            defaultWidth="100%"
+            dismissible
+            onClose={this.handleClose}
+            paneTitle={(
+              <FormattedMessage id="ui-users.loans.loanDetails">
+                {(loanDetails) => `${loanDetails} - ${getFullName(user)} (${upperFirst(patronGroup.group)})`}
+              </FormattedMessage>
+            )}
+          >
+            <FormattedMessage id="ui-users.loan404" />
+          </Pane>
+        </Paneset>
+      );
+    }
+
 
     if (!loan || !user || (loan.userId !== user.id)) {
       return (
@@ -316,6 +339,7 @@ class LoanDetails extends React.Component {
         />
       );
     }
+
 
     const loanPolicyName = isEmpty(loanPolicies)
       ? '-'

--- a/test/bigtest/interactors/loan-details-404.js
+++ b/test/bigtest/interactors/loan-details-404.js
@@ -1,0 +1,14 @@
+import {
+  interactor,
+  text,
+} from '@bigtest/interactor';
+
+import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor'; // eslint-disable-line
+
+
+@interactor class LoanDetails404 {
+  static defaultScope = '#pane-loandetails-404-content';
+  message = text();
+}
+
+export default new LoanDetails404({ timeout: 5000 });

--- a/test/bigtest/tests/loan-missing-test.js
+++ b/test/bigtest/tests/loan-missing-test.js
@@ -1,0 +1,33 @@
+import {
+  beforeEach,
+  describe,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import setupApplication from '../helpers/setup-application';
+import LoanDetails404 from '../interactors/loan-details-404';
+
+describe('Missing loan', () => {
+  setupApplication({
+    permissions: {
+      'manualblocks.collection.get': true,
+      'circulation.loans.collection.get': true,
+    },
+  });
+
+  describe('Visiting loan details page for missing loan', () => {
+    beforeEach(async function () {
+      this.server.create('user', { id: 'b612' });
+      this.visit('/users/b612/loans/view/404');
+    });
+
+    it('should display "could not retrieve loan" pane', () => {
+      expect(LoanDetails404.isPresent).to.be.true;
+    });
+
+    it('should display "could not retrieve loan" message', () => {
+      expect(LoanDetails404.message).to.equal('The requested loan could not be retrieved.');
+    });
+  });
+});

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -839,5 +839,6 @@
   "index.barcode": "Barcode",
   "index.lastName": "Last name",
   "index.username": "Username",
-  "index.all": "Keyword (name, email, identifier)"
+  "index.all": "Keyword (name, email, identifier)",
+  "loan404": "The requested loan could not be retrieved."
 }


### PR DESCRIPTION
If a URL for a loan is bookmarked (or copied, or stored in any way,
really), and then that loan is anonymized, show a "can't find that loan"
message.

Previously, the loan-details page would instead show a "loading"
spinner, as though the loan were being retrieved and just hadn't loaded
yet. Now, we show a "missing loan" message when fetching a user's loans
has finished and no matching loan is present.

Refs [UIU-1045](https://issues.folio.org/browse/UIU-1045)