### PR TITLE
UIU-2248: Support `feesfines` interface version `17.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fix hyperlink in `Financial transactions detail report`. Refs UIU-2217.
 * Fix hyperlink with missing `Patron barcode`. Refs UIU-2242.
 * Fix `Invalid date` for `Financial transaction detail report`. Refs UIU-2251.
+* Support `feesfines` interface version `17.0`. Refs UIU-2248.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "optionalOkapiInterfaces": {
       "automated-patron-blocks": "0.1",
       "circulation": "9.0 10.0 11.0",
-      "feesfines": "16.1",
+      "feesfines": "16.1 17.0",
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0 7.0",
       "notes": "2.0",


### PR DESCRIPTION
## Do not merge

## Purpose
Support `feesfines` interface version `17.0`

## Approach
We should merge all associated task with https://issues.folio.org/browse/MODFEE-98 in the same time. In scope of https://issues.folio.org/browse/MODFEE-98 was added the standard UUID regular expression pattern to all the id fields in the Fees/Fines module JSON schemas. All changes was tested in scope https://issues.folio.org/browse/MODFEE-197.

## Refs
https://issues.folio.org/browse/UIU-2248

#### TODOS and Open Questions
@zburke @mkuklis  Could you please clarify do we need to add someone else for review this task?