### PR TITLE
UIU-2052: Add changes to indicate clickable for cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Configure Jest/RTL. Refs UIU-2112.
 * Show user-readable message when user is not found. Fixes UIU-2081.
 * Fix Custom Fields error message by adding a missing permission. Fixes UIU-2104.
+* Add changes to indicate clickable for cursor. Refs UIU-2052.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.css
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.css
@@ -1,0 +1,11 @@
+:root {
+  --top-bottom-indent: 5px;
+  --left-right-indent: 10px;
+}
+
+.pointerWrapper {
+  flex-grow: 1;
+  margin: calc(-1 * var(--top-bottom-indent)) calc(-1 * var(--left-right-indent));
+  padding: var(--top-bottom-indent) var(--left-right-indent);
+  cursor: pointer;
+}

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.js
@@ -20,6 +20,8 @@ import { stripesConnect } from '@folio/stripes/core';
 
 import { calculateSortParams } from '../../util';
 
+import css from './PatronBlock.css';
+
 class PatronBlock extends React.Component {
   static manifest = Object.freeze({
     manualPatronBlocks: {
@@ -158,9 +160,23 @@ class PatronBlock extends React.Component {
       },
     } = this.props;
 
+    const pointerWrapper = (content, isManual) => (
+      isManual
+        ? <div className={css.pointerWrapper}>{content}</div>
+        : content
+    );
+
     return {
-      'Type': f => f?.type ?? <FormattedMessage id="ui-users.blocks.columns.automated.type" />,
-      'Display description': f => f.desc || f.message,
+      'Type': f => {
+        const type = f?.type ?? <FormattedMessage id="ui-users.blocks.columns.automated.type" />;
+
+        return pointerWrapper(type, f?.type);
+      },
+      'Display description': f => {
+        const description = f.desc || f.message;
+
+        return pointerWrapper(description, f?.type);
+      },
       'Blocked actions': f => {
         const blockedActions = [];
 
@@ -176,7 +192,7 @@ class PatronBlock extends React.Component {
           blockedActions.push([formatMessage({ id: 'ui-users.blocks.columns.requests' })]);
         }
 
-        return blockedActions.join(', ');
+        return pointerWrapper(blockedActions.join(', '), f?.type);
       }
     };
   }


### PR DESCRIPTION
## Purpose
We should  add clickable indicate  for cursor when we navigate to manual block.

## Approach
I according that we don't have possible add css class to row we add content wrapper for cell. Cursor should appear only for clickable block(manual block).

## Screenshot
![image](https://user-images.githubusercontent.com/24813219/112305064-edfa5d80-8ca6-11eb-907b-36a6c7473bdd.png)

# Stories
https://issues.folio.org/browse/UIU-2052

# Test
![image](https://user-images.githubusercontent.com/24813219/113264952-3daadb80-92dc-11eb-91b2-636abc9983e5.png)
