### PR TITLE
UIU-1840: Change Fee/Fine Details 'Loan details' from 'View' link to 'Anonymized' text if associated loan has been scrubbed

### DIFF
--- a/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
+++ b/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
@@ -363,7 +363,7 @@ class ViewFeesFines extends React.Component {
     // disable ellipses menu actions based on permissions
     const buttonDisabled = !this.props.stripes.hasPerm('ui-users.feesfines.actions.all');
     const isClaimReturnedItem = (loan.item && loan.item.status && loan.item.status.name && loan.item.status.name === itemStatuses.CLAIMED_RETURNED);
-
+    const loanText = isDisabled.loan ? 'ui-users.accounts.history.button.loanAnonymized' : 'ui-users.accounts.history.button.loanDetails';
     return (
       <Dropdown
         renderTrigger={this.renderToggle}
@@ -387,7 +387,7 @@ class ViewFeesFines extends React.Component {
           </this.MenuButton>
           <hr />
           <this.MenuButton disabled={isDisabled.loan || buttonDisabled} account={a} action="loanDetails">
-            <FormattedMessage id="ui-users.accounts.history.button.loanDetails" />
+            <FormattedMessage id={loanText} />
           </this.MenuButton>
         </DropdownMenu>
       </Dropdown>

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -620,7 +620,7 @@ class AccountDetails extends React.Component {
                 :
                 <KeyValue
                   label={<FormattedMessage id="ui-users.details.label.loanDetails" />}
-                  value="-"
+                  value={<FormattedMessage id="ui-users.details.label.loanAnonymized" />}
                 />
               }
             </Col>

--- a/test/bigtest/network/scenarios/fee-fine-details.js
+++ b/test/bigtest/network/scenarios/fee-fine-details.js
@@ -16,7 +16,7 @@ export default (server) => {
       name: () => 'Lost Item Policy name',
     },
   });
-  const owner = server.create('owner');
+  const owner = server.create('owner', { servicePointOwner: [{ value: 1, label: 'Test Point' }] });
   server.create('payment', {
     nameMethod: 'visa',
     ownerId: owner.id,
@@ -27,10 +27,11 @@ export default (server) => {
     defaultAmount: 10
   });
   server.create('waife', { nameReason : 'waiveReason' });
-  server.create('transfer', { accountName : 'transferAccount' });
+  server.create('transfer', { accountName : 'transferAccount', ownerId: owner.id });
   server.create('refund', { nameReason: 'Overpaid' });
   server.createList('account', 3, {
     userId: user.id,
+    ownerId: owner.id
   });
   const openAccount = server.create('account', {
     userId: user.id,

--- a/test/bigtest/network/scenarios/view-fees-fines.js
+++ b/test/bigtest/network/scenarios/view-fees-fines.js
@@ -36,6 +36,18 @@ export default (server) => {
     ownerId: owners[0].id,
     feeFineId: feefines[0].id
   });
+  server.create('account', {
+    userId: user.id,
+    status: {
+      name: 'Open'
+    },
+    amount: 100,
+    remaining: 100,
+    ownerId: owners[0].id,
+    feeFineId: feefines[0].id,
+    loanId: '0'
+  });
+
   server.create('comment');
   server.createList('waiver', 4);
   server.createList('payment', 4, { ownerId: owners[0].id });

--- a/test/bigtest/network/scenarios/view-fees-fines.js
+++ b/test/bigtest/network/scenarios/view-fees-fines.js
@@ -3,13 +3,18 @@ import CQLParser from '../cql';
 
 export default (server) => {
   const user = server.create('user', { id: 'ce0e0d5b-b5f3-4ad5-bccb-49c0784298fd' });
-  const owners = server.createList('owner', 3);
-  server.createList('feefine', 5);
-  const account = server.create('account', { userId: user.id });
+  const owners = server.createList('owner', 3, { servicePointOwner: [{ value: 1, label: 'Test Point' }] });
+
+  const feefines = server.createList('feefine', 5, { ownerId: owners[0].id });
+  const account = server.create('account', {
+    userId: user.id,
+    ownerId: owners[0].id
+  });
   server.createList('feefineaction', 1, { accountId: account.id });
   server.createList('account', 3, {
     userId: user.id,
     ownerId: owners[0].id,
+    feeFineId: feefines[0].id,
   });
   server.create('account', {
     userId: user.id,
@@ -17,7 +22,9 @@ export default (server) => {
       name: 'Open'
     },
     amount: 100,
-    remaining: 100
+    remaining: 100,
+    ownerId: owners[0].id,
+    feeFineId: feefines[0].id
   });
   server.create('account', {
     userId: user.id,
@@ -25,12 +32,14 @@ export default (server) => {
       name: 'Closed'
     },
     amount: 0,
-    remaining: 0
+    remaining: 0,
+    ownerId: owners[0].id,
+    feeFineId: feefines[0].id
   });
   server.create('comment');
   server.createList('waiver', 4);
   server.createList('payment', 4, { ownerId: owners[0].id });
-  server.createList('transfer', 4);
+  server.createList('transfer', 4, { ownerId: owners[0].id });
   server.get('/accounts');
   server.get('/accounts/:id', (schema, request) => {
     return schema.accounts.find(request.params.id).attrs;

--- a/test/bigtest/tests/fee-fine-details-test.js
+++ b/test/bigtest/tests/fee-fine-details-test.js
@@ -14,7 +14,7 @@ describe('Test Fee/Fine details', () => {
   setupApplication({
     scenarios: ['fee-fine-details'],
     currentUser: {
-      curServicePoint: { id: 1 },
+      curServicePoint: { id: 1, value: 'Test Point' },
     },
   });
   describe('visit Fee/fine details', () => {
@@ -251,7 +251,7 @@ describe('Test Fee/Fine details', () => {
         });
       });
     });
-
+    /*
     describe('Refund fee/fine', () => {
       beforeEach(async () => {
         await FeeFineDetails.refundButton.click();
@@ -301,5 +301,6 @@ describe('Test Fee/Fine details', () => {
         });
       });
     });
+    */
   });
 });

--- a/test/bigtest/tests/fee-fine-details-test.js
+++ b/test/bigtest/tests/fee-fine-details-test.js
@@ -251,7 +251,7 @@ describe('Test Fee/Fine details', () => {
         });
       });
     });
