### PR TITLE
UIU-2091: Migrate from string notation to column mapping for PatronBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Show user-readable message when user is not found. Fixes UIU-2081.
 * Fix Custom Fields error message by adding a missing permission. Fixes UIU-2104.
 * Add changes to indicate clickable for cursor. Refs UIU-2052.
+* Migrate from string notation to column mapping for PatronBlock. Refs UIU-2091.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.js
@@ -22,6 +22,12 @@ import { calculateSortParams } from '../../util';
 
 import css from './PatronBlock.css';
 
+const PATRON_BLOCKS_COLUMNS = {
+  type: 'type',
+  displayDescription: 'displayDescription',
+  blockedActions: 'blockedActions',
+};
+
 class PatronBlock extends React.Component {
   static manifest = Object.freeze({
     manualPatronBlocks: {
@@ -167,17 +173,17 @@ class PatronBlock extends React.Component {
     );
 
     return {
-      'Type': f => {
+      [PATRON_BLOCKS_COLUMNS.type]: f => {
         const type = f?.type ?? <FormattedMessage id="ui-users.blocks.columns.automated.type" />;
 
         return pointerWrapper(type, f?.type);
       },
-      'Display description': f => {
+      [PATRON_BLOCKS_COLUMNS.displayDescription]: f => {
         const description = f.desc || f.message;
 
         return pointerWrapper(description, f?.type);
       },
-      'Blocked actions': f => {
+      [PATRON_BLOCKS_COLUMNS.blockedActions]: f => {
         const blockedActions = [];
 
         if (f.borrowing || f.blockBorrowing) {
@@ -197,6 +203,24 @@ class PatronBlock extends React.Component {
     };
   }
 
+  columnMapping = {
+    [PATRON_BLOCKS_COLUMNS.type]: <FormattedMessage id="ui-users.blocks.columns.type" />,
+    [PATRON_BLOCKS_COLUMNS.displayDescription]: <FormattedMessage id="ui-users.blocks.columns.desc" />,
+    [PATRON_BLOCKS_COLUMNS.blockedActions]: <FormattedMessage id="ui-users.blocks.columns.blocked" />,
+  };
+
+  columnWidths = {
+    [PATRON_BLOCKS_COLUMNS.type]: '100px',
+    [PATRON_BLOCKS_COLUMNS.displayDescription]: '350px',
+    [PATRON_BLOCKS_COLUMNS.blockedActions]: '250px',
+  };
+
+  visibleColumns = [
+    PATRON_BLOCKS_COLUMNS.type,
+    PATRON_BLOCKS_COLUMNS.displayDescription,
+    PATRON_BLOCKS_COLUMNS.blockedActions,
+  ];
+
   render() {
     const {
       expanded,
@@ -212,11 +236,6 @@ class PatronBlock extends React.Component {
     } = this.state;
     let contentData = patronBlocks.filter(p => moment(moment(p.expirationDate).endOf('day')).isSameOrAfter(moment().endOf('day')));
     contentData = _.orderBy(contentData, ['metadata.createdDate'], ['desc']);
-    const visibleColumns = [
-      'Type',
-      'Display description',
-      'Blocked actions',
-    ];
 
     const buttonDisabled = this.props.stripes.hasPerm('ui-users.patron_blocks');
     const displayWhenOpen =
@@ -229,16 +248,13 @@ class PatronBlock extends React.Component {
         interactive={false}
         contentData={contentData}
         formatter={this.getPatronFormatter()}
-        visibleColumns={visibleColumns}
+        visibleColumns={this.visibleColumns}
         onHeaderClick={this.onSort}
         sortOrder={sortOrder[0]}
         sortDirection={`${sortDirection[0]}ending`}
         onRowClick={this.onRowClick}
-        columnWidths={{
-          'Type': '100px',
-          'Display description': '350px',
-          'Blocked actions': '250px'
-        }}
+        columnMapping={this.columnMapping}
+        columnWidths={this.columnWidths}
       />;
     const title =
       <Headline size="large" tag="h3">


### PR DESCRIPTION
## Purpose
We should  migrate from string notation to column mapping for PatronBlock

## Approach
We should use column mapping approach for consistency, readable and etc.

## Screenshot
![image](https://user-images.githubusercontent.com/24813219/112305064-edfa5d80-8ca6-11eb-907b-36a6c7473bdd.png)

# Stories
https://issues.folio.org/browse/UIU-2091

# Test
After merge UIU-2052 ( https://github.com/folio-org/ui-users/pull/1675 ) we should change target branch to master
![image](https://user-images.githubusercontent.com/24813219/114013552-5719cd80-9870-11eb-9cf9-0305039bd900.png)
