### PR TITLE
UIU-2019: add can override item blocks permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Wrong error message appears when required field not selected on Pay/Waive/Transfer modal. Refs UIU-1991.
 * Create fees/fines EXPORT spreadsheet for single patron and add EXPORT option to Fees/Fines History. Refs UIU-1955, UIU-1958.
 * Add 'User: Can override patron blocks' permission. Refs UIU-2025.
+* Add 'User: Can override item blocks' permission. Refs UIU-2019.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -762,6 +762,15 @@
           "circulation.override-patron-block"
         ],
         "visible": true
+      },
+      {
+        "permissionName": "ui-users.overrideItemBlock",
+        "displayName": "User: Can override item blocks for use with override of item blocks when borrowing",
+        "subPermissions": [
+          "circulation.override-item-limit-block",
+          "circulation.override-item-not-loanable-block"
+        ],
+        "visible": true
       }
     ]
   },

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -826,6 +826,7 @@
   "permission.settings.departments.create.edit.view": "Settings (Users): Create, edit, and view departments",
   "permission.settings.departments.all": "Settings (Users): Create, edit, view, and delete departments",
   "permission.overridePatronBlock":"User: Can override patron blocks for use with override of patron blocks when borrowing, renewing and requesting",
+  "permission.overrideItemBlock":"User: Can override item blocks for use with override of item blocks when borrowing",
   "bulkClaimReturned.item.title": "Title",
   "bulkClaimReturned.preConfirm": "Confirm claim returned",
   "bulkClaimReturned.postConfirm": "Claim returned confirmation",


### PR DESCRIPTION
# Description
- Add 'User: Can override item blocks' permission

# Stories
https://issues.folio.org/browse/UIU-2019