### PR TITLE
correctly include sectionInner

### DIFF
--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -67,7 +67,7 @@ export default class Settings extends Component {
                   {section.pages.map((setting) => this.renderSectionPageItem(setting))}
                 </NavListSection>
               );
-              return section.interface ? <IfInterface name={section.interface}>sectionInner</IfInterface> : sectionInner;
+              return section.interface ? <IfInterface name={section.interface}>{sectionInner}</IfInterface> : sectionInner;
             })}
           </NavList>
         </Pane>


### PR DESCRIPTION
Use `{sectionInner}` within JSX to evaluate the variable; without the
braces, it's just a string.

Bugfix for #1707 

Refs [UIU-2140](https://issues.folio.org/browse/UIU-2140)