### PR TITLE
UIU-1999: Change label in Cancellation Modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * Refactor to avoid deprecated props to `<Dropdown>`. Refs UIU-2007, STCOM-791.
 * Use patron block templates to populate fields in create block screen. Refs UIU-1910.
 * Set informative message when error declaring item lost. Fixes UIU-2004.
+* Change 'Reason for cancellation' to 'Additional information for staff' on Cancel Fee/Fine page. Refs UIU-1999.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/Accounts/Actions/CancellationModal.js
+++ b/src/components/Accounts/Actions/CancellationModal.js
@@ -106,10 +106,10 @@ class CancellationModal extends React.Component {
           <br />
           <Row>
             <Col xs>
-              <FormattedMessage id="ui-users.accounts.cancellation.field.reason" />
+              <FormattedMessage id="ui-users.accounts.commentStaff" />
+              {'*'}
             </Col>
           </Row>
-          <br />
           <Row>
             <Col xs>
               <Field
@@ -142,7 +142,6 @@ class CancellationModal extends React.Component {
                   <FormattedMessage id="ui-users.accounts.field.infoPatron" />
                 </Col>
               </Row>
-              <br />
               <Row>
                 <Col xs>
                   <Field
@@ -151,9 +150,9 @@ class CancellationModal extends React.Component {
                   />
                 </Col>
               </Row>
+              <br />
             </div>
           }
-          <br />
           <Row>
             <Col xs>
               <Button

--- a/src/components/Accounts/Actions/CancellationModal.js
+++ b/src/components/Accounts/Actions/CancellationModal.js
@@ -106,8 +106,7 @@ class CancellationModal extends React.Component {
           <br />
           <Row>
             <Col xs>
-              <FormattedMessage id="ui-users.accounts.commentStaff" />
-              {'*'}
+              <FormattedMessage id="ui-users.accounts.commentStaff" />*
             </Col>
           </Row>
           <Row>

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -287,7 +287,7 @@
   "information.recalculate.modal.text": "Users with patron group {group} usually expire after {offset} days. Do you want to change the expiration date accordingly?",
   "information.recalculate.modal.label": "Recalculate expiration date?",
   "information.recalculate.will.reactivate.user": "User will reactivate after saving",
-  
+
   "proxy.addProxy": "Add",
   "proxy.relationshipCreated": "Relationship Created",
   "proxy.relationshipStatus": "Relationship Status",
@@ -613,7 +613,6 @@
 
   "accounts.cancelError": "Cancelled as error",
 
-  "accounts.cancellation.field.reason": "Reason for cancellation*",
   "accounts.cancellation.field.feefinewill": "fee/fine will be",
   "accounts.cancellation.field.cancelled": "cancelled",
   "accounts.cancellation.field.confirmcancelled": "Confirm fee/fine cancellation",


### PR DESCRIPTION
# Description
- Change 'Reason for cancellation' to 'Additional information for staff' on Cancel Fee/Fine page
- Remove empty line between label and textarea
# Task
https://issues.folio.org/browse/UIU-1999
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/104473688-ec852880-55c5-11eb-8056-3b743fd4bd08.png)
**After**
![image](https://user-images.githubusercontent.com/55694637/104473769-00c92580-55c6-11eb-91bd-0934056f0f0e.png)
