### PR TITLE
UIU-2434 restore lodash implementation of collection.every

### DIFF
--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import { every } from 'lodash';
 
 import {
   requestStatuses,
@@ -145,16 +146,16 @@ export function calculateSortParams({
 
 // Return true if every item in loans has the status itemStatus
 export function hasEveryLoanItemStatus(loans, itemStatus) {
-  return !!loans && loans.every(loan => loan?.item?.status?.name === itemStatus);
+  return every(loans, (loan) => loan?.item?.status?.name === itemStatus);
 }
 
 // Return true if every item in loans has one of the statuses in the itemStatuses array
 export function hasAnyLoanItemStatus(loans, itemStatuses) {
-  return !!loans && loans.every(loan => itemStatuses.includes(loan?.item?.status?.name));
+  return every(loans, (loan) => itemStatuses.includes(loan?.item?.status?.name));
 }
 
 export function accountsMatchStatus(accounts, status) {
-  return !!accounts && accounts.every((account) => account.status.name.toLowerCase() === status.toLowerCase());
+  return every(accounts, (account) => account.status.name.toLowerCase() === status.toLowerCase());
 }
 
 export function getValue(value) {

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -31,9 +31,9 @@ describe('accountsMatchStatus', () => {
     expect(accountsMatchStatus(accounts, status)).toBe(false);
   });
 
-  it('returns false if accounts array is empty', () => {
+  it('returns true if accounts array is empty (vacuous truth)', () => {
     const status = 'monkey';
-    expect(accountsMatchStatus(null, status)).toBe(false);
+    expect(accountsMatchStatus(null, status)).toBe(true);
   });
 });
 
@@ -212,9 +212,9 @@ describe('hasAnyLoanItemStatus', () => {
     expect(hasAnyLoanItemStatus(loans, statuses)).toBe(false);
   });
 
-  it('returns false if loans array is empty', () => {
+  it('returns true if loans array is empty (vacuous truth)', () => {
     const statuses = ['monkey', 'bagel'];
-    expect(hasAnyLoanItemStatus(null, statuses)).toBe(false);
+    expect(hasAnyLoanItemStatus(null, statuses)).toBe(true);
   });
 });
 
@@ -239,10 +239,10 @@ describe('hasEveryLoanItemStatus', () => {
     expect(hasEveryLoanItemStatus(loans, status)).toBe(false);
   });
 
-  it('returns false if loans array is empty', () => {
+  it('returns true if loans array is empty (vacuous truth)', () => {
     const status = 'monkey';
     const loans = null;
 
-    expect(hasEveryLoanItemStatus(loans, status)).toBe(false);
+    expect(hasEveryLoanItemStatus(loans, status)).toBe(true);
   });
 });


### PR DESCRIPTION
lodash's `every` implementation handles any of its collection types,
including objects (which iterate their values), not just arrays.
Restoring the more flexible lodash implementation, rather than writing
an increasingly complex vanilla JS implementation, seems like the right
approach here.

Refs [UIU-2434](https://issues.folio.org/browse/UIU-2434)