### PR TITLE
UIU-2137 lock stripes-cli to ~2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.1.0 (IN PROGRESS)
 
 * Configure Jest/RTL. Refs UIU-2112.
+* Lock stripes-cli to ~2.1.1, and thus stripes-webpack to ~1.1.0. Refs UIU-2137.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -791,7 +791,7 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.2.0",
     "@folio/stripes": "^6.0.0",
-    "@folio/stripes-cli": "^2.0.0",
+    "@folio/stripes-cli": "~2.1.1",
     "@folio/stripes-components": "^9.0.0",
     "@folio/stripes-core": "^7.0.0",
     "@folio/stripes-final-form": "^5.0.0",


### PR DESCRIPTION
`stripes-cli` `2.1.1` locks `stripes-webpack` to `~1.1.0`, avoiding the
`1.2.0` release that adds some helpful things to do with CSV files and
the new react JSX transform but that does not play nice with BigTest for
some developers, making tests impossible to run, and, therefore,
releases impossible to release. This allows tests to be run locally in
order to prove they run successfully, even when the fail consistently
in CI.

Refs [UIU-2137](https://issues.folio.org/browse/UIU-2137)