### PR TITLE
UIU-2142 handle search of ASTified translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Also support `circulation` `10.0`. Refs UIU-2135.
 * Show the "Refunds to process manually" report conditionally based on permissions. Refs UIU-2125.
 * Fetch some search container routes conditionally based on permissions. Refs UIU-2132.
+* Handle search of ASTified translation values. Refs UIU-2142.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -165,7 +165,18 @@ class PermissionsModal extends React.Component {
     // in the translation key, e.g. ui-users.permission.loans.all, before looking for the
     // search query.
     const matchedPermTranslations = pickBy(translations, (label, key) => {
-      return /\.permission\./.test(key) && label.toLowerCase().match(query.toLowerCase());
+      // non-AST translations are key-value pairs and the value is a string.
+      // AST-ified translations are key-value pairs and the value is an array.
+      // when that array has only a single element, it contains an object with
+      // the property "value" that contains the translation value.
+      // multi-value arrays correspond to translations with substitutions, html, etc.,
+      // but those are not relevent here.
+      if (typeof label === 'string') {
+        return /\.permission\./.test(key) && label.toLowerCase().match(query.toLowerCase());
+      } else if (Array.isArray(label) && label.length === 1) {
+        return /\.permission\./.test(key) && label[0].value.toLowerCase().match(query.toLowerCase());
+      }
+      return false;
     });
 
     // Matched permissions may not have a displayName value. We have to compare a permission's


### PR DESCRIPTION
ASTified translations are no longer formatted as `{string, string}`,
they are `{string, array}` and the permission-search feature doesn't
know how to handle this. Given permission translation values should not
have any substitutions in them, we can somewhat naively inspect the 0th
element when the value is an array.

See also https://github.com/folio-org/ui-developer/pull/236

Refs [UIU-2142](https://issues.folio.org/browse/UIU-2142)