### PR TITLE
UIU-2123: Fix disabling "Save & close" button for Manual patron block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix Note Edit Page - doesn't return to record page after click on `Save&Close`. Fixes UIU-2087.
 * Fix Notify patron box behavior for New fee/fine when default patron notice is set. Refs UIU-2111.
 * Close "New fee/fine" page after fee/fine created. Refs UIU-2117.
+* Fix disabling "Save & close" button for Manual patron block. Refs UIU-2123.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -350,7 +350,10 @@ class PatronBlockForm extends React.Component {
 export default stripesFinalForm({
   initialValuesEqual: (a, b) => _.isEqual(a, b),
   navigationCheck: true,
-  subscription: { values: true },
+  subscription: {
+    invalid: true,
+    values: true,
+  },
   mutators: { setFieldData },
   validate: showValidationErrors,
 })(PatronBlockForm);


### PR DESCRIPTION
## Purpose
When we have invalid values Manual patron block "Save & close" button should be disabled

## Screenshot
![image](https://user-images.githubusercontent.com/24813219/114691878-cbe18180-9d20-11eb-940e-a1ea1f3821b3.png)

## Stories
https://issues.folio.org/browse/UIU-2123

## Test
![image](https://user-images.githubusercontent.com/24813219/114711697-f12dba00-9d37-11eb-8ddc-95d4ffc71436.png)