### PR TITLE
Import react

### DIFF
--- a/src/components/ErrorPane/ErrorPane.js
+++ b/src/components/ErrorPane/ErrorPane.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import {


### PR DESCRIPTION
The bugfest environment is not using the newest version of `stripes-webpack` which includes new version of jsx transform: https://github.com/folio-org/stripes-webpack/pull/11

This PR imports `react` in order to avoid issues like this one in bugfest:

`Error: ReferenceError: React is not defined`