### PR TITLE
UIU-1474 pass required props to custom-fields

### DIFF
--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -430,6 +430,7 @@ class UserForm extends React.Component {
                   entityType="user"
                   finalFormCustomFieldsValues={form.getState().values.customFields}
                   fieldComponent={Field}
+                  changeFinalFormField={form.change}
                 />
                 {initialValues.id &&
                   <div>


### PR DESCRIPTION
As noted in the [custom fields documentation](https://github.com/folio-org/stripes-smart-components/tree/d954b19c5ffefe449de91a371976501a9bd29159/lib/CustomFields),
`changeFinalFormField` is necessary when using `final-form` but was
omitted when ui-users was refactored to final-form in #1645. Probably,
we didn't have any custom fields configured at the time and therefore
did not notice the omission.

Refs [UIU-1474](https://issues.folio.org/browse/UIU-1474)