### PR TITLE
UIU-2434 array validation must handle null input

### DIFF
--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -145,16 +145,16 @@ export function calculateSortParams({
 
 // Return true if every item in loans has the status itemStatus
 export function hasEveryLoanItemStatus(loans, itemStatus) {
-  return loans.every(loan => loan?.item?.status?.name === itemStatus);
+  return !!loans && loans.every(loan => loan?.item?.status?.name === itemStatus);
 }
 
 // Return true if every item in loans has one of the statuses in the itemStatuses array
 export function hasAnyLoanItemStatus(loans, itemStatuses) {
-  return loans.every(loan => itemStatuses.includes(loan?.item?.status?.name));
+  return !!loans && loans.every(loan => itemStatuses.includes(loan?.item?.status?.name));
 }
 
 export function accountsMatchStatus(accounts, status) {
-  return accounts.every((account) => account.status.name.toLowerCase() === status.toLowerCase());
+  return !!accounts && accounts.every((account) => account.status.name.toLowerCase() === status.toLowerCase());
 }
 
 export function getValue(value) {

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -30,6 +30,11 @@ describe('accountsMatchStatus', () => {
 
     expect(accountsMatchStatus(accounts, status)).toBe(false);
   });
+
+  it('returns false if accounts array is empty', () => {
+    const status = 'monkey';
+    expect(accountsMatchStatus(null, status)).toBe(false);
+  });
 });
 
 describe('checkUserActive', () => {
@@ -206,6 +211,11 @@ describe('hasAnyLoanItemStatus', () => {
 
     expect(hasAnyLoanItemStatus(loans, statuses)).toBe(false);
   });
+
+  it('returns false if loans array is empty', () => {
+    const statuses = ['monkey', 'bagel'];
+    expect(hasAnyLoanItemStatus(null, statuses)).toBe(false);
+  });
 });
 
 describe('hasEveryLoanItemStatus', () => {
@@ -225,6 +235,13 @@ describe('hasEveryLoanItemStatus', () => {
       { id: '1234', item: { status: { name: status } } },
       { id: 'abcd', item: { status: { name: 'bagel' } } },
     ];
+
+    expect(hasEveryLoanItemStatus(loans, status)).toBe(false);
+  });
+
+  it('returns false if loans array is empty', () => {
+    const status = 'monkey';
+    const loans = null;
 
     expect(hasEveryLoanItemStatus(loans, status)).toBe(false);
   });


### PR DESCRIPTION
Array validation functions must handle null input, not just empty array
input. Sloppy, @zburke, sloppy 😠 

Refs [UIU-2434](https://issues.folio.org/browse/UIU-2434)