### PR TITLE
UIU-2063: Refactor UserAccounts to use single fetch for accounts data

### DIFF
--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -13,7 +13,7 @@ import {
 } from '@folio/stripes/components';
 import { useStripes } from '@folio/stripes/core';
 
-import { accountStatues } from '../../../constants';
+import { accountStatuses } from '../../../constants';
 
 
 /**
@@ -49,8 +49,8 @@ const UserAccounts = ({
   const displayWhenOpen = (<Button disabled={buttonDisabled} to={{ pathname: `/users/${params.id}/charge` }}><FormattedMessage id="ui-users.accounts.chargeManual" /></Button>);
 
   useEffect(() => {
-    const open = records.filter(account => account?.status?.name !== accountStatues.CLOSED);
-    const closed = records.filter(account => account?.status?.name === accountStatues.CLOSED);
+    const open = records.filter(account => account?.status?.name !== accountStatuses.CLOSED);
+    const closed = records.filter(account => account?.status?.name === accountStatuses.CLOSED);
     const openTotal = open.reduce((acc, { remaining }) => (acc + parseFloat(remaining)), 0);
 
     setTotals({

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -1,8 +1,8 @@
-import _ from 'lodash';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
+
 import {
   Badge,
   Button,
@@ -11,9 +11,10 @@ import {
   List,
   Headline
 } from '@folio/stripes/components';
-import {
-  stripesConnect
-} from '@folio/stripes/core';
+import { useStripes } from '@folio/stripes/core';
+
+import { accountStatues } from '../../../constants';
+
 
 /**
  * User-details "Accounts" accordian pane.
@@ -21,173 +22,106 @@ import {
  * Show links to the open- and closed-accounts in the body; include the
  * number of open-accounts in the preview.
  */
