### PR TITLE
UIU-1884: Show claimed returned report only if user has necessary permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Migrate from string notation to column mapping for PatronBlock. Refs UIU-2091.
 * Add Cash Drawer Reconciliaton report & Financial transactions detail report permissions to reports. Refs UIU-2088.
 * Add new fee/fine reports as options to User Actions drop-down. Refs UIU-2083.
+* Show claimed returned report only if user has necessary permission. Refs UIU-1884.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -261,19 +261,19 @@ class UserSearch extends React.Component {
                 <FormattedMessage id="ui-users.reports.overdue.label" />
               </Icon>
             </Button>
+            <Button
+              buttonStyle="dropdownItem"
+              id="export-claimed-returned-loan-report"
+              onClick={() => {
+                onToggle();
+                this.generateReport(this.props, 'claimedReturned');
+              }}
+            >
+              <Icon icon="download">
+                <FormattedMessage id="ui-users.reports.claimReturned.label" />
+              </Icon>
+            </Button>
           </IfPermission>
-          <Button
-            buttonStyle="dropdownItem"
-            id="export-claimed-returned-loan-report"
-            onClick={() => {
-              onToggle();
-              this.generateReport(this.props, 'claimedReturned');
-            }}
-          >
-            <Icon icon="download">
-              <FormattedMessage id="ui-users.reports.claimReturned.label" />
-            </Icon>
-          </Button>
           <IfPermission perm="ui-users.cashDrawerReport">
             <Button
               buttonStyle="dropdownItem"


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1884

Checks for the ui-users.loans.view perm before displaying the menu item for the claimed returned CSV report.