### PR TITLE
UIU-2158 use correct prop-types

### DIFF
--- a/src/components/Accounts/ChargeFeeFine/FeeFineInfo.js
+++ b/src/components/Accounts/ChargeFeeFine/FeeFineInfo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import { Field } from 'react-final-form';
 
 import {
@@ -20,6 +20,7 @@ class FeeFineInfo extends React.Component {
     onChangeOwner: PropTypes.func.isRequired,
     ownerOptions: PropTypes.arrayOf(PropTypes.object),
     onChangeFeeFine: PropTypes.func,
+    intl: PropTypes.object,
     isPending: PropTypes.object,
   };
 
@@ -54,6 +55,7 @@ class FeeFineInfo extends React.Component {
 
   render() {
     const {
+      intl,
       isPending,
       ownerOptions,
       feefineList,
@@ -74,21 +76,17 @@ class FeeFineInfo extends React.Component {
                 </Row>
                 <Row>
                   <Col xs={12}>
-                    <FormattedMessage id="ui-users.feefines.modal.placeholder">
-                      {placeholder => (
-                        <Field
-                          name="ownerId"
-                          id="ownerId"
-                          type="select"
-                          component={Select}
-                          fullWidth
-                          disabled={isPending.owners}
-                          dataOptions={ownerOptions}
-                          onChange={(e) => onChangeOwner(e.target.value)}
-                          placeholder={placeholder}
-                        />
-                      )}
-                    </FormattedMessage>
+                    <Field
+                      name="ownerId"
+                      id="ownerId"
+                      type="select"
+                      component={Select}
+                      fullWidth
+                      disabled={isPending.owners}
+                      dataOptions={ownerOptions}
+                      onChange={(e) => onChangeOwner(e.target.value)}
+                      placeholder={intl.formatMessage({ id: 'ui-users.feefines.modal.placeholder' })}
+                    />
                     {isPending.owners && <FormattedMessage id="ui-users.loading" />}
                   </Col>
                 </Row>
@@ -101,21 +99,17 @@ class FeeFineInfo extends React.Component {
                 </Row>
                 <Row>
                   <Col xs={12}>
-                    <FormattedMessage id="ui-users.feefines.modal.placeholder">
-                      {placeholder => (
-                        <Field
-                          name="feeFineId"
-                          id="feeFineType"
-                          type="select"
-                          component={Select}
-                          fullWidth
-                          disabled={isPending.feefines}
-                          dataOptions={feefineList}
-                          placeholder={placeholder}
-                          onChange={onChangeFeeFine}
-                        />
-                      )}
-                    </FormattedMessage>
+                    <Field
+                      name="feeFineId"
+                      id="feeFineType"
+                      type="select"
+                      component={Select}
+                      fullWidth
+                      disabled={isPending.feefines}
+                      dataOptions={feefineList}
+                      placeholder={intl.formatMessage({ id: 'ui-users.feefines.modal.placeholder' })}
+                      onChange={onChangeFeeFine}
+                    />
                     {isPending.feefines && <FormattedMessage id="ui-users.loading" />}
                   </Col>
                 </Row>
@@ -148,4 +142,4 @@ class FeeFineInfo extends React.Component {
   }
 }
 
-export default FeeFineInfo;
+export default injectIntl(FeeFineInfo);

--- a/src/settings/CommentRequiredForm.js
+++ b/src/settings/CommentRequiredForm.js
@@ -44,7 +44,7 @@ const Setting = ({
 );
 
 Setting.propTypes = {
-  label: PropTypes.string,
+  label: PropTypes.element,
   name: PropTypes.string,
   intl: PropTypes.object,
 };

--- a/src/settings/ConditionsSettings.js
+++ b/src/settings/ConditionsSettings.js
@@ -31,7 +31,7 @@ class ConditionsSettings extends Component {
     }).isRequired,
     mutator: PropTypes.shape({
       patronBlockConditions: PropTypes.shape({
-        GET: PropTypes.func.isRequired,
+        GET: PropTypes.func,
       }).isRequired,
     }).isRequired,
   };

--- a/src/settings/patronBlocks/BlockTemplates/BlockTemplates.js
+++ b/src/settings/patronBlocks/BlockTemplates/BlockTemplates.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 
 import { EntryManager } from '@folio/stripes/smart-components';
 import { stripesConnect } from '@folio/stripes/core';
@@ -21,36 +21,33 @@ function validate(values) {
 
 function BlockTemplates(props) {
   const {
+    intl: { formatMessage },
     mutator,
     resources: { manualBlockTemplates },
   } = props;
 
   return (
-    <FormattedMessage id="ui-users.manualBlockTemplate">
-      {(entryLabel) => (
-        <EntryManager
-          {...props}
-          parentMutator={mutator}
-          entryList={_.sortBy((manualBlockTemplates || {}).records || [], [
-            'name',
-          ])}
-          resourceKey="manualBlockTemplates"
-          detailComponent={BlockTemplateDetails}
-          paneTitle={
-            <FormattedMessage id="ui-users.settings.manualBlockTemplates" />
-          }
-          entryLabel={entryLabel}
-          entryFormComponent={BlockTemplateForm}
-          validate={validate}
-          nameKey="name"
-          permissions={{
-            put: 'manual-block-templates.item.put',
-            post: 'manual-block-templates.item.post',
-            delete: 'manual-block-templates.item.delete',
-          }}
-        />
-      )}
-    </FormattedMessage>
+    <EntryManager
+      {...props}
+      parentMutator={mutator}
+      entryList={_.sortBy((manualBlockTemplates || {}).records || [], [
+        'name',
+      ])}
+      resourceKey="manualBlockTemplates"
+      detailComponent={BlockTemplateDetails}
+      paneTitle={
+        <FormattedMessage id="ui-users.settings.manualBlockTemplates" />
+      }
+      entryLabel={formatMessage({ id: 'ui-users.manualBlockTemplate' })}
+      entryFormComponent={BlockTemplateForm}
+      validate={validate}
+      nameKey="name"
+      permissions={{
+        put: 'manual-block-templates.item.put',
+        post: 'manual-block-templates.item.post',
+        delete: 'manual-block-templates.item.delete',
+      }}
+    />
   );
 }
 
@@ -63,6 +60,7 @@ BlockTemplates.manifest = Object.freeze({
 });
 
 BlockTemplates.propTypes = {
+  intl: PropTypes.object,
   resources: PropTypes.shape({
     manualBlockTemplates: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
@@ -77,4 +75,4 @@ BlockTemplates.propTypes = {
   }).isRequired,
 };
 
-export default stripesConnect(BlockTemplates);
+export default injectIntl(stripesConnect(BlockTemplates));


### PR DESCRIPTION
Man oh man what a PITA `react-intl` `v5` is when it comes to
render-props. Sheesh. Fix that shiz mainly by using `injectIntl` and
`formatMessage` to get strings where they are necessary; it's so much
cleaner and easier to follow than the render-props.

And sync other prop-types that have drifted out of sync and are now
causing console pollution.

Refs [UIU-2158](https://issues.folio.org/browse/UIU-2158)