### PR TITLE
UIU-2062: Patron blocks do not appear for renew for automated patron blocks

### DIFF
--- a/src/components/Loans/OpenLoans/OpenLoansControl.js
+++ b/src/components/Loans/OpenLoans/OpenLoansControl.js
@@ -12,7 +12,10 @@ import { FormattedMessage } from 'react-intl';
 import { stripesShape } from '@folio/stripes/core';
 import { LoadingView } from '@folio/stripes/components';
 
-import { nav } from '../../util';
+import {
+  nav,
+  getRenewalPatronBlocksFromPatronBlocks,
+} from '../../util';
 import {
   withRenew,
   withDeclareLost,
@@ -335,7 +338,7 @@ class OpenLoansControl extends React.Component {
             patronBlockedModal={patronBlockedModal}
             onClosePatronBlockedModal={this.onClosePatronBlockedModal}
             openPatronBlockedModal={this.openPatronBlockedModal}
-            patronBlocks={patronBlocks.filter(p => p.renewals || p.blockRenewals)}
+            patronBlocks={getRenewalPatronBlocksFromPatronBlocks(patronBlocks)}
             patronGroup={patronGroup}
             buildRecords={this.buildRecords}
             visibleColumns={visibleColumns}

--- a/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
@@ -21,7 +21,11 @@ import {
 
 import ActionsBar from '../../../components/ActionsBar/ActionsBar';
 import { itemStatuses } from '../../../../../constants';
-import { hasEveryLoanItemStatus, hasAnyLoanItemStatus } from '../../../../util';
+import {
+  hasEveryLoanItemStatus,
+  hasAnyLoanItemStatus,
+  getRenewalPatronBlocksFromPatronBlocks,
+} from '../../../../util';
 
 import css from './OpenLoansSubHeader.css';
 
@@ -144,7 +148,7 @@ class OpenLoansSubHeader extends React.Component {
     const claimedReturnedCount = loans.filter(l => l?.item?.status?.name === itemStatuses.CLAIMED_RETURNED).length;
     const clonedLoans = cloneDeep(loans);
     const recordsToCSV = buildRecords(clonedLoans);
-    const countRenews = patronBlocks.filter(p => p.renewals === true);
+    const countRenews = getRenewalPatronBlocksFromPatronBlocks(patronBlocks);
     const onlyClaimedReturnedItemsSelected = hasEveryLoanItemStatus(checkedLoans, itemStatuses.CLAIMED_RETURNED);
     const onlyLostyItemsSelected = hasAnyLoanItemStatus(checkedLoans, lostItemStatuses);
 

--- a/src/components/util/index.js
+++ b/src/components/util/index.js
@@ -1,4 +1,5 @@
 import * as nav from './navigationHandlers';
 
 export * from './util';
+export { default as getRenewalPatronBlocksFromPatronBlocks } from './patronBlocks';
 export { nav };

--- a/src/components/util/patronBlocks.js
+++ b/src/components/util/patronBlocks.js
@@ -1,0 +1,5 @@
+const getRenewalPatronBlocksFromPatronBlocks = (patronBlocks) => (
+  patronBlocks.filter((patronBlock) => patronBlock.renewals === true || patronBlock.blockRenewals === true)
+);
+
+export default getRenewalPatronBlocksFromPatronBlocks;

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -37,6 +37,7 @@ import {
   getFullName,
   nav,
   getOpenRequestsPath,
+  getRenewalPatronBlocksFromPatronBlocks,
 } from '../../components/util';
 import { itemStatuses, loanActions } from '../../constants';
 import {
@@ -163,7 +164,7 @@ class LoanDetails extends React.Component {
     const {
       patronBlocks,
     } = this.props;
-    const countRenew = patronBlocks.filter(p => p.renewals || p.blockRenewals);
+    const countRenew = getRenewalPatronBlocksFromPatronBlocks(patronBlocks);
 
     if (!isEmpty(countRenew)) {
       return this.setState({
@@ -425,7 +426,7 @@ class LoanDetails extends React.Component {
         />
       </p>
     );
-    const patronBlocksForModal = patronBlocks.filter(p => p.renewals || p.blockRenewals);
+    const patronBlocksForModal = getRenewalPatronBlocksFromPatronBlocks(patronBlocks);
 
     return (
       <div data-test-loan-actions-history>


### PR DESCRIPTION
# Description
- Add possible for show Patron blocks modal for renew with automated patron blocks
- Move reusable code to utils

# Stories
https://issues.folio.org/browse/UIU-2062

# Screenshots
Patron blocks modal
![UIU-2062_0](https://user-images.githubusercontent.com/24813219/109526018-c9053700-7aba-11eb-8ece-7000ddf9cb1b.JPG)
Patron blocks modal not appear for renew for automated patron blocks 
![UIU-2062_1](https://user-images.githubusercontent.com/24813219/109526096-e3d7ab80-7aba-11eb-8a37-46f9821d3140.JPG)
Patron blocks modal appear for renew for automated patron blocks 
![UIU-2062_2](https://user-images.githubusercontent.com/24813219/109526179-f81ba880-7aba-11eb-97db-ec9c28a55f8d.JPG)
![UIU-2062_3](https://user-images.githubusercontent.com/24813219/109526181-f8b43f00-7aba-11eb-8380-8f370c364485.JPG)







