### PR TITLE
UIU-2411: Automatic fees/fines are appearing in New Fee/Fine "Fee/fine type" drop-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Support `feesfines` interface version `17.0`. Refs UIU-2248.
 * Update sub permissions in `ui-users.edituserservicepoints` permission set. Fixes UIU-2244.
 * Replace `babel-eslint` with `@babel/eslint-parser`; import global babel config. Refs UIU-2253, UIU-2254.
+* Automatic fees/fines are appearing in New Fee/Fine `Fee/fine type` drop-down. Refs UIU-2411.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -182,10 +182,12 @@ class ChargeForm extends React.Component {
     });
 
     feeFineTypeOptions.forEach((feefineItem) => {
-      const fee = {};
-      fee.label = feefineItem.feeFineType;
-      fee.value = feefineItem.id;
-      feefineList.push(fee);
+      if (!feefineItem.automatic) {
+        const fee = {};
+        fee.label = feefineItem.feeFineType;
+        fee.value = feefineItem.id;
+        feefineList.push(fee);
+      }
     });
 
     let showNotify = false;

--- a/test/bigtest/tests/charge-fee-fine-test.js
+++ b/test/bigtest/tests/charge-fee-fine-test.js
@@ -31,6 +31,12 @@ describe('Charge fee/fine', () => {
         { feeFineType: 'testFineType',
           ownerId: owner.id,
           defaultAmount: 500.00 });
+      this.server.create('feefine', {
+        feeFineType: 'automaticFineType',
+        automatic: true,
+        ownerId: owner.id,
+        defaultAmount: 10.00
+      });
       loan = this.server.create('loan', { status: { name: 'Open' } });
       visit(`/users/preview/${loan.userId}`);
       await userDetail.whenLoaded();
@@ -48,6 +54,10 @@ describe('Charge fee/fine', () => {
 
       it('displays the "Charge fee fine" form', () => {
         expect(chargeForm.form.isPresent).to.be.true;
+      });
+
+      it('should show only manual fee.fine types', () => {
+        expect(chargeForm.typeSelect.optionCount).to.equal(1);
       });
 
       describe('cancel the charge', () => {


### PR DESCRIPTION
# Description
There are now  is displaying the automated fee/fine types when you create a new fee/fine.  But we cannot have users creating manual fees/fines using the automated fee/fine types. So let's check if `fee/fine type` is automatic when we form `feefineList`.
# Issue
https://issues.folio.org/browse/UIU-2411
# Screenshots
**Before**
![image](https://user-images.githubusercontent.com/55694637/132342844-b6c9e47e-7fe1-4a98-8c24-f7a82917ea27.png)
**After**
![image](https://user-images.githubusercontent.com/55694637/132343056-106e3d62-65a2-4000-a62f-9f166ddcce75.png)
