### PR TITLE
UIU-2025: add can override patron blocks permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * Accessibility: Invalid ARIA attribute. Refs UIU-1685.
 * Wrong error message appears when required field not selected on Pay/Waive/Transfer modal. Refs UIU-1991.
 * Create fees/fines EXPORT spreadsheet for single patron and add EXPORT option to Fees/Fines History. Refs UIU-1955, UIU-1958.
+* Add 'User: Can override patron blocks' permission. Refs UIU-2025.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -754,6 +754,14 @@
           "ui-users.settings.departments.delete"
         ],
         "visible": true
+      },
+      {
+        "permissionName": "ui-users.overridePatronBlock",
+        "displayName": "User: Can override patron blocks for use with override of patron blocks when borrowing, renewing and requesting",
+        "subPermissions": [
+          "circulation.override-patron-block"
+        ],
+        "visible": true
       }
     ]
   },

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -825,6 +825,7 @@
   "permission.settings.departments.delete": "Settings (Users): Delete departments",
   "permission.settings.departments.create.edit.view": "Settings (Users): Create, edit, and view departments",
   "permission.settings.departments.all": "Settings (Users): Create, edit, view, and delete departments",
+  "permission.overridePatronBlock":"User: Can override patron blocks for use with override of patron blocks when borrowing, renewing and requesting",
   "bulkClaimReturned.item.title": "Title",
   "bulkClaimReturned.preConfirm": "Confirm claim returned",
   "bulkClaimReturned.postConfirm": "Claim returned confirmation",


### PR DESCRIPTION
# Description
- Add 'User: Can override patron blocks' permission

# Stories
https://issues.folio.org/browse/UIU-2025