### PR TITLE
UIU-2109: Disable running tests on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,6 @@ buildNPM {
   runLint = 'yes'
   runRegression = 'no'
   runSonarqube = true
-  runTest = 'yes'
+  runTest = 'no'
   runTestOptions = '--bundle --karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'
 }


### PR DESCRIPTION
## Purpose
We should temporarily disable running tests on Jenkins

## Approach
BigTests tests hang and timeout after a while (Disconnected issue). The example: https://jenkins-aws.indexdata.com/job/folio-org/job/ui-users/job/PR-1685/1/console
Until problem in https://issues.folio.org/browse/FOLIO-3092 will be fixed we need to have possible for merge our changes to ui-users.

We should temporarily disable running tests on Jenkins in scope of https://issues.folio.org/browse/UIU-2109
After fix https://issues.folio.org/browse/FOLIO-3092
We should enable running tests on Jenkins in scope of https://issues.folio.org/browse/UIU-2110

# Stories
https://issues.folio.org/browse/UIU-2109

# Notes
We should make a requirement to attach a screenshot with all passed tests locally until the Disconnected issue will be fixed.
How i understood this is configuration changes and we don't need add information about current changes to CHANGELOG.md
This workaround was discussed in stripes channel

@zburke @mkuklis Could you please add all necessary reviewers if needed?