### PR TITLE
UIU-2058 rewording for text on expiration date modal 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * Add Callout for Refund report. Refs UIU-2035.
 * Allow 0 as valid entry for Patron Block Limits. Refs UIU-1998.
 * Add "Save and close" button should be active immediately on refund report criteria modal. Refs UIU-2034.
+* Rewording for text on expiration date modal. Refs UIU-2058.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -52,12 +52,6 @@ class EditUserInfo extends React.Component {
     };
   }
 
-  componentDidMount() {
-    if (this.getPatronGroupOffset()) {
-      this.showModal(true);
-    }
-  }
-
   showModal = (val) => {
     this.setState({
       showRecalculateModal: val,

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -159,7 +159,7 @@ class EditUserInfo extends React.Component {
 
     const offset = this.getPatronGroupOffset();
     const group = _.get(this.props.patronGroups.find(i => i.id === this.state.selectedPatronGroup), 'group', '');
-    const date = moment(this.calculateNewExpirationDate()).format('MMMM Do YYYY');
+    const date = moment(this.calculateNewExpirationDate()).format('LL');
 
     const modalFooter = (
       <ModalFooter>

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -52,6 +52,12 @@ class EditUserInfo extends React.Component {
     };
   }
 
+  componentDidMount() {
+    if (this.getPatronGroupOffset()) {
+      this.showModal(true);
+    }
+  }
+
   showModal = (val) => {
     this.setState({
       showRecalculateModal: val,

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -6,6 +6,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import moment from 'moment-timezone';
 import { OnChange } from 'react-final-form-listeners';
 
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 import {
   Button,
@@ -315,7 +316,7 @@ class EditUserInfo extends React.Component {
           open={this.state.showRecalculateModal}
         >
           <div>
-            <FormattedMessage
+            <SafeHTMLMessage
               id="ui-users.information.recalculate.modal.text"
               values={{ group, offset, date }}
             />

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -62,8 +62,16 @@ class EditUserInfo extends React.Component {
     this.setState({ showRecalculateModal: false });
   }
 
-  recalculateExpirationDate = () => {
-    const { form: { change }, initialValues } = this.props;
+  setRecalculatedExpirationDate = () => {
+    const { form: { change } } = this.props;
+    const recalculatedDate = this.calculateNewExpirationDate();
+
+    change('expirationDate', recalculatedDate);
+    this.setState({ showRecalculateModal: false });
+  }
+
+  calculateNewExpirationDate = () => {
+    const { initialValues } = this.props;
     const expirationDate = new Date(initialValues.expirationDate);
     const now = Date.now();
     const offsetOfSelectedPatronGroup = this.state.selectedPatronGroup ? this.getPatronGroupOffset() : '';
@@ -74,9 +82,7 @@ class EditUserInfo extends React.Component {
     } else {
       recalculatedDate = (moment(expirationDate).add(offsetOfSelectedPatronGroup, 'd').format('YYYY-MM-DD'));
     }
-
-    change('expirationDate', recalculatedDate);
-    this.setState({ showRecalculateModal: false });
+    return recalculatedDate;
   }
 
   getPatronGroupOffset = () => {
@@ -147,11 +153,13 @@ class EditUserInfo extends React.Component {
 
     const offset = this.getPatronGroupOffset();
     const group = _.get(this.props.patronGroups.find(i => i.id === this.state.selectedPatronGroup), 'group', '');
+    const date = moment(this.calculateNewExpirationDate()).format('MMMM Do YYYY');
+
     const modalFooter = (
       <ModalFooter>
         <Button
           id="expirationDate-modal-recalculate-btn"
-          onClick={this.recalculateExpirationDate}
+          onClick={this.setRecalculatedExpirationDate}
         >
           <FormattedMessage id="ui-users.information.recalculate.modal.button" />
         </Button>
@@ -276,7 +284,7 @@ class EditUserInfo extends React.Component {
               {checkShowRecalculateButton() && (
                 <Button
                   id="recalculate-expirationDate-btn"
-                  onClick={this.recalculateExpirationDate}
+                  onClick={this.setRecalculatedExpirationDate}
                 >
                   <FormattedMessage id="ui-users.information.recalculate.expirationDate" />
                 </Button>
@@ -303,7 +311,7 @@ class EditUserInfo extends React.Component {
           <div>
             <FormattedMessage
               id="ui-users.information.recalculate.modal.text"
-              values={{ group, offset }}
+              values={{ group, offset, date }}
             />
           </div>
         </Modal>

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -153,7 +153,7 @@ class EditUserInfo extends React.Component {
           id="expirationDate-modal-recalculate-btn"
           onClick={this.recalculateExpirationDate}
         >
-          <FormattedMessage id="ui-users.information.recalculate.expirationDate" />
+          <FormattedMessage id="ui-users.information.recalculate.modal.button" />
         </Button>
         <Button
           id="expirationDate-modal-cancel-btn"

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -273,7 +273,7 @@
   "information.profile.label": "Display profile pictures",
   "information.recalculate.expirationDate": "Re-set",
   "information.recalculate.modal.button": "Set",
-  "information.recalculate.modal.text": "Library accounts with patron group <b>{group}</b> expire in <b>{offset}</b> days. Do you want to set this user’s account to expire on <b>{date}</b>?",
+  "information.recalculate.modal.text": "Library accounts with patron group <b>{group}</b> expire in <b>{offset} days</b>. Do you want to set this user’s account to expire on <b>{date}</b>?",
   "information.recalculate.modal.label": "Set expiration date?",
   "information.recalculate.will.reactivate.user": "User will reactivate after saving",
 

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -273,7 +273,7 @@
   "information.profile.label": "Display profile pictures",
   "information.recalculate.expirationDate": "Re-set",
   "information.recalculate.modal.button": "Set",
-  "information.recalculate.modal.text": "Users with patron group {group} usually expire after {offset} days. Do you want to change the expiration date accordingly?",
+  "information.recalculate.modal.text": "Library accounts with patron group {group} expire in {offset} days. Do you want to set this user’s account to expire on {date}?",
   "information.recalculate.modal.label": "Set expiration date?",
   "information.recalculate.will.reactivate.user": "User will reactivate after saving",
 

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -273,7 +273,7 @@
   "information.profile.label": "Display profile pictures",
   "information.recalculate.expirationDate": "Re-set",
   "information.recalculate.modal.button": "Set",
-  "information.recalculate.modal.text": "Library accounts with patron group {group} expire in {offset} days. Do you want to set this user’s account to expire on {date}?",
+  "information.recalculate.modal.text": "Library accounts with patron group <b>{group}</b> expire in <b>{offset}</b> days. Do you want to set this user’s account to expire on <b>{date}</b>?",
   "information.recalculate.modal.label": "Set expiration date?",
   "information.recalculate.will.reactivate.user": "User will reactivate after saving",
 

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -271,9 +271,10 @@
   "information.patronGroup.expirationOffset": "Expiration date offset (days)",
   "information.patronGroup.expirationOffset.error": "Must be empty or an integer > 0",
   "information.profile.label": "Display profile pictures",
-  "information.recalculate.expirationDate": "Recalculate",
+  "information.recalculate.expirationDate": "Re-set",
+  "information.recalculate.modal.button": "Set",
   "information.recalculate.modal.text": "Users with patron group {group} usually expire after {offset} days. Do you want to change the expiration date accordingly?",
-  "information.recalculate.modal.label": "Recalculate expiration date?",
+  "information.recalculate.modal.label": "Set expiration date?",
   "information.recalculate.will.reactivate.user": "User will reactivate after saving",
 
   "proxy.addProxy": "Add",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2058

The text on the **expiration data modal**  needs to be changed.
The new text should be as follows:

**Heading:**
"Set expiration date?"

**Text:**
"Library accounts with patron group group expire in offset days. Do you want to set this user’s account to expire on date?"

**Button:**
"Set" instead of "Recalculate"

 In addition, the text of the button in the users **edit form** needs to be changed:
**Button:** 
"Re-set" instead of "Recalculate".

 **Important:**
The SIG wishes the previewed expiration date in the modal to have the format like in "March 1, 2023".

The important parts of the text should be in bold - The UM SIG agreed on this in yesterday's meeting. So the text should be like this:

Library accounts with patron group **group** expire in **offset days**. Do you want to set this user’s account to expire on **date**?


For internationalisation purposes it is important that the date format will be consistent with the rest of dates displayed in FOLIO. It will also need to change according to the settings of the locale (tenant > language and localization > locale).
