### PR TITLE
UIU-1980: Disable Charge&pay button

### DIFF
--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -207,7 +207,8 @@ class ChargeForm extends React.Component {
         </Button>
         <Button
           id="chargeAndPay"
-          disabled={pristine || submitting || !valid}
+          // disabled={pristine || submitting || !valid}
+          disabled={true}
           onClick={() => {
             change('pay', true);
             handleSubmit(data => onSubmit(data));

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -207,8 +207,8 @@ class ChargeForm extends React.Component {
         </Button>
         <Button
           id="chargeAndPay"
+          disabled
           // disabled={pristine || submitting || !valid}
-          disabled={true}
           onClick={() => {
             change('pay', true);
             handleSubmit(data => onSubmit(data));

--- a/test/bigtest/tests/charge-and-pay-fee-fine-test.js
+++ b/test/bigtest/tests/charge-and-pay-fee-fine-test.js
@@ -90,7 +90,7 @@ describe('Charge and pay fee/fine', () => {
           expect(chargeFeeFine.amountField.val).to.equal('500.00');
         });
 
-        describe('Charge and pay fee/fine', () => {
+        describe.skip('Charge and pay fee/fine', () => {
           beforeEach(async () => {
             await chargeFeeFine.submitChargeAndPay.click();
           });


### PR DESCRIPTION
# Description
Since there are have appeared few bugs related to creation Fee/Fines through `Charge&pay` button, the decision was made to show always disabled `Charge&pay` button for [bugfest env](https://bugfest-honeysuckle.folio.ebsco.com/)
# Task
https://issues.folio.org/browse/UIU-1980
# Screenshot
![image](https://user-images.githubusercontent.com/55694637/100231034-24111600-2f2f-11eb-87fc-3fd7b29d6c23.png)
