### PR TITLE
UIU-1912: Fix selection of service points to display in the user record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Add "Users: User loans change due date" permission.
 * Show correct source of fee/fine in payment 'action' for 'Charge & pay now'. Refs UIU-1981.
 * Change `limit=100` to `limit=2000` across the board; patrons have more than 100 things. All. The. Time. Refs UIU-1987.
+* Fix the selection of service points from the `Add service points` popup to display in the user record. Fixes UIU-1912.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/EditSections/EditServicePoints/EditServicePoints.js
+++ b/src/components/EditSections/EditServicePoints/EditServicePoints.js
@@ -46,11 +46,10 @@ class EditServicePoints extends React.Component {
     };
   }
 
-  onAddServicePoints = (newServicePoints) => {
-    const userServicePoints = uniqBy([
-      ...this.userServicePoints.getAll(),
-      ...newServicePoints,
-    ], 'id').sort(((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true })));
+  onAddServicePoints = newServicePoints => {
+    const userServicePoints = newServicePoints.sort(
+      (a, b) => a.name.localeCompare(b.name, undefined, { numeric: true })
+    );
 
     this.userServicePoints.removeAll();
     userServicePoints.map(sp => this.userServicePoints.push(sp));

--- a/test/bigtest/tests/service-points-modal-test.js
+++ b/test/bigtest/tests/service-points-modal-test.js
@@ -66,6 +66,19 @@ describe('Service points modal', () => {
             expect(UserFormPage.servicePoints().length).to.equal(2);
           });
 
+          describe('when unchecking all service points', () => {
+            beforeEach(async function () {
+              await UserFormPage.addServicePointButton.click();
+              await UserFormPage.servicePointsModal.checkBoxes(1).clickInput();
+              await UserFormPage.servicePointsModal.checkBoxes(2).clickInput();
+              await UserFormPage.servicePointsModal.saveButton.click();
+            });
+
+            it('service points should not be displayed', () => {
+              expect(UserFormPage.servicePoints().length).to.equal(0);
+            });
+          });
+
           describe('when deleting all service points', () => {
             beforeEach(async function () {
               await UserFormPage.servicePoints(1).deleteServicePoint();


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1912

### Purpose
To be similar to the `Add permissions` functionality, the mechanism for selecting service points to be displayed in the user record has been changed. Now only the marked service points will be displayed, and not added to the existing ones, as it was before.

### Demo
![chrome-capture](https://user-images.githubusercontent.com/49517355/101495206-f4bbc980-3970-11eb-92af-6f342a179ebd.gif)
