### PR TITLE
UIU-2244: Move resourceShouldRefresh under correct place

### DIFF
--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -141,6 +141,7 @@ class UserRecordContainer extends React.Component {
       type: 'okapi',
       records: 'permissionNames',
       throwErrors: false,
+      resourceShouldRefresh: true,
       DELETE: {
         pk: 'permissionName',
         path: 'perms/users/:{id}/permissions',
@@ -149,7 +150,6 @@ class UserRecordContainer extends React.Component {
       GET: {
         path: 'perms/users/:{id}/permissions',
         params: { full: 'true', indexField: 'userId' },
-        resourceShouldRefresh: true,
       },
       PUT: {
         path: 'perms/users/%{permUserId}',


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2244

The refresh was still not happening because `resourceShouldRefresh` was defined under wrong place. 
stripes-connect checks it only on the top level of each resource:

https://github.com/folio-org/stripes-connect/blob/master/RESTResource/RESTResource.js#L522

