### PR TITLE
UIU-1635 loan action menus have a useful aria-label value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Include missing `limit` clause in request-count query. Refs UIU-2143.
 * Replace local KeyboardShortcutsModal component with import. Refs UIU-2151.
 * Clean up prop-types that generate bogus console warnings. Refs UIU-2158.
+* Provide useful `aria-label` values to loan action (ellipses) menues. Refs UIU-1635.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/Loans/ClosedLoans/ClosedLoans.js
+++ b/src/components/Loans/ClosedLoans/ClosedLoans.js
@@ -181,6 +181,8 @@ class ClosedLoans extends React.Component {
   }
 
   getLoansFormatter() {
+    const { intl: { formatMessage } } = this.props;
+
     return {
       'title': loan => _.get(loan, ['item', 'title'], ''),
       'dueDate': loan => {
@@ -243,6 +245,7 @@ class ClosedLoans extends React.Component {
             <IconButton
               {...getTriggerProps()}
               icon="ellipsis"
+              aria-label={formatMessage({ id: 'ui-users.action' })}
             />
           )}
           renderMenu={this.renderDropDownMenu(loan)}

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
 import { withRouter } from 'react-router-dom';
 
 import {
@@ -32,6 +32,7 @@ class ActionsDropdown extends React.Component {
     match: PropTypes.shape({
       params: PropTypes.object
     }),
+    intl: PropTypes.object.isRequired,
   };
 
   renderMenu = ({ onToggle }) => {
@@ -170,12 +171,14 @@ class ActionsDropdown extends React.Component {
   };
 
   render() {
+    const { intl: { formatMessage } } = this.props;
     return (
       <Dropdown
         renderTrigger={({ getTriggerProps }) => (
           <IconButton
             {...getTriggerProps()}
             icon="ellipsis"
+            aria-label={formatMessage({ id: 'ui-users.action' })}
           />
         )}
         renderMenu={this.renderMenu}
@@ -184,4 +187,4 @@ class ActionsDropdown extends React.Component {
   }
 }
 
-export default withRouter(ActionsDropdown);
+export default withRouter(injectIntl(ActionsDropdown));


### PR DESCRIPTION
The `aria-label` for the loan menus' `<IconButton>` trigger was missing.

Refs [UIU-1635](https://issues.folio.org/browse/UIU-1635)