### PR TITLE
use correct path for compiled translation output

### DIFF
--- a/package.json
+++ b/package.json
@@ -816,7 +816,7 @@
     "test:bigtest": "stripes test karma",
     "test:jest": "jest",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-users ./translations/users/compiled"
+    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-users ./translations/ui-users/compiled"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
There was a typo in the compiled translation path. h/t
@aditya-matukumalli