### PR TITLE
UIU-1985: New Fee/Fine option 'Charge only' no longer creating charge 'action'

### DIFF
--- a/src/routes/AccountDetailsContainer.js
+++ b/src/routes/AccountDetailsContainer.js
@@ -9,8 +9,8 @@ import { FormattedMessage } from 'react-intl';
 import { stripesConnect } from '@folio/stripes/core';
 import { LoadingView } from '@folio/stripes/components';
 
+import { MAX_RECORDS } from '../constants';
 import { calculateOwedFeeFines } from '../components/Accounts/accountFunctions';
-
 import { AccountDetails } from '../views';
 
 class AccountDetailsContainer extends React.Component {
@@ -39,14 +39,14 @@ class AccountDetailsContainer extends React.Component {
       path: 'accounts',
       params: {
         query: 'userId==:{id}',
-        limit: '1000',
+        limit: MAX_RECORDS,
       },
     },
     accountActions: {
       type: 'okapi',
       records: 'feefineactions',
       accumulate: 'true',
-      path: 'feefineactions?query=(accountId==:{accountid})&limit=10000',
+      path: `feefineactions?query=(accountId==:{accountid})&limit=${MAX_RECORDS}`,
     },
     activeRecord: {
       accountId: '0',

--- a/src/routes/ChargeFeesFinesContainer.js
+++ b/src/routes/ChargeFeesFinesContainer.js
@@ -79,16 +79,22 @@ class ChargeFeesFinesContainer extends React.Component {
     accounts: {
       type: 'okapi',
       records: 'accounts',
-      path: 'accounts',
+      GET: {
+        path: `accounts?query=(userId==:{id})&limit=${MAX_RECORDS}`,
+      },
       PUT: {
         path: 'accounts/%{activeRecord.id}'
+      },
+      POST: {
+        path: 'accounts'
       },
     },
     account: {
       type: 'okapi',
       resource: 'accounts',
       accumulate: 'true',
-      path: `accounts?limit=${MAX_RECORDS}`,
+      fetch: false,
+      path: 'accounts',
     },
     owners: {
       type: 'okapi',


### PR DESCRIPTION
# Description
Since on bugfest env New Fee/Fine option 'Charge only' no longer creating charge 'action', the problem appeared after huge amount of testing fee/fines. 
# Issue
https://issues.folio.org/browse/UIU-1985
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/100728889-c702dd80-33d0-11eb-867b-746f8eb7f976.png)
**After**
![image](https://user-images.githubusercontent.com/55694637/100728920-d2560900-33d0-11eb-9828-214215dc86b9.png)
