### PR TITLE
UIU-2135 also support circulation 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix disabling "Save & close" button for Manual patron block. Refs UIU-2123.
 * Fix the possibility of create manual patron block with expiration date of today. Refs UIU-2122.
 * Fix permission error for "Refunds to Process Manually" report. Refs UIU-2126.
+* Also support `circulation` `10.0`. Refs UIU-2135.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       "automated-patron-blocks": "0.1"
     },
     "optionalOkapiInterfaces": {
-      "circulation": "9.0",
+      "circulation": "9.0 10.0",
       "feesfines": "16.1",
       "notes": "2.0"
     },


### PR DESCRIPTION
The only breaking change in `circulation` `10.0` was the removal of the
`override-check-out-by-barcode` which is not used here, hence continuing
to support `9.0`.

Refs [UIU-2135](https://issues.folio.org/browse/UIU-2135)