### PR TITLE
UIU-2048: Work with Transaction Information field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,11 +59,8 @@
 * Change Overdue loans and Claims reports icons in action menu. Refs UIU-2030.
 * Add plus-sign to create buttons in action menu and switch button order. Refs UIU-2031.
 * Unable to select today's date for refund report. Refs UIU-2033.
-<<<<<<< HEAD
-* Inconsistent behavior of payment action when transaction info is blank. Refs UIU-2048.
-=======
 * Increment `@folio/stripes-cli` to `v2`. Refs UIU-2047.
->>>>>>> a280f36db88c56418fb6d60b84b91a8003ff2737
+* Inconsistent behavior of payment action when transaction info is blank. Refs UIU-2048.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * Change Overdue loans and Claims reports icons in action menu. Refs UIU-2030.
 * Add plus-sign to create buttons in action menu and switch button order. Refs UIU-2031.
 * Unable to select today's date for refund report. Refs UIU-2033.
+* Inconsistent behavior of payment action when transaction info is blank. Refs UIU-2048.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -298,10 +298,11 @@ class Actions extends React.Component {
       userId: this.props.user.id,
       amountAction: parseFloat(amount || 0).toFixed(2),
       balance: parseFloat(balance || 0).toFixed(2),
-      transactionInformation: transaction || '-',
+      transactionInformation: transaction || '',
       comments: comment,
       notify,
     };
+
     return this.props.mutator.feefineactions.POST(Object.assign(action, newAction));
   }
 
@@ -399,7 +400,7 @@ class Actions extends React.Component {
     const payload = this.buildActionBody(values);
 
     if (action === 'pay') {
-      payload.transactionInfo = values.transaction || '-';
+      payload.transactionInfo = values?.transaction ?? '';
     }
 
     mutator[action].POST(payload, ['id'])
@@ -422,7 +423,7 @@ class Actions extends React.Component {
     };
 
     if (action === 'bulkPay') {
-      payload.transactionInfo = values.transaction || '-';
+      payload.transactionInfo = values?.transaction ?? '';
     }
 
     mutator[action].POST(payload, ['id'])

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -196,10 +196,11 @@ class ChargeFeeFine extends React.Component {
         userId: user.id,
         amountAction: parseFloat(amount || 0).toFixed(2),
         balance: parseFloat(balance || 0).toFixed(2),
-        transactionInformation: transaction || '-',
+        transactionInformation: transaction || '',
         comments: comment,
         notify,
       };
+
       mutator.feefineactions.POST(Object.assign(action, newAction));
     });
   }
@@ -356,7 +357,7 @@ class ChargeFeeFine extends React.Component {
         userName: `${currentUser.lastName}, ${currentUser.firstName}`,
         paymentMethod: values.method,
         comments: comment,
-        transactionInfo: values.transaction
+        transactionInfo: values?.transaction ?? '',
       };
 
       return mutator.pay.POST(payBody)

--- a/test/bigtest/network/factories/feefineaction.js
+++ b/test/bigtest/network/factories/feefineaction.js
@@ -10,7 +10,7 @@ export default Factory.extend({
   createdAt: 'Main Circ',
   dateAction: '2019-04-22T22:07:07.343+0000',
   source: 'User, Test',
-  transactionInformation: '-',
+  transactionInformation: '',
   typeAction: 'Late',
   userId: '2da52ef1-81b8-4d7d-9b56-aba7f6885a72'
 });


### PR DESCRIPTION
# Description
Add consistency changes when 'Fee/Fine action' was occured (from all pages: ChargeFeeFine, AccountsHistory, AccountDetails).
Value or empty string will be sent instead of `-`.

- when POST on `${action}` endpoint - field `transactionInfo` is always present with `value` or empty string
- when POST on `feefineactions` endpoint - field `transactionInformation` is always present with `value` or empty string

transactionInformation field should be the same in both objects. Preferably, it should be equal to "". We need to handle this value correctly on the Fee/fine details page and display it as "-".
 
# Task
https://issues.folio.org/browse/UIU-2048