### PR TITLE
UIU-2019: Add permission for can override item blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -765,7 +765,7 @@
       },
       {
         "permissionName": "ui-users.overrideItemBlock",
-        "displayName": "User: Can override item blocks for use with override of item blocks when borrowing",
+        "displayName": "User: Can override item blocks",
         "subPermissions": [
           "circulation.override-item-limit-block",
           "circulation.override-item-not-loanable-block"

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -830,7 +830,7 @@
   "permission.settings.departments.create.edit.view": "Settings (Users): Create, edit, and view departments",
   "permission.settings.departments.all": "Settings (Users): Create, edit, view, and delete departments",
   "permission.overridePatronBlock":"User: Can override patron blocks for use with override of patron blocks when borrowing, renewing and requesting",
-  "permission.overrideItemBlock":"User: Can override item blocks for use with override of item blocks when borrowing",
+  "permission.overrideItemBlock":"User: Can override item blocks",
   "bulkClaimReturned.item.title": "Title",
   "bulkClaimReturned.preConfirm": "Confirm claim returned",
   "bulkClaimReturned.postConfirm": "Claim returned confirmation",


### PR DESCRIPTION
# Description
- Add 'User: Can override item blocks' permission

# Stories
https://issues.folio.org/browse/UIU-2019