### PR TITLE
UIU-2217: Fix hyperlink in Financial transactions detail report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Show dates in local time when generating CSV reports. Fixes UIU-2224.
 * Fix user Departments value is not visible in the user view. Fixes UIU-2238.
 * Filter out non existing service points. Fixes UIU-2245.
+* Fix hyperlink in `Financial transactions detail report`. Refs UIU-2217.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/data/reports/FinancialTransactionsReport.js
+++ b/src/components/data/reports/FinancialTransactionsReport.js
@@ -10,6 +10,14 @@ import {
   getValue,
 } from '../../util';
 
+import {
+  getItemBarcodeHyperlink,
+  getLoanPolicyHyperlink,
+  getOverduePolicyHyperlink,
+  getLostItemPolicyHyperlink,
+  getLoanDetailsHyperlink,
+} from './financialTransactionsReportHelpers';
+
 class FinancialTransactionsReport {
   constructor({
     data,
@@ -173,11 +181,11 @@ class FinancialTransactionsReport {
             feeFineDetails: `=HYPERLINK("${origin}/users/${row.patronId}/accounts/view/${row.feeFineId}", "${row.feeFineId}")`,
             patronBarcode: `=HYPERLINK("${origin}/users/preview/${row.patronId}", "${row.patronBarcode}")`,
             patronEmail: `=HYPERLINK("mailto:${row.patronEmail}", "${row.patronEmail}")`,
-            itemBarcode: `=HYPERLINK("${origin}/inventory/view/${row.instanceId}/${row.holdingsRecordId}/${row.itemId}", "${row.itemBarcode}")`,
-            loanPolicy: `=HYPERLINK("${origin}/settings/circulation/loan-policies/${row.loanPolicyId}", "${row.loanPolicyName}")`,
-            overduePolicy: `=HYPERLINK("${origin}/settings/circulation/fine-policies/${row.overdueFinePolicyId}", "${row.overdueFinePolicyName}")`,
-            lostItemPolicy: `=HYPERLINK("${origin}/settings/circulation/lost-item-fee-policy/${row.lostItemPolicyId}", "${row.lostItemPolicyName}")`,
-            loanDetails: `=HYPERLINK("${origin}/users/${row.patronId}/loans/view/${row.loanId}", "${row.loanId}")`,
+            itemBarcode: getItemBarcodeHyperlink(origin, row),
+            loanPolicy: getLoanPolicyHyperlink(origin, row),
+            overduePolicy: getOverduePolicyHyperlink(origin, row),
+            lostItemPolicy: getLostItemPolicyHyperlink(origin, row),
+            loanDetails: getLoanDetailsHyperlink(origin, row),
           };
         } else {
           return row;

--- a/src/components/data/reports/financialTransactionsReportHelpers.js
+++ b/src/components/data/reports/financialTransactionsReportHelpers.js
@@ -1,0 +1,31 @@
+export const EMPTY_HYPERLINK_VALUE = '';
+
+export const getItemBarcodeHyperlink = (origin, row) => (
+  origin && row.instanceId && row.holdingsRecordId && row.itemId && row.itemBarcode
+    ? `=HYPERLINK("${origin}/inventory/view/${row.instanceId}/${row.holdingsRecordId}/${row.itemId}", "${row.itemBarcode}")`
+    : EMPTY_HYPERLINK_VALUE
+);
+
+export const getLoanPolicyHyperlink = (origin, row) => (
+  origin && row.loanPolicyId && row.loanPolicyName
+    ? `=HYPERLINK("${origin}/settings/circulation/loan-policies/${row.loanPolicyId}", "${row.loanPolicyName}")`
+    : EMPTY_HYPERLINK_VALUE
+);
+
+export const getOverduePolicyHyperlink = (origin, row) => (
+  origin && row.overdueFinePolicyId && row.overdueFinePolicyName
+    ? `=HYPERLINK("${origin}/settings/circulation/fine-policies/${row.overdueFinePolicyId}", "${row.overdueFinePolicyName}")`
+    : EMPTY_HYPERLINK_VALUE
+);
+
+export const getLostItemPolicyHyperlink = (origin, row) => (
+  origin && row.lostItemPolicyId && row.lostItemPolicyName
+    ? `=HYPERLINK("${origin}/settings/circulation/lost-item-fee-policy/${row.lostItemPolicyId}", "${row.lostItemPolicyName}")`
+    : EMPTY_HYPERLINK_VALUE
+);
+
+export const getLoanDetailsHyperlink = (origin, row) => (
+  origin && row.patronId && row.loanId
+    ? `=HYPERLINK("${origin}/users/${row.patronId}/loans/view/${row.loanId}", "${row.loanId}")`
+    : EMPTY_HYPERLINK_VALUE
+);

--- a/src/components/data/reports/financialTransactionsReportHelpers.test.js
+++ b/src/components/data/reports/financialTransactionsReportHelpers.test.js
@@ -1,0 +1,178 @@
+import {
+  getItemBarcodeHyperlink,
+  getLoanPolicyHyperlink,
+  getOverduePolicyHyperlink,
+  getLostItemPolicyHyperlink,
+  getLoanDetailsHyperlink,
+  EMPTY_HYPERLINK_VALUE,
+} from './financialTransactionsReportHelpers';
+
+describe('financial transactions report helpers', () => {
+  const origin = 'test';
+  const emptyOrigin = '';
+
+  describe('item barcode hyperlink', () => {
+    const row = {
+      instanceId: 'id',
+      holdingsRecordId: 'holdingsRecordId',
+      itemId: 'itemId',
+      itemBarcode: 'itemBarcode',
+    };
+
+    it('should get hyperlink when all the necessary present', () => {
+      expect(getItemBarcodeHyperlink(origin, row))
+        .toBe('=HYPERLINK("test/inventory/view/id/holdingsRecordId/itemId", "itemBarcode")');
+    });
+
+    it('should get empty hyperlink when absent origin', () => {
+      expect(getItemBarcodeHyperlink(emptyOrigin, row)).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent instanceId', () => {
+      expect(getItemBarcodeHyperlink(origin, {
+        ...row,
+        instanceId: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent holdingsRecordId', () => {
+      expect(getItemBarcodeHyperlink(origin, {
+        ...row,
+        holdingsRecordId: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent itemId', () => {
+      expect(getItemBarcodeHyperlink(origin, {
+        ...row,
+        itemId: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent itemBarcode', () => {
+      expect(getItemBarcodeHyperlink(origin, {
+        ...row,
+        itemBarcode: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+  });
+
+  describe('loan policy hyperlink', () => {
+    const row = {
+      loanPolicyId: 'loanPolicyId',
+      loanPolicyName: 'loanPolicyName',
+    };
+
+    it('should get hyperlink when all the necessary present', () => {
+      expect(getLoanPolicyHyperlink(origin, row))
+        .toBe('=HYPERLINK("test/settings/circulation/loan-policies/loanPolicyId", "loanPolicyName")');
+    });
+
+    it('should get empty hyperlink when absent origin', () => {
+      expect(getLoanPolicyHyperlink(emptyOrigin, row)).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent loanPolicyId', () => {
+      expect(getLoanPolicyHyperlink(origin, {
+        ...row,
+        loanPolicyId: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent loanPolicyName', () => {
+      expect(getLoanPolicyHyperlink(origin, {
+        ...row,
+        loanPolicyName: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+  });
+
+  describe('overdue policy hyperlink', () => {
+    const row = {
+      overdueFinePolicyId: 'overdueFinePolicyId',
+      overdueFinePolicyName: 'overdueFinePolicyName',
+    };
+
+    it('should get hyperlink when all the necessary present', () => {
+      expect(getOverduePolicyHyperlink(origin, row))
+        .toBe('=HYPERLINK("test/settings/circulation/fine-policies/overdueFinePolicyId", "overdueFinePolicyName")');
+    });
+
+    it('should get empty hyperlink when absent origin', () => {
+      expect(getOverduePolicyHyperlink(emptyOrigin, row)).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent overdueFinePolicyId', () => {
+      expect(getOverduePolicyHyperlink(origin, {
+        ...row,
+        overdueFinePolicyId: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent overdueFinePolicyName', () => {
+      expect(getOverduePolicyHyperlink(origin, {
+        ...row,
+        overdueFinePolicyName: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+  });
+
+  describe('lost item policy hyperlink', () => {
+    const row = {
+      lostItemPolicyId: 'lostItemPolicyId',
+      lostItemPolicyName: 'lostItemPolicyName',
+    };
+
+    it('should get hyperlink when all the necessary present', () => {
+      expect(getLostItemPolicyHyperlink(origin, row))
+        .toBe('=HYPERLINK("test/settings/circulation/lost-item-fee-policy/lostItemPolicyId", "lostItemPolicyName")');
+    });
+
+    it('should get empty hyperlink when absent origin', () => {
+      expect(getLostItemPolicyHyperlink(emptyOrigin, row)).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent lostItemPolicyId', () => {
+      expect(getLostItemPolicyHyperlink(origin, {
+        ...row,
+        lostItemPolicyId: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent lostItemPolicyName', () => {
+      expect(getLostItemPolicyHyperlink(origin, {
+        ...row,
+        lostItemPolicyName: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+  });
+
+  describe('loan details hyperlink', () => {
+    const row = {
+      patronId: 'patronId',
+      loanId: 'loanId',
+    };
+
+    it('should get hyperlink when all the necessary present', () => {
+      expect(getLoanDetailsHyperlink(origin, row)).toBe('=HYPERLINK("test/users/patronId/loans/view/loanId", "loanId")');
+    });
+
+    it('should get empty hyperlink when absent origin', () => {
+      expect(getLoanDetailsHyperlink(emptyOrigin, row)).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent patronId', () => {
+      expect(getLoanDetailsHyperlink(origin, {
+        ...row,
+        patronId: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent loanId', () => {
+      expect(getLoanDetailsHyperlink(origin, {
+        ...row,
+        loanId: '',
+      })).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Fix hyperlink in Financial transactions detail report

## Approach
We should not render hyperlink for "Item Barcode", "Loan Policy", "Overdue Policy", "Lost Item Policy", "Loan Details" when we don't have all necessary data.

## Stories
https://issues.folio.org/browse/UIU-2217