### PR TITLE
UIU-2183: Add resourceShouldRefresh to permissions resource to refresh permissions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Delete user through UI: change dialog text for no open transactions. Refs UIU-2192.
 * Delete user confirmation message. Refs UIU-2193.
 * Comment icon is missing again on Fee/Fine History page. Refs UIU-2185.
+* Add `resourceShouldRefresh` to `permissions` resource to refresh permissions. Fixes UIU-2183.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/routes/UserDetailContainer.js
+++ b/src/routes/UserDetailContainer.js
@@ -3,14 +3,15 @@ import PropTypes from 'prop-types';
 import UserRecordContainer from './UserRecordContainer';
 import { UserDetail, UserDetailFullscreen } from '../views';
 
-export const UserDetailContainer = ({ children, ...rest }) => (
-  <UserRecordContainer {...rest}>
+export const UserDetailContainer = ({ children, match, ...rest }) => (
+  <UserRecordContainer key={`user-record-${match?.params?.id}`} match={match} {...rest}>
     { payload => <UserDetail {...payload} paneWidth="44%">{children}</UserDetail> }
   </UserRecordContainer>
 );
 
 UserDetailContainer.propTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
+  match: PropTypes.object,
 };
 
 export const UserDetailFullscreenContainer = ({ children, ...rest }) => (

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -149,6 +149,7 @@ class UserRecordContainer extends React.Component {
       GET: {
         path: 'perms/users/:{id}/permissions',
         params: { full: 'true', indexField: 'userId' },
+        resourceShouldRefresh: true,
       },
       PUT: {
         path: 'perms/users/%{permUserId}',


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2183

The `key` is required in order to unmount / mount `UserRecordContainer` when switching between users.
The remounting together with `resourceShouldRefresh` will trigger refresh for permissions endpoint.