### PR TITLE
UIU-2164: Add permissiions type fiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Clean up prop-types that generate bogus console warnings. Refs UIU-2158.
 * Provide useful `aria-label` values to loan action (ellipses) menues. Refs UIU-1635.
 * Allow a user to assign an existing permission set to a permission set. Refs UIU-1630.
+*  Add permissions type filter to users settings permissions sets. Refs UIU-2164.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/settings/permissions/PermissionSetForm.js
+++ b/src/settings/permissions/PermissionSetForm.js
@@ -25,7 +25,10 @@ import stripesFinalForm from '@folio/stripes/final-form';
 import { Field } from 'react-final-form';
 
 import PermissionsAccordion from '../../components/PermissionsAccordion';
-import { statusFilterConfig } from '../../components/PermissionsAccordion/helpers/filtersConfig';
+import {
+  statusFilterConfig,
+  permissionTypeFilterConfig,
+} from '../../components/PermissionsAccordion/helpers/filtersConfig';
 
 import styles from './PermissionSetForm.css';
 
@@ -281,7 +284,10 @@ class PermissionSetForm extends React.Component {
               confirmLabel={<FormattedMessage id="ui-users.delete" />}
             />
             <PermissionsAccordion
-              filtersConfig={[statusFilterConfig]}
+              filtersConfig={[
+                permissionTypeFilterConfig,
+                statusFilterConfig,
+              ]}
               expanded={sections.permSection}
               visibleColumns={[
                 'selected',


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2164

**Description**

At users settings - Permission sets - select a permission - Edit permission - Add permission:
The "Select Permissions" modal should be expanded for filter **Permissions types** with the values _Permission sets_ and _Permissions_.