### PR TITLE
UIU-2004: Set informative message when error declaring item lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Increment `notes` interface to `2.0`
 * Refactor to avoid deprecated props to `<Dropdown>`. Refs UIU-2007, STCOM-791.
 * Use patron block templates to populate fields in create block screen. Refs UIU-1910.
+* Set informative message when error declaring item lost. Fixes UIU-2004.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/ErrorModal/ErrorModal.js
+++ b/src/components/ErrorModal/ErrorModal.js
@@ -21,6 +21,7 @@ const ErrorModal = (props) => {
 
   return (
     <Modal
+      data-test-error-modal
       size="small"
       footer={footer}
       dismissible

--- a/src/components/LoanActionDialog/LoanActionDialog.js
+++ b/src/components/LoanActionDialog/LoanActionDialog.js
@@ -52,7 +52,10 @@ class LoanActionDialog extends React.Component {
 
     const footer = (
       <ModalFooter>
-        <Button onClick={this.clearErrorMessage}>
+        <Button
+          data-test-close-button
+          onClick={this.clearErrorMessage}
+        >
           <FormattedMessage id="ui-users.blocks.closeButton" />
         </Button>
       </ModalFooter>

--- a/src/components/LoanActionDialog/LoanActionDialog.js
+++ b/src/components/LoanActionDialog/LoanActionDialog.js
@@ -1,9 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
-import { Modal } from '@folio/stripes/components';
+import {
+  Button,
+  Modal,
+  ModalFooter,
+} from '@folio/stripes/components';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
+import ErrorModal from '../ErrorModal';
 import ModalContent from '../ModalContent';
+
+import { NO_FEE_FINE_OWNER_FOUND_MESSAGE } from '../../constants';
 
 class LoanActionDialog extends React.Component {
   static propTypes = {
@@ -15,6 +24,10 @@ class LoanActionDialog extends React.Component {
     disableButton: PropTypes.func,
     itemRequestCount: PropTypes.number.isRequired,
   };
+
+  setErrorMessage = errorMessage => this.setState({ errorMessage });
+
+  clearErrorMessage = () => this.setState({ errorMessage: null });
 
   render() {
     const {
@@ -29,24 +42,56 @@ class LoanActionDialog extends React.Component {
 
     if (!loan) return null;
 
-    return (
-      <Modal
-        id={`${loanAction}-modal`}
-        size="small"
-        dismissible
-        closeOnBackgroundClick
-        open={open}
-        label={modalLabel}
-        onClose={onClose}
-      >
-        <ModalContent
-          loanAction={loanAction}
-          loan={loan}
-          itemRequestCount={itemRequestCount}
-          onClose={onClose}
-          disableButton={disableButton}
+    const informativeErrorMessage = (
+      <>
+        <SafeHTMLMessage id="ui-users.feefines.errors.notBilledMessage" />
+        <br />
+        <SafeHTMLMessage id="ui-users.feefines.errors.updateOwnerMessage" />
+      </>
+    );
+
+    const footer = (
+      <ModalFooter>
+        <Button onClick={this.clearErrorMessage}>
+          <FormattedMessage id="ui-users.blocks.closeButton" />
+        </Button>
+      </ModalFooter>
+    );
+
+    const errorModal =
+      this.state?.errorMessage === NO_FEE_FINE_OWNER_FOUND_MESSAGE
+        ? <ErrorModal
+          label={<FormattedMessage id="ui-users.feefines.errors.notBilledTitle" />}
+          open={!!this.state.errorMessage}
+          message={informativeErrorMessage}
+          dismissible={false}
+          footer={footer}
+          onClose={this.clearErrorMessage}
         />
-      </Modal>
+        : null;
+
+    return (
+      <>
+        <Modal
+          id={`${loanAction}-modal`}
+          size="small"
+          dismissible
+          closeOnBackgroundClick
+          open={open}
+          label={modalLabel}
+          onClose={onClose}
+        >
+          <ModalContent
+            loanAction={loanAction}
+            loan={loan}
+            itemRequestCount={itemRequestCount}
+            onClose={onClose}
+            disableButton={disableButton}
+            handleError={this.setErrorMessage}
+          />
+        </Modal>
+        {errorModal}
+      </>
     );
   }
 }

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -31,6 +31,7 @@ class ModalContent extends React.Component {
     declareLost: {
       type: 'okapi',
       fetch: false,
+      throwErrors: false,
       POST: {
         path: 'circulation/loans/!{loan.id}/declare-item-lost',
       },
@@ -65,6 +66,7 @@ class ModalContent extends React.Component {
     loanAction: PropTypes.string.isRequired,
     loan: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
+    handleError: PropTypes.func.isRequired,
     disableButton: PropTypes.func,
     itemRequestCount: PropTypes.number.isRequired,
   };
@@ -122,10 +124,26 @@ class ModalContent extends React.Component {
 
     disableButton();
 
-    await POST(requestData);
+    try {
+      await POST(requestData);
+    } catch (error) {
+      this.processError(error);
+    }
 
     onClose();
   };
+
+  processError(resp) {
+    const { handleError } = this.props;
+
+    const contentType = resp.headers.get('Content-Type') || '';
+
+    if (contentType.startsWith('application/json')) {
+      resp.json().then(error => handleError(error.errors[0].message));
+    } else {
+      resp.text().then(handleError);
+    }
+  }
 
   render() {
     const {

--- a/src/constants.js
+++ b/src/constants.js
@@ -130,3 +130,5 @@ export const refundReportColumns = [
   'staffMemberName',
   'actionTaken'
 ];
+
+export const NO_FEE_FINE_OWNER_FOUND_MESSAGE = 'No fee/fine owner found for item\'s permanent location';

--- a/test/bigtest/interactors/open-loans.js
+++ b/test/bigtest/interactors/open-loans.js
@@ -53,6 +53,14 @@ import DialogInteractor from './dialog';
   confirmButton = clickable('[data-test-bulk-cr-continue-button]');
 }
 
+@interactor class ErrorModal {
+  static defaultScope = '[data-test-error-modal]';
+
+  headline = text('[data-test-headline]');
+  content = text('[class^="modalContent---"] p');
+  closeButton = new ButtonInteractor('[data-test-close-button]');
+}
+
 @interactor class OpenLoans {
   static defaultScope = '[data-test-open-loans]';
 
@@ -74,6 +82,7 @@ import DialogInteractor from './dialog';
   patronBlockModal = new PatronBlockModal();
   changeDueDateOverlay = new ChangeDueDateOverlay();
   bulkClaimReturnedModal = new BulkClaimReturnedModal();
+  errorModal = new ErrorModal();
   declareLostDialog = new DialogInteractor('#declareLost-modal');
   claimReturnedDialog = new DialogInteractor('#claimReturned-modal');
   markAsMissingDialog = new DialogInteractor('#markAsMissing-modal');

--- a/test/bigtest/tests/declare-lost-test.js
+++ b/test/bigtest/tests/declare-lost-test.js
@@ -11,6 +11,8 @@ import DummyComponent from '../helpers/DummyComponent';
 import OpenLoansInteractor from '../interactors/open-loans';
 import LoanActionsHistory from '../interactors/loan-actions-history';
 
+import translations from '../../../translations/ui-users/en';
+
 describe('Declare Lost', () => {
   const requestsPath = '/requests';
   const requestsAmount = 5;
@@ -142,6 +144,44 @@ describe('Declare Lost', () => {
 
             it('should hide declare lost dialog', () => {
               expect(OpenLoansInteractor.declareLostDialog.isPresent).to.be.false;
+            });
+          });
+
+          describe('when no fee/fine owner found', () => {
+            const errorMessage = 'No fee/fine owner found for item\'s permanent location';
+
+            beforeEach(async function () {
+              this.server.post(`/circulation/loans/${loan.id}/declare-item-lost`, () => {
+                return new Response(422, { 'Content-Type': 'application/json' }, {
+                  errors: [{
+                    message: errorMessage,
+                  }]
+                });
+              });
+
+              await OpenLoansInteractor.declareLostDialog.confirmButton.click();
+            });
+
+            it('should display error modal', () => {
+              expect(OpenLoansInteractor.errorModal.isPresent).to.be.true;
+            });
+
+            it('error modal should have title', () => {
+              expect(OpenLoansInteractor.errorModal.headline).to.equal(translations['feefines.errors.notBilledTitle']);
+            });
+
+            it('error modal should have content', () => {
+              expect(OpenLoansInteractor.errorModal.content).to.include(translations['feefines.errors.updateOwnerMessage']);
+            });
+
+            describe('clicking close button', () => {
+              beforeEach(async () => {
+                await OpenLoansInteractor.errorModal.closeButton.click();
+              });
+
+              it('should not display error modal', () => {
+                expect(OpenLoansInteractor.errorModal.isPresent).to.be.false;
+              });
             });
           });
         });

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -394,6 +394,9 @@
   "feefines.errors.exist": "Fee/fine type exists",
   "feefines.errors.existShared": "Fee/fine type exists for owner {owner}",
   "feefines.errors.reservedName": "Fee/fine type already exists as automated fee/fine",
+  "feefines.errors.notBilledTitle": "Lost item fee(s) not billed to patron",
+  "feefines.errors.notBilledMessage": "Lost item fee(s) not billed to patron because 'Fee/fine owner' not found for item's 'Primary service point' in Setting 'Fee/fine: Owners'.<div><b>Need to bill lost item fee(s) manually.</b></div>",
+  "feefines.errors.updateOwnerMessage": "To avoid error in future, please request that appropriate administrator at institution update 'Fee/fine owner' setting to associate 'Primary service point' to 'Fee/fine owner'.",
 
   "feefines.modal.error": "Select one to continue",
   "feefines.modal.yes": "Yes",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2004

### Purpose
An error modal appears when an item is declared lost and a lost fee will be charged. In this case, a 
fee/fine owner for the item effective permanent location service point must be created.
This PR resolves the bug by displaying a more informative message explaining the cause and how to fix it.

### Screenshot
![Screen Shot 2021-01-06 at 00 38 46](https://user-images.githubusercontent.com/49517355/103707637-ade4e200-4fb7-11eb-8ee9-4ffdcef19d13.png)