### PR TITLE
UIU-2211: Fix Total owed amount/Total paid amount on Fee/Fine Details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add translations for Custom fields. Refs UIU-2210.
 * Error window when opening or saving user data. Fixes UIU-2212.
 * Omit empty `username` during user creation. Fixes UIU-2214.
+* Fix `Total owed amount`/`Total paid amount` on `Fee/Fine Details`. Refs UIU-2211.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/routes/AccountsListingContainer.js
+++ b/src/routes/AccountsListingContainer.js
@@ -1,49 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+
 import { stripesConnect } from '@folio/stripes/core';
-import { makeQueryFunction } from '@folio/stripes/smart-components';
 import { LoadingView } from '@folio/stripes/components';
 
 import { AccountsListing } from '../views';
-
-const filterConfig = [
-  {
-    label: <FormattedMessage id="ui-users.feefines.ownerLabel" />,
-    name: 'owner',
-    cql: 'feeFineOwner',
-    values: [],
-  }, {
-    label: <FormattedMessage id="ui-users.accounts.history.columns.status" />,
-    name: 'status',
-    cql: 'paymentStatus.name',
-    values: [],
-  }, {
-    label: <FormattedMessage id="ui-users.details.field.feetype" />,
-    name: 'type',
-    cql: 'feeFineType',
-    values: [],
-  }, {
-    label: <FormattedMessage id="ui-users.details.field.type" />,
-    name: 'material',
-    cql: 'materialType',
-    values: [],
-  },
-];
-
-const queryFunction = (findAll, queryTemplate, sortMap, fConfig, failOnCondition, nsParams, a) => {
-  const getCql = makeQueryFunction(findAll, queryTemplate, sortMap, fConfig, failOnCondition, nsParams);
-  return (queryParams, pathComponents, resourceValues, logger) => {
-    let cql = getCql(queryParams, pathComponents, resourceValues, logger);
-    const userId = a[0].value;
-    if (cql === undefined) { cql = `userId==${userId}`; } else { cql = `(${cql}) and (userId==${userId})`; }
-    return cql;
-  };
-};
-
-const args = [
-  { name: 'user', value: 'x' },
-];
+import { MAX_RECORDS } from '../constants';
+import {
+  filterConfig,
+  queryFunction,
+  args,
+} from './feeFineConfig';
 
 class AccountsListingContainer extends React.Component {
   static manifest = Object.freeze({
@@ -79,7 +47,7 @@ class AccountsListingContainer extends React.Component {
       type: 'okapi',
       records: 'accounts',
       recordsRequired: '%{activeRecord.records}',
-      path: 'accounts?query=userId==:{id}&limit=10000',
+      path: `accounts?query=userId==:{id}&limit=${MAX_RECORDS}`,
     },
     loans: {
       type: 'okapi',
@@ -92,7 +60,7 @@ class AccountsListingContainer extends React.Component {
       records: 'accounts',
       path: 'accounts',
       recordsRequired: '%{activeRecord.records}',
-      perRequest: 10000,
+      perRequest: MAX_RECORDS,
       GET: {
         params: {
           query: queryFunction(
@@ -111,7 +79,9 @@ class AccountsListingContainer extends React.Component {
         return refresh || action.meta.path === 'accounts-bulk';
       },
     },
-    activeRecord: { records: 10000 },
+    activeRecord: {
+      records: MAX_RECORDS,
+    },
     user: {},
   });
 

--- a/src/routes/feeFineConfig.js
+++ b/src/routes/feeFineConfig.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import { makeQueryFunction } from '@folio/stripes/smart-components';
+
+export const filterConfig = [
+  {
+    label: <FormattedMessage id="ui-users.feefines.ownerLabel" />,
+    name: 'owner',
+    cql: 'feeFineOwner',
+    values: [],
+  }, {
+    label: <FormattedMessage id="ui-users.accounts.history.columns.status" />,
+    name: 'status',
+    cql: 'paymentStatus.name',
+    values: [],
+  }, {
+    label: <FormattedMessage id="ui-users.details.field.feetype" />,
+    name: 'type',
+    cql: 'feeFineType',
+    values: [],
+  }, {
+    label: <FormattedMessage id="ui-users.details.field.type" />,
+    name: 'material',
+    cql: 'materialType',
+    values: [],
+  },
+];
+
+export const queryFunction = (findAll, queryTemplate, sortMap, fConfig, failOnCondition, nsParams, a) => {
+  const getCql = makeQueryFunction(findAll, queryTemplate, sortMap, fConfig, failOnCondition, nsParams);
+
+  return (queryParams, pathComponents, resourceValues, logger) => {
+    let cql = getCql(queryParams, pathComponents, resourceValues, logger);
+    const userId = a[0].value;
+
+    if (cql === undefined) {
+      cql = `userId==${userId}`;
+    } else {
+      cql = `(${cql}) and (userId==${userId})`;
+    }
+
+    return cql;
+  };
+};
+
+export const args = [
+  { name: 'user', value: 'x' },
+];


### PR DESCRIPTION
## Purpose
Fix `Total owed amount`/`Total paid amount` on `Fee/Fine Details`. Refs UIU-2211.

## Approach
1. File AccountsListingContainer.js 
- Moved reusable part (filterConfig, queryFunction, args) form AccountDetailsContainer.js to  feeFineConfig.js
- Changed hardcode 10000 to MAX_RECORDS 

2. File AccountDetailsContainer.js
- Added feefineshistory and all necessary changes for use it (we add it in the same way that we use it in AccountDetailsContainer.js)
- Changed hardcode 10000 to MAX_RECORDS 

3. File feeFineConfig.js
- Reusable part (filterConfig, queryFunction, args) was moved from AccountsListingContainer.js  without any code changes


4. File AccountDetails.js
- Was added all necessary changes for calculate Total owed amount and Total paid amount
- Calculation for balance was implemented in the similar way that we use in in AccountsListing.js

## Stories
https://issues.folio.org/browse/UIU-2211

## Screenshot

### Before changes
![Total-amount-owed-from-ff-details](https://user-images.githubusercontent.com/24813219/126527034-1466b081-9291-439a-b3dc-e4223bb27d77.jpg)
![Total-amount-owed-from-ff-history](https://user-images.githubusercontent.com/24813219/126527038-8894f53b-2ea6-4be2-b565-f177adf66ade.jpg)

### After changes
![image](https://user-images.githubusercontent.com/24813219/126528294-fdb6ae6a-a933-47ab-83ea-c8c1dc1692a1.png)
![image](https://user-images.githubusercontent.com/24813219/126530299-228fca23-2771-45d8-9544-d83fc41aa057.png)
