### PR TITLE
UIU-2172 correctly initialize new user initialValues

### DIFF
--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -82,6 +82,7 @@ class UserEdit extends React.Component {
       active: true,
       personal: {
         addresses: [],
+        firstName: '',
         preferredContactTypeId: (find(contactTypes, { 'name': 'email' }) || {}).id,
       },
       requestPreferences: {
@@ -89,7 +90,8 @@ class UserEdit extends React.Component {
         delivery: false,
         defaultServicePointId: null,
         defaultDeliveryAddressTypeId: null,
-      }
+      },
+      username: '',
     };
 
     if (!match.params.id) return initialFormValues;


### PR DESCRIPTION
`EditExtendedInfo` expects certain attributes to be present, even if
empty.

Refs [UIU-2172](https://issues.folio.org/browse/UIU-2172)