### PR TITLE
UIU-2122: Fix the possibility of create manual patron block with expiration date of today

### DIFF
--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -51,7 +51,7 @@ const showValidationErrors = ({
     errors.renewals = patronBlockError;
     errors.requests = patronBlockError;
   }
-  if (moment(moment(expirationDate).endOf('day')).isBefore(moment().endOf('day').add(1, 'days'))) {
+  if (expirationDate && moment(moment(expirationDate).endOf('day')).isBefore(moment().endOf('day').add(1, 'days'))) {
     errors.expirationDate = <FormattedMessage id="ui-users.blocks.form.validate.future" />;
   }
 


### PR DESCRIPTION
## Purpose
Not allowed to have an expiration date of today because manual patron blocks will be expire.

## Screenshot
![image](https://user-images.githubusercontent.com/24813219/114722456-7e760c00-9d42-11eb-8118-7baee30ee888.png)

## Stories
https://issues.folio.org/browse/UIU-2122

## Notes
We should run expiration date validation only when expiration date exists. Associated with https://github.com/folio-org/ui-users/pull/1698

## Test
![image](https://user-images.githubusercontent.com/24813219/114988042-8ba80d80-9e9e-11eb-8e94-70bb15810a18.png)
