### PR TITLE
UIU-1981: Show correct fee/fine source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Show an error message, not a spinner, when a loan is missing. Refs UIU-1045.
 * Remove "Users: User loan edit" permission.
 * Add "Users: User loans change due date" permission.
+* Show correct source of fee/fine in payment 'action' for 'Charge & pay now'. Refs UIU-1981.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -317,11 +317,11 @@ class ChargeFeeFine extends React.Component {
     const {
       intl: { formatMessage },
       okapi: {
+        currentUser,
         currentUser: {
           curServicePoint: { id: servicePointId }
         },
       },
-      user,
       mutator,
     } = this.props;
     const tagStaff = formatMessage({ id: 'ui-users.accounts.actions.tag.staff' });
@@ -353,7 +353,7 @@ class ChargeFeeFine extends React.Component {
         amount: values.amount,
         notifyPatron: values.notify,
         servicePointId,
-        userName: getFullName(user),
+        userName: `${currentUser.lastName}, ${currentUser.firstName}`,
         paymentMethod: values.method,
         comments: comment,
         transactionInfo: values.transaction

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -207,8 +207,7 @@ class ChargeForm extends React.Component {
         </Button>
         <Button
           id="chargeAndPay"
-          disabled
-          // disabled={pristine || submitting || !valid}
+          disabled={pristine || submitting || !valid}
           onClick={() => {
             change('pay', true);
             handleSubmit(data => onSubmit(data));

--- a/test/bigtest/network/factories/feefineaction.js
+++ b/test/bigtest/network/factories/feefineaction.js
@@ -9,7 +9,7 @@ export default Factory.extend({
   comments: (i) => 'This is a comment' + i,
   createdAt: 'Main Circ',
   dateAction: '2019-04-22T22:07:07.343+0000',
-  source: 'ADMINISTRATOR, DIKU',
+  source: 'User, Test',
   transactionInformation: '-',
   typeAction: 'Late',
   userId: '2da52ef1-81b8-4d7d-9b56-aba7f6885a72'

--- a/test/bigtest/tests/charge-and-pay-fee-fine-test.js
+++ b/test/bigtest/tests/charge-and-pay-fee-fine-test.js
@@ -21,7 +21,8 @@ describe('Charge and pay fee/fine', () => {
   });
 
   describe('from the user detail view', () => {
-    let user, account;
+    let user;
+    let account;
     beforeEach(async function () {
       const owner = this.server.create('owner', {
         owner: 'testOwner',

--- a/test/bigtest/tests/charge-and-pay-fee-fine-test.js
+++ b/test/bigtest/tests/charge-and-pay-fee-fine-test.js
@@ -10,6 +10,7 @@ import { expect } from 'chai';
 
 import setupApplication from '../helpers/setup-application';
 import ChargeFeeFineInteractor from '../interactors/charge-fee-fine';
+import FeeFineHistoryInteractor from '../interactors/fee-fine-history';
 
 describe('Charge and pay fee/fine', () => {
   const chargeFeeFine = new ChargeFeeFineInteractor();
@@ -20,7 +21,7 @@ describe('Charge and pay fee/fine', () => {
   });
 
   describe('from the user detail view', () => {
-    let user;
+    let user, account;
     beforeEach(async function () {
       const owner = this.server.create('owner', {
         owner: 'testOwner',
@@ -37,7 +38,7 @@ describe('Charge and pay fee/fine', () => {
         defaultAmount: 500
       });
       user = this.server.create('user');
-      const account = this.server.create('account', { userId: user.id });
+      account = this.server.create('account', { userId: user.id });
       this.server.create('feefineaction', {
         accountId: account.id,
         amountAction: 500,
@@ -90,7 +91,7 @@ describe('Charge and pay fee/fine', () => {
           expect(chargeFeeFine.amountField.val).to.equal('500.00');
         });
 
-        describe.skip('Charge and pay fee/fine', () => {
+        describe('Charge and pay fee/fine', () => {
           beforeEach(async () => {
             await chargeFeeFine.submitChargeAndPay.click();
           });
@@ -134,6 +135,17 @@ describe('Charge and pay fee/fine', () => {
 
                 it('show successfull callout', () => {
                   expect(chargeFeeFine.callout.successCalloutIsPresent).to.be.true;
+                });
+
+                describe('visit created Fee/Fine details page', () => {
+                  beforeEach(function () {
+                    visit(`/users/${user.id}/accounts/view/${account.id}`);
+                  });
+
+                  it('displays source of fee/fine', () => {
+                    expect(FeeFineHistoryInteractor.mclAccountActions.rows(0).cells(6).content).to.equal('User, Test');
+                    expect(FeeFineHistoryInteractor.mclAccountActions.rows(1).cells(6).content).to.equal('User, Test');
+                  });
                 });
               });
             });


### PR DESCRIPTION
# Description
When you generate a manual fee/fine using the 'Charge & pay now' option, two 'actions' are created. One for the charge and one for the payment. Both payments 'action' should be listing the Source as the staff member who took the payment.

Also in scope of this ticket the button "Charge & pay now" became active again. 
# Issue
https://issues.folio.org/browse/UIU-1981
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/100899187-3b6d7780-34ca-11eb-9633-ed2e310ba03a.png)
**After**
![image](https://user-images.githubusercontent.com/55694637/100899107-255fb700-34ca-11eb-9bef-caa56d01f45c.png)