### PR TITLE
UIU-2227 whitespace should not make loan-action forms dirty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Error window when opening or saving user data. Fixes UIU-2212.
 * Omit empty `username` during user creation. Fixes UIU-2214.
 * Fix `Total owed amount`/`Total paid amount` on `Fee/Fine Details`. Refs UIU-2211.
+* Whitespace should not mark loan-action forms dirty. Refs UIU-2227.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/Loans/OpenLoans/components/BulkClaimReturnedModal/BulkClaimReturnedModal.js
+++ b/src/components/Loans/OpenLoans/components/BulkClaimReturnedModal/BulkClaimReturnedModal.js
@@ -122,7 +122,7 @@ class BulkClaimReturnedModal extends React.Component {
   }
 
   handleAdditionalInfoChange = e => {
-    this.setState({ additionalInfo: e.target.value });
+    this.setState({ additionalInfo: e.target.value.trim() });
   };
 
   claimItemReturned = (loan) => {

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -111,7 +111,7 @@ class ModalContent extends React.Component {
   }
 
   handleAdditionalInfoChange = event => {
-    this.setState({ additionalInfo: event.target.value });
+    this.setState({ additionalInfo: event.target.value.trim() });
   };
 
   submit = async () => {


### PR DESCRIPTION
Additional information in loan-action forms is a required field;
whitespace alone should not be acceptable as valid.

Refs [UIU-2227](https://issues.folio.org/browse/UIU-2227)