### PR TITLE
UIU-1897: Refresh feeFineActions

### DIFF
--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -44,7 +44,9 @@ class Actions extends React.Component {
       records: 'feefineactions',
       path: `feefineactions?query=(userId==%{user.id})&limit=${MAX_RECORDS}`,
       shouldRefresh: (resource, action, refresh) => {
-        return refresh || action.meta.path === 'accounts';
+        const { path } = action.meta;
+
+        return refresh || path === 'accounts' || path === 'accounts-bulk';
       },
     },
     payments: {


### PR DESCRIPTION
# Description
The multiple refund in Fees/Fines History does not refresh right after the multiple waive 
# In scope of
https://issues.folio.org/browse/UIU-1897