### PR TITLE
FOLIO-3279 correctly configure npm registry

### DIFF
--- a/.github/workflows/buildnpm.yml
+++ b/.github/workflows/buildnpm.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Set _auth in .npmrc
         if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
-        run: npm config set @folio:registry https://repository.folio.org/repository/npm-folioci-test/ &&  npm config set _auth ${{ env.NODE_AUTH_TOKEN }}
+        run: npm config set @folio:registry ${{ env.FOLIO_NPM_REGISTRY }} &&  npm config set _auth ${{ env.NODE_AUTH_TOKEN }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -188,4 +188,3 @@ jobs:
           data: ${{ steps.moduleDescriptor.outputs.content }}
           username: ${{ secrets.FOLIO_REGISTRY_USERNAME }}
           password: ${{ secrets.FOLIO_REGISTRY_PASSWORD }}
-


### PR DESCRIPTION
It appears a test-value was left in place, leading build artifacts to be
published in the wrong places.

Refs [FOLIO-3279](https://issues.folio.org/browse/FOLIO-3279)