### PR TITLE
UIU-2158 correct proptypes do not generate console warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Handle search of ASTified translation values. Refs UIU-2142.
 * Fix optional dependencies to be actually optional and add a few. UIU-2140.
 * Include missing `limit` clause in request-count query. Refs UIU-2143.
+* Clean up prop-types that generate bogus console warnings. Refs UIU-2158.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/PermissionsAccordion/components/PermissionsList/PermissionsList.js
+++ b/src/components/PermissionsAccordion/components/PermissionsList/PermissionsList.js
@@ -140,7 +140,7 @@ PermissionsList.propTypes = {
   filteredPermissions: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
-      displayName: PropTypes.string.isRequired,
+      displayName: PropTypes.string,
       permissionName: PropTypes.string.isRequired,
       subPermissions: PropTypes.arrayOf(PropTypes.string).isRequired,
       dummy: PropTypes.bool.isRequired,

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -111,7 +111,7 @@ const UserAccounts = ({
 };
 
 UserAccounts.propTypes = {
-  accounts: PropTypes.arrayOf(PropTypes.object),
+  accounts: PropTypes.object,
   accordionId: PropTypes.string,
   expanded: PropTypes.bool,
   onToggle: PropTypes.func,

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -109,7 +109,7 @@ class UserDetail extends React.Component {
     }).isRequired,
     okapi: PropTypes.shape({
       currentUser: PropTypes.shape({
-        servicePoints: PropTypes.string.isRequired,
+        servicePoints: PropTypes.arrayOf(PropTypes.object).isRequired,
       }).isRequired,
     }).isRequired,
     onClose: PropTypes.func,


### PR DESCRIPTION
Some proptype declarations have drifted out of sync and generate bogus
console warnings, making legit console messages difficult to track down
amid the noise.

* PermissionsList.js: `displayName` is not a required attribute of
permissions.
* UserAccounts.js: `accounts` represents the resource. It contains
an array of records, but it is not itself an array of records.
* UserDetail.js: a user's service points are represented by an
array of objects, not string corresponding to a single UUID.

Refs [UIU-2158](https://issues.folio.org/browse/UIU-2158)