### PR TITLE
use deps compatible with @folio/stripes v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * Loan Details no longer displays Fines incurred. Refs UIU-2045.
 * Fix eslint error in `LoanDetails.js`. Refs UIU-2068.
 * Improve fetching account data by making sure fetch happens only once. Fixes UIU-2063.
+* Update `@folio/plugin-find-user` for compatibility with `@folio/stripes` `v6`.
 
 ## [5.0.1](https://github.com/folio-org/ui-users/tree/v5.0.1) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -831,7 +831,7 @@
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^4.0.0"
+    "@folio/plugin-find-user": "^5.0.0"
   },
   "resolutions": {
     "moment": "~2.24.0"


### PR DESCRIPTION
Update deps for compatibility with `@folio/stripes` `v6`, including:
* `@folio/plugin-find-user`