### PR TITLE
test cleanup; lint cleanup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,6 +20,9 @@ module.exports = {
   },
   testMatch: ['**/(lib|src)/**/?(*.)test.{js,jsx}'],
   testPathIgnorePatterns: ['/node_modules/', '/test/bigtest/', '/test/ui-testing/'],
-  setupFiles: [path.join(__dirname, './test/jest/setupTests.js')],
+  setupFiles: [
+    path.join(__dirname, './test/jest/setupTests.js'),
+    'jest-canvas-mock'
+  ],
   setupFilesAfterEnv: [path.join(__dirname, './test/jest/jest.setup.js')],
 };

--- a/package.json
+++ b/package.json
@@ -835,6 +835,7 @@
     "faker": "^4.1.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",
+    "jest-canvas-mock": "^2.3.0",
     "jest-junit": "^12.0.0",
     "history": "^5.0.0",
     "miragejs": "^0.1.32",

--- a/src/components/ReportModals/CashDrawerReportModal.test.js
+++ b/src/components/ReportModals/CashDrawerReportModal.test.js
@@ -67,13 +67,10 @@ describe('Cash drawer reconciliation modal', () => {
     afterEach(cleanup);
 
     it('should be rendered', () => {
-
       const { container } = cashDrawerModal;
       const modalContent = container.querySelector('[data-test-cash-drawer-report-modal]');
       const modalMainHeader = container.querySelector('[data-test-cash-drawer-report-modal] h1');
       const form = container.querySelector('form');
-
-
 
       expect(container).toBeVisible();
       expect(modalContent).toBeVisible();

--- a/src/components/ReportModals/CashDrawerReportModal.test.js
+++ b/src/components/ReportModals/CashDrawerReportModal.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Router } from 'react-router-dom';
 import {
-  render,
   cleanup,
+  render,
   screen,
 } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
@@ -17,7 +17,7 @@ const renderCashDrawerReportModal = ({
   handleSubmit = jest.fn(),
   values = {},
   cashDrawerReportSources = {
-    POST: jest.fn()
+    POST: jest.fn(() => Promise.resolve({ data: {} })),
   },
   intl = {},
   form = {},
@@ -57,7 +57,6 @@ describe('Cash drawer reconciliation modal', () => {
       cashDrawerModal = renderCashDrawerReportModal({
         initialValues: {
           format: 'both',
-          servicePoint: 'Online',
           sources: ['ADMIN'],
           startDate: '2020-05-11',
           endDate: '2021-05-11'
@@ -68,10 +67,13 @@ describe('Cash drawer reconciliation modal', () => {
     afterEach(cleanup);
 
     it('should be rendered', () => {
+
       const { container } = cashDrawerModal;
       const modalContent = container.querySelector('[data-test-cash-drawer-report-modal]');
       const modalMainHeader = container.querySelector('[data-test-cash-drawer-report-modal] h1');
       const form = container.querySelector('form');
+
+
 
       expect(container).toBeVisible();
       expect(modalContent).toBeVisible();

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -181,6 +181,7 @@ UserAccounts.propTypes = {
     loansHistory: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
     }),
-  }) };
+  })
+};
 
 export default UserAccounts;

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -21,7 +21,6 @@ jest.mock('@folio/stripes/components', () => ({
     </div>
   )),
   Headline: jest.fn(({ children }) => <div>{ children }</div>),
-
   Icon: jest.fn((props) => (props && props.children ? props.children : <span />)),
   IconButton: jest.fn(({
     buttonProps,
@@ -36,12 +35,28 @@ jest.mock('@folio/stripes/components', () => ({
   Label: jest.fn(({ children, ...rest }) => (
     <span {...rest}>{children}</span>
   )),
-  Modal: jest.fn(({ children, label, dismissible, ...rest }) => (
-    <div {...rest}>
-      <h1>{label}</h1>
-      {children}
-    </div>
-  )),
+  // oy, dismissible. we need to pull it out of props so it doesn't
+  // get applied to the div as an attribute, which must have a string-value,
+  // which will shame you in the console:
+  //
+  //     Warning: Received `true` for a non-boolean attribute `dismissible`.
+  //     If you want to write it to the DOM, pass a string instead: dismissible="true" or dismissible={value.toString()}.
+  //         in div (created by mockConstructor)
+  //
+  // is there a better way to throw it away? If we don't destructure and
+  // instead access props.label and props.children, then we get a test
+  // failure that the modal isn't visible. oy, dismissible.
+  Modal: jest.fn(({ children, label, dismissible, ...rest }) => {
+    return (
+      <div
+        data-test={dismissible ? '' : ''}
+        {...rest}
+      >
+        <h1>{label}</h1>
+        {children}
+      </div>
+    );
+  }),
   ModalFooter: jest.fn((props) => (
     <div>{props.children}</div>
   )),
@@ -68,11 +83,27 @@ jest.mock('@folio/stripes/components', () => ({
   NavListSection: jest.fn(({ children, className, ...rest }) => (
     <div className={className} {...rest}>{children}</div>
   )),
-  Pane: jest.fn(({ children, className, defaultWidth, paneTitle, firstMenu, ...rest }) => (
-    <div className={className} {...rest}>{children}</div>
-  )),
+  Pane: jest.fn(({ children, className, defaultWidth, paneTitle, firstMenu, lastMenu, ...rest }) => {
+    return (
+      <div className={className} {...rest} style={{ width: defaultWidth }}>
+        <div>
+          {firstMenu ?? null}
+          {paneTitle}
+          {lastMenu ?? null}
+        </div>
+        {children}
+      </div>
+    );
+  }),
   PaneFooter: jest.fn(({ ref, children, ...rest }) => (
     <div ref={ref} {...rest}>{children}</div>
+  )),
+  PaneHeader: jest.fn(({ paneTitle, firstMenu, lastMenu }) => (
+    <div>
+      {firstMenu ?? null}
+      {paneTitle}
+      {lastMenu ?? null}
+    </div>
   )),
   PaneBackLink: jest.fn(() => <span />),
   PaneMenu: jest.fn((props) => <div>{props.children}</div>),


### PR DESCRIPTION
Spacing!
Mock the stripes-COMPONENTS like an ADULT
INSTALL PACKAGES!
[LINT ALL THE THINGS!](http://hyperboleandahalf.blogspot.com/2010/06/this-is-why-ill-never-be-adult.html)

If anybody has better idea about how we can destructure props in the mocks to avoid misapplying them as HTML element attributes, I'm all ears. We need to pull out `dismissible` to avoid this one: 
```
    console.error
      Warning: Received `true` for a non-boolean attribute `dismissible`.
      
      If you want to write it to the DOM, pass a string instead: dismissible="true" or dismissible={value.toString()}.
          in div (created by mockConstructor)
          in mockConstructor (created by CashDrawerReportModal)
          in CashDrawerReportModal
          in Unknown (created by ReactFinalForm)
          in ReactFinalForm (created by Context.Consumer)
          in StripesFinalFormWrapper (created by Context.Consumer)
          in withRouter(StripesFinalFormWrapper)
          in Unknown
          in Router
```
and `jest-canvas-mock` resolves this one: 
```
    console.error
      Error: Not implemented: HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)
          at module.exports (/Users/zburke/projects/stripes/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
          at HTMLCanvasElementImpl.getContext (/Users/zburke/projects/stripes/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js:42:5)
          at HTMLCanvasElement.getContext (/Users/zburke/projects/stripes/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/living/generated/HTMLCanvasElement.js:131:58)
          at hasBrowserCanvas (/Users/zburke/projects/stripes/node_modules/jspdf/src/libs/png.js:479:36)
          at /Users/zburke/projects/stripes/node_modules/jspdf/src/libs/png.js:488:3
          at Object.<anonymous> (/Users/zburke/projects/stripes/node_modules/jspdf/src/libs/png.js:28:11)
          at Runtime._execModule (/Users/zburke/projects/stripes/node_modules/jest-runtime/build/index.js:1299:24)
          at Runtime._loadModule (/Users/zburke/projects/stripes/node_modules/jest-runtime/build/index.js:898:12)
          at Runtime.requireModule (/Users/zburke/projects/stripes/node_modules/jest-runtime/build/index.js:746:10)
          at Runtime.requireModuleOrMock (/Users/zburke/projects/stripes/node_modules/jest-runtime/build/index.js:919:21) undefined

```