### PR TITLE
 UIU-2228: Make sure users module builds with babel-plugin-lodash present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Disable renewals for inactive users. Fixes UIU-2229.
 * Fix Export of fees/fines. Refs UIU-2209.
 * `Financial transactions detail report:` date with empty value columns says "Unix Epoch". Refs UIU-2239.
+* Make sure users module builds with `babel-plugin-lodash` present. Fixes UIU-2228.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/util/refundTransferClaimReturned.js
+++ b/src/components/util/refundTransferClaimReturned.js
@@ -207,7 +207,7 @@ refundTransfers = async (loan, props) => {
         data => map(data, (accountsByOwner, idOwner) => {
           return {
             idFeeFineOwner: idOwner,
-            accountsO: accountsByOwner
+            accountsO: accountsByOwner,
           };
         }),
       )(accountsWithTransferredActions);


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2228

`babel-plugin-lodash` currently complains about lodash using chain sequences. 

This PR refactors it to use `flow` instead.

More info:

https://medium.com/bootstart/why-using-chain-is-a-mistake-9bc1f80d51ba

We need this in place in order to finalize work on https://issues.folio.org/browse/STRWEB-20