### PR TITLE
UIU-2025: Add permission for can override patron blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -757,7 +757,7 @@
       },
       {
         "permissionName": "ui-users.overridePatronBlock",
-        "displayName": "User: Can override patron blocks for use with override of patron blocks when borrowing, renewing and requesting",
+        "displayName": "User: Can override patron blocks",
         "subPermissions": [
           "circulation.override-patron-block"
         ],

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -829,7 +829,7 @@
   "permission.settings.departments.delete": "Settings (Users): Delete departments",
   "permission.settings.departments.create.edit.view": "Settings (Users): Create, edit, and view departments",
   "permission.settings.departments.all": "Settings (Users): Create, edit, view, and delete departments",
-  "permission.overridePatronBlock":"User: Can override patron blocks for use with override of patron blocks when borrowing, renewing and requesting",
+  "permission.overridePatronBlock":"User: Can override patron blocks",
   "permission.overrideItemBlock":"User: Can override item blocks",
   "bulkClaimReturned.item.title": "Title",
   "bulkClaimReturned.preConfirm": "Confirm claim returned",


### PR DESCRIPTION
# Description
- Add 'User: Can override patron blocks' permission

# Stories
https://issues.folio.org/browse/UIU-2025