### PR TITLE
UIU-1763: fix issue when `Patron groups` and `Limits` have diferent name formating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Automatic fees/fines are appearing in New Fee/Fine `Fee/fine type` drop-down. Refs UIU-2411.
 * Remove unused permission set. Fixes UIU-2247.
 * Don't choke when editing minimal user object. Fixes UIU-2435.
+* Patron groups displayed as Patron block LIMITS are not in same 'case' as actual Patron groups. Fixes UIU-1763.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/settings/LimitsSettings.js
+++ b/src/settings/LimitsSettings.js
@@ -6,7 +6,6 @@ import {
 } from 'react-intl';
 import {
   isEmpty,
-  capitalize,
 } from 'lodash';
 
 import {
@@ -101,13 +100,12 @@ class LimitsSettings extends Component {
         id,
         group: patronGroup,
       } = group;
-      const capitilizedPatronGroup = capitalize(patronGroup);
       const renderLimits = () => {
         return (
           <Limits
             key={id}
             patronGroupId={id}
-            patronGroup={capitilizedPatronGroup}
+            patronGroup={patronGroup}
             patronBlockConditions={this.getPatronBlockConditions()}
             patronBlockLimits={this.getPatronBlockLimits()}
           />
@@ -116,7 +114,7 @@ class LimitsSettings extends Component {
 
       routes.push({
         route: id,
-        label: capitilizedPatronGroup,
+        label: patronGroup,
         component: renderLimits,
       });
     });


### PR DESCRIPTION
## Purpose
Keep existing formating of "Patron groups" names on "Limits" tab.

## Refs
https://issues.folio.org/browse/UIU-1763

## Screenshots
Name of created "Patrong group":
![image](https://user-images.githubusercontent.com/88130496/133034686-2639691c-817a-4129-8bf5-2b815ce9a445.png)

Before:
![image](https://user-images.githubusercontent.com/88130496/133034371-b47e18f5-5144-495c-a8d4-208674b29e90.png)

After:
![image](https://user-images.githubusercontent.com/88130496/133034442-690944a9-d22f-4139-8180-ef5064020154.png)