### PR TITLE
UIU-2244: Update sub permissions in ui-users.edituserservicepoints perrmission set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Fix hyperlink with missing `Patron barcode`. Refs UIU-2242.
 * Fix `Invalid date` for `Financial transaction detail report`. Refs UIU-2251.
 * Support `feesfines` interface version `17.0`. Refs UIU-2248.
+* Update sub permissions in `ui-users.edituserservicepoints` permission set. Fixes UIU-2244.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/package.json
+++ b/package.json
@@ -169,7 +169,9 @@
           "ui-users.edit",
           "ui-users.viewuserservicepoints",
           "inventory-storage.service-points-users.item.post",
-          "inventory-storage.service-points-users.item.put"
+          "inventory-storage.service-points-users.item.put",
+          "circulation-storage.request-preferences.item.post",
+          "circulation-storage.request-preferences.item.put"
         ],
         "visible": true
       },


### PR DESCRIPTION
Permissions  `circulation-storage.request-preferences.item.post` and `circulation-storage.request-preferences.item.put` were missing in `ui-users.edituserservicepoints` permission set.

https://issues.folio.org/browse/UIU-2244