### PR TITLE
UIU-2224: Show dates in local time when generating CSV reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix Export of fees/fines. Refs UIU-2209.
 * `Financial transactions detail report:` date with empty value columns says "Unix Epoch". Refs UIU-2239.
 * Make sure users module builds with `babel-plugin-lodash` present. Fixes UIU-2228.
+* Show dates in local time when generating CSV reports. Fixes UIU-2224.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -147,10 +147,8 @@ class UserSearch extends React.Component {
     this.resultsPaneTitleRef = createRef();
     this.SRStatusRef = createRef();
 
-    const { formatMessage } = props.intl;
-    this.CsvReport = new CsvReport({
-      formatMessage
-    });
+    const { intl } = props;
+    this.CsvReport = new CsvReport({ intl });
   }
 
   static getDerivedStateFromProps(props) {


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2224

Overdue loans report included dates in UTC rather than local time. This PR is trying to address it and use local time instead.