### PR TITLE
UIU-2059 expiration date modal open bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * Add Callout for Refund report. Refs UIU-2035.
 * Allow 0 as valid entry for Patron Block Limits. Refs UIU-1998.
 * Add "Save and close" button should be active immediately on refund report criteria modal. Refs UIU-2034.
+* Expiration date modal opens every time when editing a user. Refs UIU-2059.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -52,12 +52,6 @@ class EditUserInfo extends React.Component {
     };
   }
 
-  componentDidMount() {
-    if (this.getPatronGroupOffset()) {
-      this.showModal(true);
-    }
-  }
-
   showModal = (val) => {
     this.setState({
       showRecalculateModal: val,


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2059


**Overview:**
**Steps to Reproduce:**

1. Go to users app
2. Choose a user record with a patron group that has an expiration date offset defined in the settings
3. Open this user record for editing

**Expected Results:** The modal should only open on patron group change.
**Actual Results:** The modal opens right away, for every edit

This is a new bug, the behaviour has been correct before.
