### PR TITLE
UIU-2242: Fix hyperlink with missing `Patron barcode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix user Departments value is not visible in the user view. Fixes UIU-2238.
 * Filter out non existing service points. Fixes UIU-2245.
 * Fix hyperlink in `Financial transactions detail report`. Refs UIU-2217.
+* Fix hyperlink with missing `Patron barcode`. Refs UIU-2242.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/data/reports/FinancialTransactionsReport.js
+++ b/src/components/data/reports/FinancialTransactionsReport.js
@@ -11,6 +11,7 @@ import {
 } from '../../util';
 
 import {
+  getPatronBarcodeHyperlink,
   getItemBarcodeHyperlink,
   getLoanPolicyHyperlink,
   getOverduePolicyHyperlink,
@@ -179,7 +180,7 @@ class FinancialTransactionsReport {
           return {
             ...row,
             feeFineDetails: `=HYPERLINK("${origin}/users/${row.patronId}/accounts/view/${row.feeFineId}", "${row.feeFineId}")`,
-            patronBarcode: `=HYPERLINK("${origin}/users/preview/${row.patronId}", "${row.patronBarcode}")`,
+            patronBarcode: getPatronBarcodeHyperlink(origin, row, this.formatMessage({ id: 'ui-users.reports.financial.patronBarcode.noBarcode' })),
             patronEmail: `=HYPERLINK("mailto:${row.patronEmail}", "${row.patronEmail}")`,
             itemBarcode: getItemBarcodeHyperlink(origin, row),
             loanPolicy: getLoanPolicyHyperlink(origin, row),

--- a/src/components/data/reports/financialTransactionsReportHelpers.js
+++ b/src/components/data/reports/financialTransactionsReportHelpers.js
@@ -1,5 +1,13 @@
 export const EMPTY_HYPERLINK_VALUE = '';
 
+export const getPatronBarcodeHyperlink = (origin, row, noBarcode) => {
+  const patronBarcodeLabel = row.patronBarcode || noBarcode;
+
+  return origin && row.patronId
+    ? `=HYPERLINK("${origin}/users/preview/${row.patronId}", "${patronBarcodeLabel}")`
+    : EMPTY_HYPERLINK_VALUE;
+};
+
 export const getItemBarcodeHyperlink = (origin, row) => (
   origin && row.instanceId && row.holdingsRecordId && row.itemId && row.itemBarcode
     ? `=HYPERLINK("${origin}/inventory/view/${row.instanceId}/${row.holdingsRecordId}/${row.itemId}", "${row.itemBarcode}")`

--- a/src/components/data/reports/financialTransactionsReportHelpers.test.js
+++ b/src/components/data/reports/financialTransactionsReportHelpers.test.js
@@ -1,4 +1,5 @@
 import {
+  getPatronBarcodeHyperlink,
   getItemBarcodeHyperlink,
   getLoanPolicyHyperlink,
   getOverduePolicyHyperlink,
@@ -10,6 +11,39 @@ import {
 describe('financial transactions report helpers', () => {
   const origin = 'test';
   const emptyOrigin = '';
+
+  describe('patron barcode hyperlink', () => {
+    const emptyBarcodeValue = 'emptyBarcodeValue';
+    const row = {
+      patronId: 'patronId',
+      patronBarcode: 'patronBarcode',
+    };
+
+    it('should get hyperlink when all the necessary present', () => {
+      expect(getPatronBarcodeHyperlink(origin, row, emptyBarcodeValue))
+        .toBe('=HYPERLINK("test/users/preview/patronId", "patronBarcode")');
+    });
+
+    it('should get empty hyperlink when absent origin', () => {
+      expect(getPatronBarcodeHyperlink(emptyOrigin, row, emptyBarcodeValue)).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get empty hyperlink when absent patronId', () => {
+      expect(getPatronBarcodeHyperlink(origin, {
+        ...row,
+        patronId: '',
+      },
+      emptyBarcodeValue)).toBe(EMPTY_HYPERLINK_VALUE);
+    });
+
+    it('should get hyperlink with noBarcode value when absent patronBarcode', () => {
+      expect(getPatronBarcodeHyperlink(origin, {
+        ...row,
+        patronBarcode: '',
+      },
+      emptyBarcodeValue)).toBe(`=HYPERLINK("test/users/preview/patronId", "${emptyBarcodeValue}")`);
+    });
+  });
 
   describe('item barcode hyperlink', () => {
     const row = {

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -860,6 +860,7 @@
   "reports.financial.transferAccount": "Transfer account",
   "reports.financial.patronName": "Patron name",
   "reports.financial.patronBarcode": "Patron barcode",
+  "reports.financial.patronBarcode.noBarcode": "[no barcode]",
   "reports.financial.patronGroup": "Patron group",
   "reports.financial.patronEmail": "Patron email address",
   "reports.financial.instance": "Instance",


### PR DESCRIPTION
## Purpose
Fix hyperlink with missing `Patron barcode`

## Approach
We should not render hyperlink for `Patron barcode` when we don't have all necessary data.
We should render `Patron barcode` hyperlink with `no barcode` label when Patron don't have barcode.

## Stories
https://issues.folio.org/browse/UIU-2242