### PR TITLE
STCOR-516 SWR POC

### DIFF
--- a/src/settings/AddressTypesSettings.js
+++ b/src/settings/AddressTypesSettings.js
@@ -4,7 +4,7 @@ import {
   FormattedMessage,
   injectIntl,
 } from 'react-intl';
-import { ControlledVocab } from '@folio/stripes/smart-components';
+import { ControlledVocabSwr as ControlledVocab } from '@folio/stripes/smart-components';
 import { withStripes } from '@folio/stripes/core';
 
 class AddressTypesSettings extends React.Component {


### PR DESCRIPTION
`ControlledVocab` SWR POC from `stripes-smart-components` and
`stripes-core`. 

There's really nothing to see here; the API `<ControlledVocab>` doesn't change any. 

Refs [STCOR-516](https://issues.folio.org/browse/STCOR-516)