### PR TITLE
UIU-2175: Fix validation error with END DATE for Cash drawer reconciliation report modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Add possible for enter correct values for Fee/Fine amount. Refs UIU-2156.
 * Added `NotePopupModal` to User Details page. Refs UIU-2008.
 * Fix selecting current fee fine type. Refs UIU-2157.
+* Fix validation error with END DATE for `Cash drawer reconciliation report` modal. Refs UIU-2175.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/ReportModals/CashDrawerReportModal.js
+++ b/src/components/ReportModals/CashDrawerReportModal.js
@@ -26,7 +26,7 @@ import {
 
 import { DATE_FORMAT } from '../../constants';
 
-const validate = (options) => {
+export const validate = (options) => {
   const errors = {};
   const { startDate, endDate, servicePoint } = options;
 
@@ -38,16 +38,12 @@ const validate = (options) => {
     errors.startDate = <FormattedMessage id="ui-users.reports.cash.drawer.report.endDateWithoutStart.error" />;
   }
 
-  if ((!isEmpty(startDate) && !isEmpty(endDate)) && (moment(startDate).isAfter(moment(endDate)) || moment(endDate).isAfter(moment()))) {
+  if ((!isEmpty(startDate) && !isEmpty(endDate)) && (moment(startDate).isAfter(moment(endDate)))) {
     errors.endDate = <FormattedMessage id="ui-users.reports.cash.drawer.report.endDate.error" />;
   }
 
   if (!servicePoint) {
     errors.servicePoint = <FormattedMessage id="ui-users.reports.cash.drawer.report.servicePoint.error" />;
-  }
-
-  if (!options.format) {
-    options.format = 'both';
   }
 
   return errors;

--- a/src/components/ReportModals/CashDrawerReportModal.test.js
+++ b/src/components/ReportModals/CashDrawerReportModal.test.js
@@ -6,9 +6,10 @@ import {
   screen,
 } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { forEach } from 'lodash';
 
 import '../../../test/jest/__mock__';
-import CashDrawerReportModal from './CashDrawerReportModal';
+import CashDrawerReportModal, { validate } from './CashDrawerReportModal';
 
 const modalHeader = 'Cash drawer reconciliation modal';
 const renderCashDrawerReportModal = ({
@@ -165,6 +166,83 @@ describe('Cash drawer reconciliation modal', () => {
 
       expect(container).toBeVisible();
       expect(form).toBeVisible();
+    });
+  });
+
+  describe('Validation', () => {
+    const customRender = (options) => {
+      let validationError = '';
+
+      forEach(validate(options), (error) => {
+        validationError = error;
+      });
+
+      return render(
+        <div data-testid="validation-error">
+          {
+            validationError
+          }
+        </div>,
+      );
+    };
+
+    it('should return validation error for start date', () => {
+      const options = {
+        startDate: '',
+        endDate: '',
+        servicePoint: [],
+      };
+
+      customRender(options);
+
+      expect(screen.getByTestId('validation-error').textContent).toBe('ui-users.reports.cash.drawer.report.startDate.error');
+    });
+
+    it('should return validation error for end date without start date', () => {
+      const options = {
+        startDate: '',
+        endDate: '2021-06-15',
+        servicePoint: [],
+      };
+
+      customRender(options);
+
+      expect(screen.getByTestId('validation-error').textContent).toBe('ui-users.reports.cash.drawer.report.endDateWithoutStart.error');
+    });
+
+    it('should return validation error for end date', () => {
+      const options = {
+        startDate: '2021-06-30',
+        endDate: '2021-06-15',
+        servicePoint: [],
+      };
+
+      customRender(options);
+
+      expect(screen.getByTestId('validation-error').textContent).toBe('ui-users.reports.cash.drawer.report.endDate.error');
+    });
+
+    it('should return validation error for service point', () => {
+      const options = {
+        startDate: '2021-06-15',
+        endDate: '2021-06-30',
+      };
+
+      customRender(options);
+
+      expect(screen.getByTestId('validation-error').textContent).toBe('ui-users.reports.cash.drawer.report.servicePoint.error');
+    });
+
+    it('should not return validation error', () => {
+      const options = {
+        startDate: '2021-06-15',
+        endDate: '2021-06-30',
+        servicePoint: [],
+      };
+
+      customRender(options);
+
+      expect(screen.getByTestId('validation-error').textContent).toBe('');
     });
   });
 });


### PR DESCRIPTION
## Purpose
Fix validation error with `END DATE` for` Cash drawer reconciliation report` modal

## Approach
Fix problem with `END DATE`
Add tests for validation
Remove default value for format (`options.format = 'both'`) that we already sent it in `initialValues`.

## Stories
https://issues.folio.org/browse/UIU-2175

## Screenshot
### Before changes 
![image](https://user-images.githubusercontent.com/24813219/120480817-1fcf2500-c3b8-11eb-9e9b-f1ed75053aae.png)

### After changes
![image](https://user-images.githubusercontent.com/24813219/120480856-29f12380-c3b8-11eb-8bd0-e2330536aa26.png)
