### PR TITLE
UIU-1973 auto-focus Last Name field in user edit form

### DIFF
--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -16,6 +16,8 @@ import {
 
 import css from './EditUserInfo.css';
 
+const autoFocusThisField = { autoFocus: true };
+
 class EditUserInfo extends React.Component {
   static propTypes = {
     accordionId: PropTypes.string.isRequired,
@@ -88,6 +90,7 @@ class EditUserInfo extends React.Component {
               name="personal.lastName"
               id="adduser_lastname"
               component={TextField}
+              props={autoFocusThisField}
               required
               fullWidth
             />

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -16,8 +16,6 @@ import {
 
 import css from './EditUserInfo.css';
 
-const autoFocusThisField = { autoFocus: true };
-
 class EditUserInfo extends React.Component {
   static propTypes = {
     accordionId: PropTypes.string.isRequired,
@@ -90,9 +88,9 @@ class EditUserInfo extends React.Component {
               name="personal.lastName"
               id="adduser_lastname"
               component={TextField}
-              props={autoFocusThisField}
               required
               fullWidth
+              autoFocus
             />
           </Col>
           <Col xs={12} md={3}>


### PR DESCRIPTION
Refs [UIU-1973](https://issues.folio.org/browse/UIU-1973)

In the User Edit form, when the form opens, there were no focused field by default.
Now focus goes to Last Name field.