### PR TITLE
UIU-2239: Handle empty date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Hide Department label in User's Detail and Edit views if there are no depts set up in Settings. Refs UIU-2012.
 * Disable renewals for inactive users. Fixes UIU-2229.
 * Fix Export of fees/fines. Refs UIU-2209.
+* `Financial transactions detail report:` date with empty value columns says "Unix Epoch". Refs UIU-2239.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -25,7 +25,9 @@ export const formatActionDescription = (action) => {
 
 export const formatCurrencyAmount = (amount = 0) => parseFloat(amount).toFixed(2);
 
-export const formatDateAndTime = (date, formatter) => formatter(date, { day: 'numeric', month: 'numeric', year: 'numeric' });
+export const formatDateAndTime = (date, formatter) => {
+  return date ? formatter(date, { day: 'numeric', month: 'numeric', year: 'numeric' }) : '';
+};
 
 export const getServicePointOfCurrentAction = (action, servicePoints = []) => {
   const servicePoint = servicePoints.find(sp => sp.id === action.createdAt);


### PR DESCRIPTION
# Description
`Financial transactions detail report:` date with empty value columns says "Unix Epoch"

# Issue
https://issues.folio.org/browse/UIU-2239
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/127670516-578f1fb0-f5c6-43cb-98fe-25beeac5c1aa.png)

**After**
![image](https://user-images.githubusercontent.com/55694637/127670445-97022bd3-4b07-4440-a2c4-81524334b492.png)
