### PR TITLE
UIU-2229: Disable renewals for inactive users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Whitespace should not mark loan-action forms dirty. Refs UIU-2227.
 * Default notice not sent to patron when Transfer done in one of the three ways. Refs UIU-2215.
 * Hide Department label in User's Detail and Edit views if there are no depts set up in Settings. Refs UIU-2012.
+* Disable renewals for inactive users. Fixes UIU-2229.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -17,6 +17,7 @@ import {
 import {
   getChargeFineToLoanPath,
   getOpenRequestsPath,
+  checkUserActive,
 } from '../../../../util';
 
 import { itemStatuses } from '../../../../../constants';
@@ -33,6 +34,7 @@ class ActionsDropdown extends React.Component {
       params: PropTypes.object
     }),
     intl: PropTypes.object.isRequired,
+    user: PropTypes.object.isRequired,
   };
 
   renderMenu = ({ onToggle }) => {
@@ -44,12 +46,14 @@ class ActionsDropdown extends React.Component {
       stripes,
       disableFeeFineDetails,
       match: { params },
+      user,
     } = this.props;
 
     const itemStatusName = loan?.item?.status?.name;
     const itemDetailsLink = `/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`;
     const loanPolicyLink = `/settings/circulation/loan-policies/${loan.loanPolicyId}`;
     const buttonDisabled = !stripes.hasPerm('ui-users.feesfines.actions.all');
+    const isUserActive = checkUserActive(user);
 
     return (
       <DropdownMenu data-role="menu">
@@ -62,7 +66,7 @@ class ActionsDropdown extends React.Component {
           </Button>
         </IfPermission>
         <IfPermission perm="ui-users.loans.renew">
-          { itemStatusName !== itemStatuses.CLAIMED_RETURNED &&
+          { isUserActive && itemStatusName !== itemStatuses.CLAIMED_RETURNED &&
           <Button
             buttonStyle="dropdownItem"
             data-test-dropdown-content-renew-button

--- a/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
@@ -25,6 +25,7 @@ import {
   hasEveryLoanItemStatus,
   hasAnyLoanItemStatus,
   getRenewalPatronBlocksFromPatronBlocks,
+  checkUserActive,
 } from '../../../../util';
 
 import css from './OpenLoansSubHeader.css';
@@ -52,6 +53,7 @@ class OpenLoansSubHeader extends React.Component {
     openBulkClaimReturnedModal: PropTypes.func.isRequired,
     openPatronBlockedModal: PropTypes.func.isRequired,
     showChangeDueDateDialog: PropTypes.func.isRequired,
+    user: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -137,6 +139,7 @@ class OpenLoansSubHeader extends React.Component {
       patronBlocks,
       openPatronBlockedModal,
       openBulkClaimReturnedModal,
+      user,
     } = this.props;
 
     const {
@@ -151,6 +154,7 @@ class OpenLoansSubHeader extends React.Component {
     const countRenews = getRenewalPatronBlocksFromPatronBlocks(patronBlocks);
     const onlyClaimedReturnedItemsSelected = hasEveryLoanItemStatus(checkedLoans, itemStatuses.CLAIMED_RETURNED);
     const onlyLostyItemsSelected = hasAnyLoanItemStatus(checkedLoans, lostItemStatuses);
+    const isUserActive = checkUserActive(user);
 
     return (
       <ActionsBar
@@ -191,7 +195,7 @@ class OpenLoansSubHeader extends React.Component {
               <Button
                 marginBottom0
                 id="renew-all"
-                disabled={noSelectedLoans || onlyClaimedReturnedItemsSelected}
+                disabled={noSelectedLoans || onlyClaimedReturnedItemsSelected || !isUserActive}
                 onClick={!isEmpty(countRenews)
                   ? openPatronBlockedModal
                   : () => renewSelected()

--- a/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.js
@@ -76,6 +76,7 @@ class OpenLoansWithStaticData extends React.Component {
       handleOptionsChange,
       stripes,
       feeFineCount,
+      user,
     } = this.props;
 
     this.tableData = getListDataFormatter(
@@ -91,6 +92,7 @@ class OpenLoansWithStaticData extends React.Component {
       this.getFeeFine,
       this.getContributorslist,
       feeFineCount,
+      user,
     );
 
     this.sortMap = this.getSortMap();
@@ -246,6 +248,7 @@ class OpenLoansWithStaticData extends React.Component {
         {!isEmpty(loans) &&
         <OpenLoansSubHeader
           loans={loans}
+          user={user}
           patronBlocks={patronBlocks}
           columnMapping={this.columnMapping}
           checkedLoans={checkedLoans}

--- a/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
+++ b/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
@@ -23,6 +23,7 @@ export default function getListDataFormatter(
   getFeeFine,
   getContributorslist,
   feeFineCount,
+  user,
 ) {
   return {
     '  ' : {
@@ -150,6 +151,7 @@ export default function getListDataFormatter(
               itemRequestCount={itemRequestCount}
               disableFeeFineDetails={disableFeeFineDetails}
               handleOptionsChange={handleOptionsChange}
+              user={user}
             />
           </div>
         );

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -145,3 +145,9 @@ export function accountsMatchStatus(accounts, status) {
 export function getValue(value) {
   return value || '';
 }
+
+// Given a user record, test whether the user is active. Checking the `active` property ought to
+// be sufficient, but test the expiration date as well just to be sure.
+export function checkUserActive(user) {
+  return user.active && (new Date(user.expirationDate) >= new Date());
+}

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -1,0 +1,32 @@
+import '../../../test/jest/__mock__';
+import { checkUserActive } from './util';
+
+describe('checkUserActive', () => {
+  it('returns true for active users', () => {
+    const user = {
+      active: true,
+      expirationDate: new Date(),
+    };
+
+    expect(checkUserActive(user)).toBe(true);
+  });
+
+  it('returns false for inactive users', () => {
+    const user = {
+      active: false,
+      expirationDate: new Date(),
+    };
+
+    expect(checkUserActive(user)).toBe(false);
+  });
+
+  it('returns false for expired users', () => {
+    const expDate = new Date();
+    const user = {
+      active: true,
+      expirationDate: expDate.setDate(expDate.getDate() - 1),
+    };
+
+    expect(checkUserActive(user)).toBe(false);
+  });
+});

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -39,6 +39,7 @@ import {
   getOpenRequestsPath,
   getRenewalPatronBlocksFromPatronBlocks,
   accountsMatchStatus,
+  checkUserActive,
 } from '../../components/util';
 import { itemStatuses, loanActions, refundClaimReturned } from '../../constants';
 import {
@@ -438,6 +439,7 @@ class LoanDetails extends React.Component {
       </p>
     );
     const patronBlocksForModal = getRenewalPatronBlocksFromPatronBlocks(patronBlocks);
+    const isUserActive = checkUserActive(user);
 
     return (
       <div data-test-loan-actions-history>
@@ -458,7 +460,7 @@ class LoanDetails extends React.Component {
                 <IfPermission perm="ui-users.loans.renew">
                   <Button
                     data-test-renew-button
-                    disabled={buttonDisabled || isClaimedReturnedItem}
+                    disabled={buttonDisabled || isClaimedReturnedItem || !isUserActive}
                     buttonStyle="primary"
                     onClick={this.renew}
                   >


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2229

When loading the loan detail or loan history views, this checks the user record to see whether the `active` flag is set and the expiration date hasn't expired yet (which is probably redundant).