### PR TITLE
UIU-2435 don't choke when editing minimal user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Replace `babel-eslint` with `@babel/eslint-parser`; import global babel config. Refs UIU-2253, UIU-2254.
 * Automatic fees/fines are appearing in New Fee/Fine `Fee/fine type` drop-down. Refs UIU-2411.
 * Remove unused permission set. Fixes UIU-2247.
+* Don't choke when editing minimal user object. Fixes UIU-2435.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -272,7 +272,7 @@ class EditUserInfo extends React.Component {
                 disabled={isStatusFieldDisabled()}
                 dataOptions={statusOptions}
                 defaultValue={initialValues.active}
-                format={v => v ? v.toString() : "false"}
+                format={(v) => (v ? v.toString() : 'false')}
                 aria-required="true"
                 required
               />

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -272,7 +272,7 @@ class EditUserInfo extends React.Component {
                 disabled={isStatusFieldDisabled()}
                 dataOptions={statusOptions}
                 defaultValue={initialValues.active}
-                format={v => v.toString()}
+                format={v => v ? v.toString() : "false"}
                 aria-required="true"
                 required
               />


### PR DESCRIPTION
It's possible to create a minimal user object at the `/users` endpoint,
e.g. a POST request with a username field and nothing else, but editing
such a record in the UI fails because fields the UI requires (though the
backend does not) are missing.

## Approach 

Provide default value (`"false"`) for the `active` field when it is
missing.

Refs [UIU-2435](https://issues.folio.org/browse/UIU-2435)