### PR TITLE
UIU-2126: Fix permission error for Refunds to Process Manually report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Close "New fee/fine" page after fee/fine created. Refs UIU-2117.
 * Fix disabling "Save & close" button for Manual patron block. Refs UIU-2123.
 * Fix the possibility of create manual patron block with expiration date of today. Refs UIU-2122.
+* Fix permission error for "Refunds to Process Manually" report. Refs UIU-2126.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
           "feefines.item.post",
           "feefines.item.put",
           "settings.users.enabled",
-          "feefine-reports.refund.get"
+          "feefine-reports.refund.post"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
We should have possible for create "Refunds to Process Manually" report

## Approach
Permission was changed on BE from feefine-reports.refund.get to feefine-reports.refund.post, we add consistency changes on UI

## Stories
https://issues.folio.org/browse/UIU-2126

## Test
![image](https://user-images.githubusercontent.com/24813219/114891359-7be3e700-9e14-11eb-9464-947f1dac7d31.png)