### PR TITLE
UIU-2175: Fix validation error with END DATE for Cash drawer reconciliation report modal

### DIFF
--- a/src/components/ReportModals/CashDrawerReportModal.js
+++ b/src/components/ReportModals/CashDrawerReportModal.js
@@ -123,7 +123,6 @@ const CashDrawerReportModal = (props) => {
             <Field
               label={<FormattedMessage id="ui-users.reports.refunds.modal.endDate" />}
               name="endDate"
-              required
               component={Datepicker}
               parse={parseDate}
             />


### PR DESCRIPTION
## Purpose
Fix validation error with `END DATE` for` Cash drawer reconciliation report` modal

## Approach
We remove  red asterisk next to END DATE
Associated with https://github.com/folio-org/ui-users/pull/1762

## Stories
https://issues.folio.org/browse/UIU-2175