### PR TITLE
UIU-2193: Delete user confirmation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update local babel config to handle new JSX transform. Refs UIU-2190.
 * Delete user with check for open transactions. Refs UIU-1971.
 * Prevent fetching resource delUser Refs UIU-2191.
+* Delete user confirmation message. Refs UIU-2193.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -11,6 +11,7 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 
 import {
   AppIcon,
+  CalloutContext,
   IfPermission,
   IfInterface,
   TitleManager,
@@ -135,6 +136,8 @@ class UserDetail extends React.Component {
     paneWidth: '44%'
   };
 
+  static contextType = CalloutContext;
+
   constructor(props) {
     super(props);
 
@@ -189,16 +192,32 @@ class UserDetail extends React.Component {
   }
 
   handleDeleteUser = (id) => {
-    const { history, location, mutator } = this.props;
-    mutator.delUser.DELETE({ id })
-      .then(() => history.replace(
-        {
-          pathname: '/users',
-          search: `${location.search}`,
-          state: { deletedUserId: id }
-        }
-      ));
-  };
+    const { history, location, mutator, intl } = this.props;
+    const user = this.getUser();
+    const fullNameOfUser = getFullName(user);
+
+    try {
+      mutator.delUser.DELETE({ id })
+        .then(() => history.replace(
+          {
+            pathname: '/users',
+            search: `${location.search}`,
+            state: { deletedUserId: id }
+          }
+        ))
+        .then(() => {
+          this.context.sendCallout({
+            type: 'success',
+            message: intl.formatMessage({ id: 'ui-users.details.deleteUser.success' }, { name: fullNameOfUser }),
+          });
+        });
+    } catch (error) {
+      this.context.sendCallout({
+        type: 'error',
+        message: intl.formatMessage({ id: 'ui-users.details.deleteUser.failed' }, { name: fullNameOfUser }),
+      });
+    }
+  }
 
   checkScope = () => {
     return document.getElementById('ModuleContainer').contains(document.activeElement);

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -501,6 +501,8 @@
   "details.label.loanAnonymized": "Anonymized",
   "details.checkDelete": "Check for open transactions/delete user",
   "details.checkDelete.confirmation": "Are you sure you want to delete this user <strong>{name}</strong>?",
+  "details.deleteUser.success": "User <strong>{name}</strong> deleted successfully.",
+  "details.deleteUser.failed": "User <strong>{name}</strong> could not be deleted.",
   "details.openTransactions": "Open transactions",
   "details.openTransactions.info": "User <strong>{name}</strong> has the following open transactions:",
   "details.openTransactions.resolve": "Please resolve the transactions to proceed to delete the user.",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2193


Given a staff person selects "check for open transactions/delete user,"
the user does not have any open transactions and the staff person confirms to delete the user.

Then the system does delete the user.

**To be added:**
This deletion process should create a confirmation toast message in the lower right corner of the screen:

IF the deletion was successful:
 Green message: "User **[last name], [first name]** deleted successfully."
else
Red message: "User **[last name], [first name]** could not be deleted." OR any other more detailed error message that already be implemented.

