### PR TITLE
UIU-2208: Shared manual fees/fines not showing up for new fee/fine owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add `resourceShouldRefresh` to `permissions` resource to refresh permissions. Fixes UIU-2183.
 * Add modal for `Financial transactions detail report`. Refs UIU-1960.
 * The `date picker` for report modals is cut off and user is not able select date. Refs UIU-2204.
+* Shared manual fees/fines not showing up for new fee/fine owner. Refs UIU-2208.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -480,7 +480,7 @@ class ChargeFeeFine extends React.Component {
     const servicePointOwnerId = loadServicePoints({ owners: (shared ? owners : list), defaultServicePointId, servicePointsIds });
     const initialOwnerId = ownerId !== '0' ? ownerId : servicePointOwnerId;
     const selectedFeeFine = feefines.find(f => f.id === feeFineTypeId);
-    const currentOwnerFeeFineTypes = feefines.filter(f => f.ownerId === resources.activeRecord.ownerId);
+    const currentOwnerFeeFineTypes = feefines.filter(f => f.ownerId === resources.activeRecord.ownerId || f.ownerId === resources.activeRecord.shared);
     const selectedOwner = owners.find(o => o.id === initialOwnerId);
 
     const initialChargeValues = {


### PR DESCRIPTION
# Description
Shared manual fees/fines not showing up for new fee/fine owner.
Fee/fine types should be populated with the 6 Shared fee/fine types.
# Issue
https://issues.folio.org/browse/UIU-2208
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/125631968-ac91e558-080c-4274-bcb6-fcd768ca02a7.png)
**After**
![image](https://user-images.githubusercontent.com/55694637/125632208-91bcb2d4-9da6-45a6-a6b3-22821b961194.png)
