### PR TITLE
UIU-2214: Omit empty username during user creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Create `Financial transactions detail report`. Refs UIU-1962.
 * Add translations for Custom fields. Refs UIU-2210.
 * Error window when opening or saving user data. Fixes UIU-2212.
+* Omit empty `username` during user creation. Fixes UIU-2214.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -173,6 +173,10 @@ class UserEdit extends React.Component {
     user.personal.email = user.personal.email.trim();
     user.departments = compact(user.departments);
 
+    if (!user.username) {
+      delete user.username;
+    }
+
     mutator.records.POST(user)
       .then(() => {
         this.createRequestPreferences(requestPreferences, user.id);


### PR DESCRIPTION
An empty username is causing an error on the server. This PR removes it from the POST request.

https://issues.folio.org/browse/UIU-2214


