### PR TITLE
UIU-2184 CashDrawerReconciliationReportCSV should handle empty data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Added `NotePopupModal` to User Details page. Refs UIU-2008.
 * Fix selecting current fee fine type. Refs UIU-2157.
 * Fix validation error with END DATE for `Cash drawer reconciliation report` modal. Refs UIU-2175.
+* Handle empty report data in `CashDrawerReconciliationReportCSV`. Refs UIU-2184.
 
 ## [6.0.0](https://github.com/folio-org/ui-users/tree/v6.0.0) (2021-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v5.0.9...v6.0.0)

--- a/src/components/data/reports/cashDrawerReconciliationReportCSV.js
+++ b/src/components/data/reports/cashDrawerReconciliationReportCSV.js
@@ -99,18 +99,20 @@ class CashDrawerReconciliationReportCSV extends CashDrawerReconciliationReport {
     this.reportData = this.buildReport();
     const origin = window.location.origin;
 
-    const partOfReport = this.reportData.map(row => {
-      if (row.feeFineId) {
-        return {
-          ...row,
-          feeFineDetails: `=HYPERLINK("${origin}/users/${row.patronId}/accounts/view/${row.feeFineId}", "${row.feeFineId}")`,
-        };
-      } else {
-        return row;
-      }
-    });
+    if (this.reportData) {
+      const partOfReport = this.reportData.map(row => {
+        if (row.feeFineId) {
+          return {
+            ...row,
+            feeFineDetails: `=HYPERLINK("${origin}/users/${row.patronId}/accounts/view/${row.feeFineId}", "${row.feeFineId}")`,
+          };
+        } else {
+          return row;
+        }
+      });
 
-    partOfReport.forEach((row) => report.push({ ...row }));
+      partOfReport.forEach((row) => report.push({ ...row }));
+    }
 
     return report;
   }

--- a/src/components/data/reports/cashDrawerReconciliationReportCSV.test.js
+++ b/src/components/data/reports/cashDrawerReconciliationReportCSV.test.js
@@ -1,11 +1,28 @@
 import CashDrawerReconciliationReportCSV from './cashDrawerReconciliationReportCSV';
 import options from '../../../../test/jest/__mock__/cashDrawerReconciliationReportData.mock';
+import emptyOptions from '../../../../test/jest/__mock__/cashDrawerReconciliationReportEmptyData.mock';
 
 describe('Cash Drawer Reconciliation Report in CSV format', () => {
   const report = new CashDrawerReconciliationReportCSV(options);
 
   it('should contain fields', () => {
     expect(report.data).toBe(options.data);
+  });
+
+  it('should call toCSV method', () => {
+    const toCSVSpy = jest.spyOn(report, 'toCSV');
+    report.toCSV();
+
+    expect(toCSVSpy).toHaveBeenCalled();
+  });
+});
+
+
+describe('Cash Drawer Reconciliation Report in CSV format (empty data)', () => {
+  const report = new CashDrawerReconciliationReportCSV(emptyOptions);
+
+  it('should contain fields', () => {
+    expect(report.data).toBe(emptyOptions.data);
   });
 
   it('should call toCSV method', () => {

--- a/test/jest/__mock__/cashDrawerReconciliationReportEmptyData.mock.js
+++ b/test/jest/__mock__/cashDrawerReconciliationReportEmptyData.mock.js
@@ -1,0 +1,19 @@
+const options = {
+  data: {
+    reportData: [],
+    reportStats: {},
+  },
+  intl: {
+    formatMessage: jest.fn(() => ''),
+    formatTime: jest.fn(),
+    formatDate: jest.fn(),
+  },
+  headerData: {
+    createdAt: 'Online',
+    sources: 'ADMINISTRATOT, DIKU',
+    startDate: '2020/01/05',
+    endDate: '2021/01/05'
+  }
+};
+
+export default options;


### PR DESCRIPTION
An empty data array would cause an NPE in `parse()` because it did not
validate the return value from `buildReport()`.

Refs [UIU-2184](https://issues.folio.org/browse/UIU-2184)