### PR TITLE
Increased "notes" interface version to "2.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Show an error message, not a spinner, when a loan is missing. Refs UIU-1045.
 * Remove "Users: User loan edit" permission.
 * Add "Users: User loans change due date" permission.
+* Increment `notes` interface to `2.0`
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "optionalOkapiInterfaces": {
       "circulation": "9.0",
       "feesfines": "16.1",
-      "notes": "1.0"
+      "notes": "2.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Description
- Increased `notes` interface version to `2.0`.

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/967
https://github.com/folio-org/ui-notes/pull/134