### PR TITLE
UIU-2171 correctly handle undefined in nullOrStringIsRequiredTypeValidator

### DIFF
--- a/src/customTypeValidators.js
+++ b/src/customTypeValidators.js
@@ -1,9 +1,16 @@
+/**
+ * PropTypes validator: accept null, undefined, or string values.
+ *
+ * @param {object} props collection of props
+ * @param {string} propName name of prop to validate
+ * @param {string} componentName name of component receiving props
+ * @returns null or Error
+ */
 // eslint-disable-next-line import/prefer-default-export
 export const nullOrStringIsRequiredTypeValidator = (props, propName, componentName) => {
   const propValue = props[propName];
-  if (propValue === null) return;
+  if (propValue === null || propValue === undefined) return;
   if (typeof propValue === 'string') return;
   // eslint-disable-next-line consistent-return
-  return new Error('Invalid prop `' + propName + '` supplied to' +
-  ' `' + componentName + '`. Validation failed.');
+  return new Error(`Invalid prop ${propName} of type ${typeof propValue} supplied to ${componentName}. Validation failed.`);
 };


### PR DESCRIPTION
When a prop is not passed at all, its value will be `undefined`, not
`null`. Such a value should be acceptable to this validator.

Refs [UIU-2171](https://issues.folio.org/browse/UIU-2171)