-    /*
+
     describe('Refund fee/fine', () => {
       beforeEach(async () => {
         await FeeFineDetails.refundButton.click();
@@ -301,6 +301,5 @@ describe('Test Fee/Fine details', () => {
         });
       });
     });
-    */
   });
 });

--- a/test/bigtest/tests/fee-fine-history-test.js
+++ b/test/bigtest/tests/fee-fine-history-test.js
@@ -52,7 +52,7 @@ describe('Test Fee/Fine History', () => {
           expect(FeeFineHistoryInteractor.paneSub).to.string('Outstanding balance for page');
           expect(FeeFineHistoryInteractor.paneSub).to.string('Suspended balance for page');
           expect(FeeFineHistoryInteractor.labelMenu).to.string('Open fees/fines for');
-          expect(FeeFineHistoryInteractor.outstandingMenu).to.string('Total outstanding balance: 560.00 | Total suspended balance: 0.00');
+          expect(FeeFineHistoryInteractor.outstandingMenu).to.string('Total outstanding balance: 660.00 | Total suspended balance: 0.00');
         });
 
         describe('displays open fees/fines rows', () => {
@@ -62,7 +62,7 @@ describe('Test Fee/Fine History', () => {
           });
 
           it('renders proper amount of rows', () => {
-            expect(FeeFineHistoryInteractor.mclViewFeesFines.rowCount).to.equal(5);
+            expect(FeeFineHistoryInteractor.mclViewFeesFines.rowCount).to.equal(6);
           });
 
           describe('activate the Search & filter', () => {
@@ -382,6 +382,15 @@ describe('Test Fee/Fine History', () => {
             it('show the loan details modal', () => {
               expect(FeeFineHistoryInteractor.loanDetailsIsPresent).to.be.true;
             });
+          });
+        });
+
+        describe('est the ellipsis menu (anonymized)', () => {
+          beforeEach(async () => {
+            await FeeFineHistoryInteractor.rows(5).cells(13).selectEllipsis();
+          });
+          it('Check text on loan details option', () => {
+            expect(FeeFineHistoryInteractor.dropDownEllipsisOptions(5).text).to.string('Loan details (anonymized)');
           });
         });
       });

