### PR TITLE
UIU-2244: Move permissions under correct perm set

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,9 @@
           "users.item.put",
           "login.item.put",
           "tags.collection.get",
-          "tags.item.post"
+          "tags.item.post",
+          "circulation-storage.request-preferences.item.post",
+          "circulation-storage.request-preferences.item.put"
         ],
         "visible": true
       },
@@ -170,8 +172,6 @@
           "ui-users.viewuserservicepoints",
           "inventory-storage.service-points-users.item.post",
           "inventory-storage.service-points-users.item.put",
-          "circulation-storage.request-preferences.item.post",
-          "circulation-storage.request-preferences.item.put"
         ],
         "visible": true
       },

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
           "ui-users.edit",
           "ui-users.viewuserservicepoints",
           "inventory-storage.service-points-users.item.post",
-          "inventory-storage.service-points-users.item.put",
+          "inventory-storage.service-points-users.item.put"
         ],
         "visible": true
       },


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2244

This PR moves permissions
 
````
circulation-storage.request-preferences.item.post 
circulation-storage.request-preferences.item.put 
````

under correct permission set `ui-users.edit` based on the feedback from Brooks Travis.