### PR TITLE
UIU-2159: Remove unused translations

### DIFF
--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -3,8 +3,6 @@
   "user.pluralized": "{count} {count, plural, one {user} other {users}}",
   "meta.title": "Users",
   "appMenu.keyboardShortcuts": "Keyboard shortcuts",
-  "shortcut.action": "Action",
-  "shortcut.shortcut": "Shortcut",
   "shortcut.createRecord": "Create a new record",
   "shortcut.editRecord": "Edit a record",
   "shortcut.saveRecord": "Save a record",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2159

Remove unused translation strings, which will be translated in stripes-component now:
_"shortcut.action": "Action",
"shortcut.shortcut": "Shortcut",_