### PR TITLE
UIU-2247: Remove unused permission set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Update sub permissions in `ui-users.edituserservicepoints` permission set. Fixes UIU-2244.
 * Replace `babel-eslint` with `@babel/eslint-parser`; import global babel config. Refs UIU-2253, UIU-2254.
 * Automatic fees/fines are appearing in New Fee/Fine `Fee/fine type` drop-down. Refs UIU-2411.
+* Remove unused permission set. Fixes UIU-2247.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/package.json
+++ b/package.json
@@ -706,19 +706,6 @@
         "visible": true
       },
       {
-        "permissionName": "ui-users.settings.profilePictures",
-        "displayName": "Settings (Users): Can create, edit and remove permission sets",
-        "description": "",
-        "subPermissions": [
-          "settings.users.enabled",
-          "configuration.entries.collection.get",
-          "configuration.entries.item.get",
-          "configuration.entries.item.post",
-          "configuration.entries.item.put"
-        ],
-        "visible": true
-      },
-      {
         "permissionName": "ui-users.settings.departments.view",
         "displayName": "Settings (Users): View departments",
         "subPermissions": [


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2247

Permission set `ui-users.settings.profilePictures` is not used anymore (it also had a wrong `displayName` which was confusing).