### PR TITLE
UIU-2215: Default notice not sent to patron when Transfer done in one of the three ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Omit empty `username` during user creation. Fixes UIU-2214.
 * Fix `Total owed amount`/`Total paid amount` on `Fee/Fine Details`. Refs UIU-2211.
 * Whitespace should not mark loan-action forms dirty. Refs UIU-2227.
+* Default notice not sent to patron when Transfer done in one of the three ways. Refs UIU-2215.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -644,12 +644,10 @@ class Actions extends React.Component {
     const currentFeeFineType = feefines.find(({ id }) => id === account?.feeFineId);
     const currentOwnerId = servicePointOwnerId || currentFeeFineType?.ownerId || account?.ownerId;
     const currentOwner = owners.find(o => o.id === currentOwnerId) || {};
-    const accountTypes = this.props.accounts.map(a => a.feeFineType);
-    const checkSomeNotify = feefines.filter(feeFine => feeFine.actionNoticeId && accountTypes.includes(feeFine.feeFineType));
     const initialValues = {
       ownerId: currentOwnerId,
       amount: calculateSelectedAmount(this.props.accounts),
-      notify: actions.transferMany ? checkSomeNotify.length > 0 : !!(currentFeeFineType?.actionNoticeId || currentOwner?.defaultActionNoticeId),
+      notify: !!(currentFeeFineType?.actionNoticeId || currentOwner?.defaultActionNoticeId),
     };
 
     const modals = [


### PR DESCRIPTION
## Purpose
We should show "Notify patron" in three ways

## Approach
The transfer of a single fee/fine may be executed in three different ways:
1. Using the TRANSFER button in Fee/Fine Details.
2. Using the TRANSFER option in the ellipsis menu in Fees/Fines History.
3. Using the TRANSFER button in Fees/Fines History after putting a check mark in the box for a single fee/fine.

We have inconsistency behavior in case 3.

After discussing this issue with "PO", we should fix this issue as follows:
1. We must have consistent behavior in all 3 cases.
2. We must have the same behavior as we have on "iris"
3. If we will need provide any changes in behavior for "Notify patron" we should provide them in separate story/task.

## Stories
https://issues.folio.org/browse/UIU-2215

## Screenshot

### Before changes
![1](https://user-images.githubusercontent.com/24813219/126624722-e0dccc5a-58a7-4c65-9ee5-d408c04b8c7d.JPG)

### After changes
![2](https://user-images.githubusercontent.com/24813219/126624731-7ae10ade-90ce-4f82-bef4-cee339f2fc49.JPG)