### PR TITLE
UIU-2111: Fix Notify patron box behavior for New fee/fine when default patron notice is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add new fee/fine reports as options to User Actions drop-down. Refs UIU-2083.
 * Show claimed returned report only if user has necessary permission. Refs UIU-1884.
 * Fix Note Edit Page - doesn't return to record page after click on `Save&Close`. Fixes UIU-2087.
+* Fix Notify patron box behavior for New fee/fine when default patron notice is set. Refs UIU-2111.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -235,8 +235,7 @@ class ChargeFeeFine extends React.Component {
     }
   }
 
-  onChangeOwner(e) {
-    const ownerId = e.target.value;
+  onChangeOwner(ownerId) {
     const {
       resources,
       mutator,

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -116,12 +116,11 @@ class ChargeForm extends React.Component {
     }
   }
 
-  onChangeOwner(e) {
+  onChangeOwner(ownerId) {
     const { form: { change, reset } } = this.props;
     reset();
-    const ownerId = e.target.value;
 
-    this.props.onChangeOwner(e);
+    this.props.onChangeOwner(ownerId);
     change('ownerId', ownerId);
   }
 

--- a/src/components/Accounts/ChargeFeeFine/FeeFineInfo.js
+++ b/src/components/Accounts/ChargeFeeFine/FeeFineInfo.js
@@ -14,11 +14,27 @@ class FeeFineInfo extends React.Component {
   static propTypes = {
     feefineList: PropTypes.arrayOf(PropTypes.object),
     form: PropTypes.object.isRequired,
-    onChangeOwner: PropTypes.func,
+    initialValues: PropTypes.shape({
+      ownerId: PropTypes.string,
+    }).isRequired,
+    onChangeOwner: PropTypes.func.isRequired,
     ownerOptions: PropTypes.arrayOf(PropTypes.object),
     onChangeFeeFine: PropTypes.func,
     isPending: PropTypes.object,
   };
+
+  componentDidMount() {
+    const {
+      initialValues: {
+        ownerId,
+      },
+      onChangeOwner,
+    } = this.props;
+
+    if (ownerId) {
+      onChangeOwner(ownerId);
+    }
+  }
 
   constructor(props) {
     super(props);
@@ -68,7 +84,7 @@ class FeeFineInfo extends React.Component {
                           fullWidth
                           disabled={isPending.owners}
                           dataOptions={ownerOptions}
-                          onChange={onChangeOwner}
+                          onChange={(e) => onChangeOwner(e.target.value)}
                           placeholder={placeholder}
                         />
                       )}


### PR DESCRIPTION
## Purpose
"Notify patron" box should be check marked for "New fee/fine" when default patron notice is set.

## Approach
When we have initial values for Fee/fine owner or we select them should work the same logic.

## Screenshot
![image](https://user-images.githubusercontent.com/24813219/114165658-6dd62800-9935-11eb-9693-9d71cb28a450.png)

# Stories
https://issues.folio.org/browse/UIU-2111

# Test
![image](https://user-images.githubusercontent.com/24813219/114586164-0ac5f780-9c8d-11eb-87f1-161f80489d86.png)