### PR TITLE
UIU-2033: Unable to select today's date for refund report	

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * Add EXPORT option to fees/fines Details. Refs UIU-1956.
 * Change Overdue loans and Claims reports icons in action menu. Refs UIU-2030.
 * Add plus-sign to create buttons in action menu and switch button order. Refs UIU-2031.
+* Unable to select today's date for refund report. Refs UIU-2033.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/RefundsReportModal/RefundsReportModal.js
+++ b/src/components/RefundsReportModal/RefundsReportModal.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
+// import moment from 'moment';
+import moment from 'moment-timezone';
 import { Field } from 'react-final-form';
 import { isEmpty } from 'lodash';
 import {
@@ -57,9 +58,7 @@ const RefundsReportModal = (props) => {
     return disabled;
   };
 
-  const parseDate = (date) => {
-    return moment(date).format('YYYY-MM-DD');
-  };
+  const parseDate = (date) => moment.tz(date, props.timezone).format('YYYY-MM-DD');
 
   const feeFineOwners = props.owners.map(({ id, owner }) => ({
     value: id,
@@ -154,6 +153,7 @@ RefundsReportModal.propTypes = {
   owners: PropTypes.arrayOf(PropTypes.object).isRequired,
   onClose: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
+  timezone: PropTypes.string.isRequired,
 };
 
 export default stripesFinalForm({

--- a/src/components/RefundsReportModal/RefundsReportModal.js
+++ b/src/components/RefundsReportModal/RefundsReportModal.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// import moment from 'moment';
 import moment from 'moment-timezone';
 import { Field } from 'react-final-form';
 import { isEmpty } from 'lodash';

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -97,6 +97,9 @@ class UserSearch extends React.Component {
       }).isRequired,
     }).isRequired,
     source: PropTypes.object,
+    stripes: PropTypes.shape({
+      timezone: PropTypes.string.isRequired,
+    }),
   }
 
   static defaultProps = {
@@ -453,6 +456,7 @@ class UserSearch extends React.Component {
       resources,
       contentRef,
       mutator: { resultOffset },
+      stripes: { timezone },
     } = this.props;
     const visibleColumns = this.getVisibleColumns();
 
@@ -646,6 +650,7 @@ class UserSearch extends React.Component {
               owners={owners}
               onClose={() => { this.changeRefundReportModalState(false); }}
               onSubmit={this.handleRefundsReportFormSubmit}
+              timezone={timezone}
             />
           )}
         </div>


### PR DESCRIPTION
# Description
The issue is related to tenant's timezone. No matter what date is selected, the previous day appears.
# Issue
https://issues.folio.org/browse/UIU-2033