### PR TITLE
UIU-2192: Change text for no open transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update local babel config to handle new JSX transform. Refs UIU-2190.
 * Delete user with check for open transactions. Refs UIU-1971.
 * Prevent fetching resource delUser Refs UIU-2191.
+* Delete user through UI: change dialog text for no open transactions. Refs UIU-2192.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -500,7 +500,7 @@
   "details.label.loanDetails": "Loan details",
   "details.label.loanAnonymized": "Anonymized",
   "details.checkDelete": "Check for open transactions/delete user",
-  "details.checkDelete.confirmation": "Are you sure you want to delete this user <strong>{name}</strong>?",
+  "details.checkDelete.confirmation": "No open transactions for user <strong>{name}</strong>. <p>Are you sure you want to delete this user?</p>",
   "details.openTransactions": "Open transactions",
   "details.openTransactions.info": "User <strong>{name}</strong> has the following open transactions:",
   "details.openTransactions.resolve": "Please resolve the transactions to proceed to delete the user.",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2192

**Current situation:**
Given a staff person selects "check for open transactions/delete user,"
and the user does not have any open transactions
then the pop up currently says: 

"Are you sure you want to delete this user [last name], [first name]?
Yes No"

**This should be changed to:**
"No open transactions for user [last name], [first name].
Are you sure you want to delete this user?
Yes No"