### PR TITLE
UIU-1630: Allow assign permission set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Replace local KeyboardShortcutsModal component with import. Refs UIU-2151.
 * Clean up prop-types that generate bogus console warnings. Refs UIU-2158.
 * Provide useful `aria-label` values to loan action (ellipses) menues. Refs UIU-1635.
+* Allow a user to assign an existing permission set to a permission set. Refs UIU-1630.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/settings/permissions/PermissionSetForm.js
+++ b/src/settings/permissions/PermissionSetForm.js
@@ -296,7 +296,6 @@ class PermissionSetForm extends React.Component {
               permToModify="perms.permissions.item.put"
               formName="permissionSetForm"
               permissionsField="subPermissions"
-              excludePermissionSets
               form={form}
             />
           </Pane>


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-1630

**Acceptance Criteria**

Given I create a permission set
When I click Add permissions to view the Add permissions modal
Then show me permissions sets that have been created along with individual permissions

Given I am assigning permissions to a permission set B in Settings
When I select permission set A on the Add permissions modal
Then permission set A is now assigned to permission set B