### PR TITLE
UIU-2122: Fix the possibility of create manual patron block with expiration date of today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix Notify patron box behavior for New fee/fine when default patron notice is set. Refs UIU-2111.
 * Close "New fee/fine" page after fee/fine created. Refs UIU-2117.
 * Fix disabling "Save & close" button for Manual patron block. Refs UIU-2123.
+* Fix the possibility of create manual patron block with expiration date of today. Refs UIU-2122.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -51,7 +51,7 @@ const showValidationErrors = ({
     errors.renewals = patronBlockError;
     errors.requests = patronBlockError;
   }
-  if (moment(moment(expirationDate).endOf('day')).isBefore(moment().endOf('day'))) {
+  if (moment(moment(expirationDate).endOf('day')).isBefore(moment().endOf('day').add(1, 'days'))) {
     errors.expirationDate = <FormattedMessage id="ui-users.blocks.form.validate.future" />;
   }
 


### PR DESCRIPTION
## Purpose
Not allowed to have an expiration date of today because manual patron blocks will be expire.

## Screenshot
![image](https://user-images.githubusercontent.com/24813219/114722456-7e760c00-9d42-11eb-8118-7baee30ee888.png)

## Stories
https://issues.folio.org/browse/UIU-2122

## Test
![image](https://user-images.githubusercontent.com/24813219/114724954-bed68980-9d44-11eb-9ab4-2b829c40fe94.png)