### PR TITLE
UIU-2063: Improve fetching account data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * Patron blocks: Allow for override of Renewing when logged in user has credentials. Refs UIU-1954.
 * Loan Details no longer displays Fines incurred. Refs UIU-2045.
 * Fix eslint error in `LoanDetails.js`. Refs UIU-2068.
+* Improve fetching account data by making sure fetch happens only once. Fixes UIU-2063.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)


### PR DESCRIPTION
This PR Improves fetching account data by making sure fetch happens only once per given query. It also removes unused `accountsHistory` definition from the `UserAccounts` manifest.

https://issues.folio.org/browse/UIU-2063

Fetches before this change:

![before](https://user-images.githubusercontent.com/63545/110997723-cf61a180-834b-11eb-8efc-6d2ba9907a90.png)

Fetches after:

![after](https://user-images.githubusercontent.com/63545/110997740-d4265580-834b-11eb-8889-a23247cf3133.png)
