### PR TITLE
UIU-2143 include missing limit clause in request-count query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fetch some search container routes conditionally based on permissions. Refs UIU-2132.
 * Handle search of ASTified translation values. Refs UIU-2142.
 * Fix optional dependencies to be actually optional and add a few. UIU-2140.
+* Include missing `limit` clause in request-count query. Refs UIU-2143.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/Wrappers/withRenew.js
+++ b/src/components/Wrappers/withRenew.js
@@ -11,7 +11,7 @@ import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import BulkRenewalDialog from '../BulkRenewalDialog';
 import isOverridePossible from '../Loans/OpenLoans/helpers/isOverridePossible';
-import { requestStatuses } from '../../constants';
+import { requestStatuses, MAX_RECORDS } from '../../constants';
 
 // HOC used to manage renew
 const withRenew = WrappedComponent => class WithRenewComponent extends React.Component {
@@ -271,7 +271,7 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
         .join(' or ');
       const query = `(itemId==(${q})) and status==(${statusList}) sortby requestDate desc`;
       reset();
-      GET({ params: { query } })
+      GET({ params: { query, limit: MAX_RECORDS } })
         .then((requestRecords) => {
           const requestCountObject = requestRecords.reduce((map, record) => {
             map[record.itemId] = map[record.itemId]


### PR DESCRIPTION
The limit clause in the request count query was missing. We did a nice
job batching the query to handle a long list of loan-ids, but,
astonishingly, completely forgot that if we had, say, 15 loan-ids, we
might get 15+ requests (or even if we had only one loan-id that it might
have 15 open requests). Whoops.

Refs [UIU-2143](https://issues.folio.org/browse/UIU-2143)