--- a/test/bigtest/tests/fee-fine-history-test.js
+++ b/test/bigtest/tests/fee-fine-history-test.js
@@ -12,7 +12,7 @@ describe('Test Fee/Fine History', () => {
   setupApplication({
     scenarios: ['view-fees-fines'],
     currentUser: {
-      curServicePoint: { id: 1 },
+      curServicePoint: { id: 1, value: 'Test Point' },
     },
   });
   describe('visit user details', () => {
@@ -36,7 +36,7 @@ describe('Test Fee/Fine History', () => {
 
       it('It should render with the labels', () => {
         expect(FeeFineHistoryInteractor.openFeesFines).to.string('open fees/fines');
-        expect(FeeFineHistoryInteractor.closedFeesFines).to.string('1 closed fee/fine');
+        expect(FeeFineHistoryInteractor.closedFeesFines).to.string('0 closed fees/fines');
         expect(FeeFineHistoryInteractor.allFeesFines).to.string('View all fees/fines');
         expect(FeeFineHistoryInteractor.refundedFeesFines).to.string('0 refunded fees/fines (Total: 0.00)');
         expect(FeeFineHistoryInteractor.claimFeesFines).to.string('0 suspended claim returned fees/fines (Total: 0.00)');

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -526,6 +526,7 @@
   "accounts.history.button.refund": "Refund",
   "accounts.history.button.transfer": "Transfer",
   "accounts.history.button.loanDetails": " Loan details",
+  "accounts.history.button.loanAnonymized": "Loan details (anonymized)",
   "accounts.history.comment": "Additional information",
   "accounts.history.of": "of",
   "accounts.history.filter": "Search & Filter",

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -498,6 +498,7 @@
   "details.field.returnedate": "Returned date",
   "details.paneTitle.feeFineDetails": "Fee/fine details",
   "details.label.loanDetails": "Loan details",
+  "details.label.loanAnonymized": "Anonymized",
   "accounts.button.new": " New fee/fine",
   "accounts.button.error": "Error",
   "accounts.error.field": "Please fill this field in to continue",

--- a/translations/ui-users/en_US.json
+++ b/translations/ui-users/en_US.json
@@ -296,6 +296,7 @@
     "accounts.history.button.refund": "Refund",
     "accounts.history.button.transfer": "Transfer",
     "accounts.history.button.loanDetails": " Loan details",
+    "accounts.history.button.loanAnonymized": "Loan details (anonymized)",
     "accounts.history.comment": "Additional information",
     "accounts.history.of": "of",
     "accounts.waive.error.amount": "Waive amount must be > 0",

--- a/translations/ui-users/en_US.json
+++ b/translations/ui-users/en_US.json
@@ -285,6 +285,7 @@
     "details.columns.transactioninfo": "Transaction information",
     "details.paneTitle.feeFineDetails": "Fee/fine details",
     "details.label.loanDetails": "Loan details",
+    "details.label.loanAnonymized": "Anonymized",
     "accounts.button.new": " New fee/fine",
     "accounts.button.error": "Error",
     "accounts.error.field": "Please fill this field in to continue",


### PR DESCRIPTION
### Purpose
If a fee/fine is associated with a loan, but the loan has been scrubbed (i.e. no longer exists) change the Loan details 'View' link value in Fee/Fine Details to text 'Anonymized'.

### Stories
https://issues.folio.org/browse/UIU-1840

Related to https://github.com/folio-org/ui-users/pull/1757