-class UserAccounts extends React.Component {
-  static manifest = Object.freeze({
-    openAccountsCount: {
-      type: 'okapi',
-      accumulate: 'true',
-      GET: {
-        path: 'accounts?query=(userId==:{id} and status.name<>Closed)&limit=10000',
-      },
-      fetch: false,
-    },
-    closedAccountsCount: {
-      type: 'okapi',
-      accumulate: 'true',
-      GET: {
-        path: 'accounts?query=(userId==:{id} and status.name=Closed)&limit=1',
-      },
-      fetch: false,
-    },
-    activeRecord: {},
-    userid: {},
+const UserAccounts = ({
+  expanded,
+  onToggle,
+  accordionId,
+  match: { params },
+  accounts: {
+    records,
+    isPending,
+  },
+}) => {
+  const [totals, setTotals] = useState({
+    openAccountsCount: 0,
+    closedAccountsCount: 0,
+    total: 0.00,
   });
+  const stripes = useStripes();
+  const accountsLoaded = !isPending;
+  const {
+    openAccountsCount,
+    closedAccountsCount,
+    total,
+  } = totals;
+  const displayWhenClosed = accountsLoaded ? (<Badge>{openAccountsCount}</Badge>) : (<Icon icon="spinner-ellipsis" width="10px" />);
+  const buttonDisabled = !stripes?.hasPerm('ui-users.feesfines.actions.all');
+  const displayWhenOpen = (<Button disabled={buttonDisabled} to={{ pathname: `/users/${params.id}/charge` }}><FormattedMessage id="ui-users.accounts.chargeManual" /></Button>);
 
-  static propTypes = {
-    resources: PropTypes.shape({
-      closedAccountsCount: PropTypes.number,
-      openAccountsCount: PropTypes.number,
-    }),
-    mutator: PropTypes.shape({
-      openAccountsCount: PropTypes.object,
-      closedAccountsCount: PropTypes.object,
-    }),
-    stripes: PropTypes.shape({
-      hasPerm: PropTypes.func,
-    }),
-    accordionId: PropTypes.string,
-    addRecord: PropTypes.bool,
-    expanded: PropTypes.bool,
-    onToggle: PropTypes.func,
-    location: PropTypes.shape({
-      search: PropTypes.string,
-      pathname: PropTypes.string,
-    }),
-    match: PropTypes.shape({
-      params: PropTypes.object,
-    }).isRequired
-  };
+  useEffect(() => {
+    const open = records.filter(account => account?.status?.name !== accountStatues.CLOSED);
+    const closed = records.filter(account => account?.status?.name === accountStatues.CLOSED);
+    const openTotal = open.reduce((acc, { remaining }) => (acc + parseFloat(remaining)), 0);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      openAccounts: 0,
-      closedAccounts: 0,
-    };
-
-    this._isMounted = false;
-  }
-
-  componentDidMount() {
-    this._isMounted = true;
-    this.loadAccounts();
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.addRecord !== prevProps.addRecord) {
-      this.loadAccounts();
-    }
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
-  }
-
-  loadAccounts() {
-    const {
-      mutator: {
-        openAccountsCount,
-        closedAccountsCount,
-      },
-    } = this.props;
-
-    openAccountsCount.reset();
-    closedAccountsCount.reset();
-
-    const promises = [
-      openAccountsCount.GET(),
-      closedAccountsCount.GET(),
-    ];
-
-    Promise.all(promises).then(([open, closed]) => {
-      if (this._isMounted) {
-        this.setState({
-          total: this.getTotalOpenAccounts(open.accounts),
-          openAccounts: open.totalRecords,
-          closedAccounts: closed.totalRecords,
-        });
-      }
+    setTotals({
+      openAccountsCount: open.length,
+      closedAccountsCount: closed.length,
+      total: parseFloat(openTotal).toFixed(2),
     });
-  }
+  }, [records]);
 
-  getTotalOpenAccounts = (accounts) => {
-    const total = accounts.reduce((t, { remaining }) => (t + parseFloat(remaining)), 0);
-    return parseFloat(total).toFixed(2);
-  }
+  return (
+    <Accordion
+      open={expanded}
+      id={accordionId}
+      onToggle={onToggle}
+      label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.accounts.title.feeFine" /></Headline>}
+      displayWhenClosed={displayWhenClosed}
+      displayWhenOpen={displayWhenOpen}
+    >
+      {accountsLoaded ?
+        <List
+          listStyle="bullets"
+          itemFormatter={(item, index) => (
+            <li key={index}>
+              <Link
+                id={item.id}
+                to={`/users/${params.id}/accounts/${item.status}`}
+              >
+                <FormattedMessage id={item.formattedMessageId} values={{ count: item.count }} />
+                {' '}
+                {' '}
+              </Link>
+              {item.id === 'clickable-viewcurrentaccounts' && <FormattedMessage id="ui-users.accounts.totalOpenAccounts" values={{ amount: total }} />}
+            </li>)}
+          items={[
+            {
+              id: 'clickable-viewcurrentaccounts',
+              count: openAccountsCount,
+              formattedMessageId: 'ui-users.accounts.numOpenAccounts',
+              status: 'open',
+            },
+            {
+              id: 'clickable-viewclosedaccounts',
+              count: closedAccountsCount,
+              formattedMessageId: 'ui-users.accounts.numClosedAccounts',
+              status: 'closed',
+            },
+            {
+              id: 'clickable-viewallaccounts',
+              count: 0,
+              formattedMessageId: 'ui-users.accounts.viewAllFeesFines',
+              status: 'all',
+            },
+          ]}
+        /> : <Icon icon="spinner-ellipsis" width="10px" />
+      }
+    </Accordion>
+  );
+};
 
-  render() {
-    const resources = this.props.resources;
-    const openAccountsTotal = this.state.openAccounts || 0;
-    const closedAccountsTotal = this.state.closedAccounts || 0;
-    const total = this.state.total || '0.00';
-    const { expanded, onToggle, accordionId, match: { params } } = this.props;
+UserAccounts.propTypes = {
+  accounts: PropTypes.arrayOf(PropTypes.object),
+  accordionId: PropTypes.string,
+  expanded: PropTypes.bool,
+  onToggle: PropTypes.func,
+  location: PropTypes.shape({
+    search: PropTypes.string,
+    pathname: PropTypes.string,
+  }),
+  match: PropTypes.shape({
+    params: PropTypes.object,
+  }).isRequired,
+};
 
-    const openAccountsCount = (_.get(resources.openAccountsCount, ['isPending'], true)) ? -1 : openAccountsTotal;
-    const closedAccountsCount = (_.get(resources.closedAccountsCount, ['isPending'], true)) ? -1 : closedAccountsTotal;
-
-    const accountsLoaded = openAccountsCount >= 0 && closedAccountsCount >= 0;
-    const displayWhenClosed = accountsLoaded ? (<Badge>{openAccountsCount}</Badge>) : (<Icon icon="spinner-ellipsis" width="10px" />);
-    const buttonDisabled = !this.props.stripes.hasPerm('ui-users.feesfines.actions.all');
-    const displayWhenOpen = (<Button disabled={buttonDisabled} to={{ pathname: `/users/${params.id}/charge` }}><FormattedMessage id="ui-users.accounts.chargeManual" /></Button>);
-    return (
-      <Accordion
-        open={expanded}
-        id={accordionId}
-        onToggle={onToggle}
-        label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.accounts.title.feeFine" /></Headline>}
-        displayWhenClosed={displayWhenClosed}
-        displayWhenOpen={displayWhenOpen}
-      >
-        {accountsLoaded ?
-          <List
-            listStyle="bullets"
-            itemFormatter={(item, index) => (
-              <li key={index}>
-                <Link
-                  id={item.id}
-                  to={`/users/${params.id}/accounts/${item.status}`}
-                >
-                  <FormattedMessage id={item.formattedMessageId} values={{ count: item.count }} />
-                  {' '}
-                  {' '}
-                </Link>
-                {item.id === 'clickable-viewcurrentaccounts' && <FormattedMessage id="ui-users.accounts.totalOpenAccounts" values={{ amount: total }} />}
-              </li>)}
-            items={[
-              {
-                id: 'clickable-viewcurrentaccounts',
-                count: openAccountsCount,
-                formattedMessageId: 'ui-users.accounts.numOpenAccounts',
-                status: 'open',
-              },
-              {
-                id: 'clickable-viewclosedaccounts',
-                count: closedAccountsCount,
-                formattedMessageId: 'ui-users.accounts.numClosedAccounts',
-                status: 'closed',
-              },
-              {
-                id: 'clickable-viewallaccounts',
-                count: 0,
-                formattedMessageId: 'ui-users.accounts.viewAllFeesFines',
-                status: 'all',
-              },
-            ]}
-          /> : <Icon icon="spinner-ellipsis" width="10px" />
-        }
-      </Accordion>
-    );
-  }
-}
-
-export default stripesConnect(UserAccounts);
+export default UserAccounts;

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,9 +20,9 @@ export const loanStatuses = {
   CLOSED: 'Closed',
 };
 
-export const accountStatues = {
+export const accountStatuses = {
   CLOSED: 'Closed',
-  OPEN: 'OPEN',
+  OPEN: 'Open',
 };
 
 export const loanActions = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,11 @@ export const loanStatuses = {
   CLOSED: 'Closed',
 };
 
+export const accountStatues = {
+  CLOSED: 'Closed',
+  OPEN: 'OPEN',
+};
+
 export const loanActions = {
   CLAIMED_RETURNED: 'claimedReturned',
   DECLARED_LOST: 'declaredLost',

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -77,6 +77,9 @@ class UserDetail extends React.Component {
     resources: PropTypes.shape({
       selUser: PropTypes.object,
       user: PropTypes.arrayOf(PropTypes.object),
+      accounts: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
       addressTypes: PropTypes.shape({
         records: PropTypes.arrayOf(PropTypes.object),
       }),
@@ -417,7 +420,6 @@ class UserDetail extends React.Component {
     const {
       sections,
       helperApp,
-      addRecord
     } = this.state;
 
     const user = this.getUser();
@@ -455,6 +457,7 @@ class UserDetail extends React.Component {
     const departments = resources?.departments?.records || [];
     const userDepartments = (user?.departments || [])
       .map(departmentId => departments.find(({ id }) => id === departmentId)?.name);
+    const accounts = resources?.accounts;
 
     if (!user) {
       return (
@@ -530,7 +533,6 @@ class UserDetail extends React.Component {
                     expanded={sections.patronBlocksSection}
                     onToggle={this.handleSectionToggle}
                     onClickViewPatronBlock={this.onClickViewPatronBlock}
-                    addRecord={this.state.addRecord}
                     {...this.props}
                   />
                   }
@@ -579,8 +581,8 @@ class UserDetail extends React.Component {
                       expanded={sections.accountsSection}
                       onToggle={this.handleSectionToggle}
                       accordionId="accountsSection"
-                      addRecord={addRecord}
                       location={location}
+                      accounts={accounts}
                       match={match}
                     />
                   </IfPermission>

--- a/test/bigtest/tests/fee-fine-history-test.js
+++ b/test/bigtest/tests/fee-fine-history-test.js
@@ -36,7 +36,7 @@ describe('Test Fee/Fine History', () => {
 
       it('It should render with the labels', () => {
         expect(FeeFineHistoryInteractor.openFeesFines).to.string('open fees/fines');
-        expect(FeeFineHistoryInteractor.closedFeesFines).to.string('closed fees/fines');
+        expect(FeeFineHistoryInteractor.closedFeesFines).to.string('1 closed fee/fine');
         expect(FeeFineHistoryInteractor.allFeesFines).to.string('View all fees/fines');
       });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2063

We made some progress to cut the number of requests related to accounts from 6 to 3 in https://github.com/folio-org/ui-users/pull/1666

This PR takes it further based on some good feedback from @wafschneider under [UIU-2063](https://issues.folio.org/browse/UIU-2063?focusedCommentId=99814&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-99814) and cuts it down to a single request. The number of open and closed accounts are calculated on the client.


  