### PR TITLE
UIU-1915 add app dropdown menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * Change Overdue loans and Claims reports icons in action menu. Refs UIU-2030.
 * Add plus-sign to create buttons in action menu and switch button order. Refs UIU-2031.
 * Unable to select today's date for refund report. Refs UIU-2033.
+* Add app dropdown menu. Refs UIU-1915.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,10 @@ class UsersRouting extends React.Component {
           {(handleToggle) => (
             <NavList>
               <NavListSection>
-                <NavListItem onClick={() => { this.shortcutModalToggle(handleToggle); }}>
+                <NavListItem
+                  id="keyboard-shortcuts-item"
+                  onClick={() => { this.shortcutModalToggle(handleToggle); }}
+                >
                   <FormattedMessage id="ui-users.appMenu.keyboardShortcuts" />
                 </NavListItem>
               </NavListSection>
@@ -166,6 +169,7 @@ class UsersRouting extends React.Component {
         </AppContextMenu>
         <Modal
           footer={modalFooter}
+          id="keyboard-shortcuts-modal"
           label={<FormattedMessage id="ui-users.appMenu.keyboardShortcuts" />}
           open={this.state.showInfoModal}
         >

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import { hot } from 'react-hot-loader';
 
-import { Route, Switch, IfPermission } from '@folio/stripes/core';
-import { CommandList, HasCommand } from '@folio/stripes/components';
+import { AppContextMenu, Route, Switch, IfPermission } from '@folio/stripes/core';
+import { NavList, NavListItem, NavListSection, CommandList, HasCommand } from '@folio/stripes/components';
 
 import * as Routes from './routes';
 
@@ -127,63 +127,76 @@ class UsersRouting extends React.Component {
     }
 
     return (
-      <CommandList commands={commands}>
-        <HasCommand
-          commands={this.shortcuts}
-          isWithinScope={this.checkScope}
-          scope={this.shortcutScope}
-        >
-          <Switch>
-            <Route
-              path={`${base}/:id/loans/view/:loanid`}
-              render={(props) => (
-                <IfPermission perm="ui-users.loans.view">
-                  <Routes.LoanDetailContainer {...props} />
-                </IfPermission>
-              )}
-            />
-            <Route
-              path={`${base}/:id/loans/:loanstatus`}
-              render={(props) => (
-                <IfPermission perm="ui-users.loans.view">
-                  <Routes.LoansListingContainer {...props} />
-                </IfPermission>
-              )}
-            />
-            <Route
-              path={`${base}/:id/accounts/view/:accountid`}
-              render={(props) => (
-                <IfPermission perm="ui-users.feesfines.actions.all">
-                  <Routes.AccountDetailsContainer {...props} />
-                </IfPermission>
-              )}
-            />
-            <Route
-              path={`${base}/:id/accounts/:accountstatus`}
-              exact
-              component={Routes.AccountsListingContainer}
-              render={(props) => (
-                <IfPermission perm="ui-users.feesfines.actions.all">
-                  <Routes.AccountsListingContainer {...props} />
-                </IfPermission>
-              )}
-            />
-            <Route path={`${base}/:id/charge/:loanid?`} component={Routes.ChargeFeesFinesContainer} />
-            <Route path={`${base}/:id/patronblocks/edit/:patronblockid`} component={Routes.PatronBlockContainer} />
-            <Route path={`${base}/:id/patronblocks/create`} component={Routes.PatronBlockContainer} />
-            <Route path={`${base}/create`} component={Routes.UserEditContainer} />
-            <Route path={`${base}/:id/edit`} component={Routes.UserEditContainer} />
-            <Route path={`${base}/view/:id`} component={Routes.UserDetailFullscreenContainer} />
-            <Route path={`${base}/notes/new`} exact component={NoteCreatePage} />
-            <Route path={`${base}/notes/:id`} exact component={NoteViewPage} />
-            <Route path={`${base}/notes/:id/edit`} exact component={NoteEditPage} />
-            <Route path={base} component={Routes.UserSearchContainer}>
-              <Route path={`${base}/preview/:id`} component={Routes.UserDetailContainer} />
-            </Route>
-            <Route render={this.noMatch} />
-          </Switch>
-        </HasCommand>
-      </CommandList>
+      <>
+        <AppContextMenu>
+          {(handleToggle) => (
+            <NavList>
+              <NavListSection>
+                <NavListItem>
+                  <FormattedMessage id="ui-users.appMenu.keyboardShortcuts" />
+                </NavListItem>
+              </NavListSection>
+            </NavList>
+          )}
+        </AppContextMenu>
+        <CommandList commands={commands}>
+          <HasCommand
+            commands={this.shortcuts}
+            isWithinScope={this.checkScope}
+            scope={this.shortcutScope}
+          >
+            <Switch>
+              <Route
+                path={`${base}/:id/loans/view/:loanid`}
+                render={(props) => (
+                  <IfPermission perm="ui-users.loans.view">
+                    <Routes.LoanDetailContainer {...props} />
+                  </IfPermission>
+                )}
+              />
+              <Route
+                path={`${base}/:id/loans/:loanstatus`}
+                render={(props) => (
+                  <IfPermission perm="ui-users.loans.view">
+                    <Routes.LoansListingContainer {...props} />
+                  </IfPermission>
+                )}
+              />
+              <Route
+                path={`${base}/:id/accounts/view/:accountid`}
+                render={(props) => (
+                  <IfPermission perm="ui-users.feesfines.actions.all">
+                    <Routes.AccountDetailsContainer {...props} />
+                  </IfPermission>
+                )}
+              />
+              <Route
+                path={`${base}/:id/accounts/:accountstatus`}
+                exact
+                component={Routes.AccountsListingContainer}
+                render={(props) => (
+                  <IfPermission perm="ui-users.feesfines.actions.all">
+                    <Routes.AccountsListingContainer {...props} />
+                  </IfPermission>
+                )}
+              />
+              <Route path={`${base}/:id/charge/:loanid?`} component={Routes.ChargeFeesFinesContainer} />
+              <Route path={`${base}/:id/patronblocks/edit/:patronblockid`} component={Routes.PatronBlockContainer} />
+              <Route path={`${base}/:id/patronblocks/create`} component={Routes.PatronBlockContainer} />
+              <Route path={`${base}/create`} component={Routes.UserEditContainer} />
+              <Route path={`${base}/:id/edit`} component={Routes.UserEditContainer} />
+              <Route path={`${base}/view/:id`} component={Routes.UserDetailFullscreenContainer} />
+              <Route path={`${base}/notes/new`} exact component={NoteCreatePage} />
+              <Route path={`${base}/notes/:id`} exact component={NoteViewPage} />
+              <Route path={`${base}/notes/:id/edit`} exact component={NoteEditPage} />
+              <Route path={base} component={Routes.UserSearchContainer}>
+                <Route path={`${base}/preview/:id`} component={Routes.UserDetailContainer} />
+              </Route>
+              <Route render={this.noMatch} />
+            </Switch>
+          </HasCommand>
+        </CommandList>
+      </ >
     );
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import queryString from 'query-string';
 import { hot } from 'react-hot-loader';
 
 import { AppContextMenu, Route, Switch, IfPermission } from '@folio/stripes/core';
-import { NavList, NavListItem, NavListSection, CommandList, HasCommand } from '@folio/stripes/components';
+import { Button, NavList, NavListItem, NavListSection, CommandList, HasCommand, Modal, ModalFooter } from '@folio/stripes/components';
 
 import * as Routes from './routes';
 
@@ -31,6 +31,14 @@ class UsersRouting extends React.Component {
   }
 
   static actionNames = ['stripesHome', 'usersSortByName'];
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showInfoModal: false,
+    };
+  }
 
   componentDidMount() {
     const {
@@ -103,6 +111,15 @@ class UsersRouting extends React.Component {
     return document.body.contains(document.activeElement);
   }
 
+  shortcutModalToggle(handleToggle) {
+    handleToggle();
+    this.setState({ showInfoModal: true });
+  }
+
+  handleClose = () => {
+    this.setState({ showInfoModal: false });
+  }
+
   render() {
     const {
       showSettings,
@@ -112,6 +129,14 @@ class UsersRouting extends React.Component {
 
     this.shortcutScope = document.body;
     const base = '/users';
+
+    const modalFooter = (
+      <ModalFooter>
+        <Button onClick={this.handleClose}>
+          <FormattedMessage id="ui-users.blocks.closeButton" />
+        </Button>
+      </ModalFooter>
+    );
 
     if (showSettings) {
       return (
@@ -132,13 +157,20 @@ class UsersRouting extends React.Component {
           {(handleToggle) => (
             <NavList>
               <NavListSection>
-                <NavListItem>
+                <NavListItem onClick={() => { this.shortcutModalToggle(handleToggle); }}>
                   <FormattedMessage id="ui-users.appMenu.keyboardShortcuts" />
                 </NavListItem>
               </NavListSection>
             </NavList>
           )}
         </AppContextMenu>
+        <Modal
+          footer={modalFooter}
+          label={<FormattedMessage id="ui-users.appMenu.keyboardShortcuts" />}
+          open={this.state.showInfoModal}
+        >
+          <div />
+        </Modal>
         <CommandList commands={commands}>
           <HasCommand
             commands={this.shortcuts}

--- a/test/bigtest/interactors/application.js
+++ b/test/bigtest/interactors/application.js
@@ -1,6 +1,32 @@
-import { interactor } from '@bigtest/interactor';
+import {
+  ButtonInteractor,
+  clickable,
+  interactor,
+  scoped,
+} from '@bigtest/interactor';
+
+@interactor class KeyboardShortcutsModal {
+  static defaultScope = '#keyboard-shortcuts-modal';
+}
+
+@interactor class ApplicationContextButton {
+  static defaultScope = '[data-test-context-menu-toggle-button]';
+
+  clickAppContextButton = clickable('[data-test-context-menu-toggle-button]');
+}
+
+@interactor class ApplicationContextMenu {
+  static defaultScope = '#App_context_dropdown_menu';
+
+  keyboardShortcutsItem = scoped('#keyboard-shortcuts-item');
+  clickKeyboardShortcutsItem = scoped('#keyboard-shortcuts-item', ButtonInteractor);
+}
 
 // https://bigtestjs.io/guides/interactors/introduction/
 export default @interactor class ApplicationInteractor {
   static defaultScope = '#ModuleContainer';
+
+  keyboardShortcutsModal = new KeyboardShortcutsModal();
+  appContextButton = new ApplicationContextButton();
+  appContextMenu = new ApplicationContextMenu();
 }

--- a/test/bigtest/tests/application-test.js
+++ b/test/bigtest/tests/application-test.js
@@ -21,6 +21,28 @@ describe('Application', function () {
     });
   });
 
+  describe('visit users-app', () => {
+    beforeEach(function () {
+      this.visit('/users?sort=Name');
+    });
+
+    it('renders context button', () => {
+      expect(app.appContextButton.isPresent).to.be.true;
+    });
+    it('renders keyboard shortcuts item', () => {
+      expect(app.appContextMenu.keyboardShortcutsItem.isPresent).to.be.true;
+    });
+
+    describe('click keyboard shortcuts item', () => {
+      beforeEach(async () => {
+        await app.appContextMenu.clickKeyboardShortcutsItem.click();
+      });
+      it('renders keyboard shortcuts modal', () => {
+        expect(app.keyboardShortcutsModal.isPresent).to.be.true;
+      });
+    });
+  });
+
   describe('redirect: loan detail', () => {
     let user;
     let loan;

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -2,7 +2,7 @@
   "user": "User",
   "user.pluralized": "{count} {count, plural, one {user} other {users}}",
   "meta.title": "Users",
-  "appMenu.keyboardShortcuts": "Keyboard Shortcuts",
+  "appMenu.keyboardShortcuts": "Keyboard shortcuts",
   "actions": "Actions",
   "showColumns": "Show columns",
   "loading": "Loading...",

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -2,6 +2,7 @@
   "user": "User",
   "user.pluralized": "{count} {count, plural, one {user} other {users}}",
   "meta.title": "Users",
+  "appMenu.keyboardShortcuts": "Keyboard Shortcuts",
   "actions": "Actions",
   "showColumns": "Show columns",
   "loading": "Loading...",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1915

As a librarian
I want to use shortcut keys to navigate a Folio app(s)

**Screenshot use Agreements as a pattern**
![image](https://user-images.githubusercontent.com/48911833/107622083-9c969180-6c57-11eb-9c82-382b2f4dafef.png)

**PR**
See https://github.com/folio-org/stripes-core/pull/598

**Requirement**
To the right of Users that appears to the left hand side of the screen, display a carat
Carat enables a dropdown
Dropdown should include the following option: Keyboard shortcuts
Selecting Keyboard shortcuts should open Keyboard shortcuts modal
Clicking on Users should behave no differently

