### PR TITLE
UIU-2203: Add Contributors field to account request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Don't choke when editing minimal user object. Fixes UIU-2435.
 * Patron groups displayed as Patron block LIMITS are not in same 'case' as actual Patron groups. Fixes UIU-1763.
 * Change setting "Patron block templates" to "Templates". Refs UIU-2412.
+* Add Contributors field to account request. Refs UIU-2203.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -133,6 +133,7 @@ class ChargeFeeFine extends React.Component {
     type.materialType = (item.materialType || {}).name;
     type.materialTypeId = (selectedLoan.id) ? undefined : (item.materialType || {}).id || undefined;
 
+    if (item.contributorNames) { type.contributors = item.contributorNames; }
     if (selectedLoan.dueDate) type.dueDate = selectedLoan.dueDate;
     if (selectedLoan.returnDate) type.returnedDate = selectedLoan.returnDate;
     type.id = uuid();

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -168,3 +168,9 @@ export function checkUserActive(user) {
   if (user.expirationDate == null || user.expirationDate === undefined) return user.active;
   return user.active && (new Date(user.expirationDate) >= new Date());
 }
+
+export const getContributors = (account, instance) => {
+  const contributors = account?.contributors || instance?.contributors;
+
+  return contributors && contributors.map(({ name }) => name.split(',').reverse().join(', '));
+};

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -8,6 +8,7 @@ import {
   getFullName,
   hasAnyLoanItemStatus,
   hasEveryLoanItemStatus,
+  getContributors,
 } from './util';
 
 describe('accountsMatchStatus', () => {
@@ -244,5 +245,33 @@ describe('hasEveryLoanItemStatus', () => {
     const loans = null;
 
     expect(hasEveryLoanItemStatus(loans, status)).toBe(true);
+  });
+});
+
+describe('getContributors', () => {
+  it('should return undefined if nothing is passed', () => {
+    expect(getContributors()).toBe();
+  });
+
+  it('should return contributors from `account` if it passed', () => {
+    const mockedAccount = {
+      contributors: [{ name: 'Bond,James' }, { name: 'Doe,John' }],
+    };
+    const mockedInstance = {
+      contributors: [{ name: 'test' }],
+    };
+    const expectedResult = ['James, Bond', 'John, Doe'];
+
+    expect(getContributors(mockedAccount, mockedInstance)).toEqual(expectedResult);
+  });
+
+  it('should return contributors from `instance` if `account` have no contributors', () => {
+    const mockedAccount = {};
+    const mockedInstance = {
+      contributors: [{ name: 'Bond,James' }, { name: 'Doe,John' }],
+    };
+    const expectedResult = ['James, Bond', 'John, Doe'];
+
+    expect(getContributors(mockedAccount, mockedInstance)).toEqual(expectedResult);
   });
 });

--- a/src/routes/AccountDetailsContainer.js
+++ b/src/routes/AccountDetailsContainer.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   first,
-  isEmpty,
 } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
@@ -17,6 +16,7 @@ import {
   queryFunction,
   args,
 } from './feeFineConfig';
+import { getContributors } from '../components/util';
 
 class AccountDetailsContainer extends React.Component {
   static manifest = Object.freeze({
@@ -209,9 +209,7 @@ class AccountDetailsContainer extends React.Component {
       ? first(resources?.instance?.records)
       : [];
     const loanRecords = resources?.loans?.records ?? [];
-    const contributors = !isEmpty(instance)
-      ? instance.contributors.map(({ name }) => name.split(',').reverse().join(', '))
-      : [];
+    const contributors = getContributors(account, instance);
     const loanId = account?.loanId;
 
     if (loanId === '0') return { contributors };

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -398,7 +398,7 @@ class AccountDetails extends React.Component {
     const overdueFinePolicyName = itemDetails?.overdueFinePolicyName;
     const lostItemPolicyId = itemDetails?.lostItemPolicyId;
     const lostItemPolicyName = itemDetails?.lostItemPolicyName;
-    const contributors = itemDetails?.contributors.join(', ');
+    const contributors = itemDetails?.contributors?.join('; ');
 
     const totalPaidAmount = calculateTotalPaymentAmount(resources?.feefineshistory?.records, feeFineActions);
     const refundAllowed = isRefundAllowed(account, feeFineActions);


### PR DESCRIPTION
## Purpose

We should additionaly send `contributors` filed when we create fee/fine record.
We should also display contributors from fee/fine record.

## Approach

When we display `contributors` on fee/fine details page, we should in first order display contributors from fee/fine record. If there are no contributors in fee/fine record, we should display them from instance record. If contributors absent at all, we should display '`-`'.
This approach was discussed here https://issues.folio.org/browse/UIU-2092?focusedCommentId=111003&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-111003

Function `getContributors` was extracted in `util` to be able to test it..
Initialy it was in `AccountDetailsContainer`. But when I try to export it and test it separately, I am faced with the inability to run the tests. The tests did not run due to something wrong with smart-components mock i think, but they are not even used in my function. But smart-components used somwhere in inside imports in `AccountDetailsContainer` component. Extracting my function into `util` was the easiest way. 

## Refs
https://issues.folio.org/browse/UIU-2203

## Screenshots

POST request before:
![image](https://user-images.githubusercontent.com/88130496/133392220-75facb0d-9bc8-443a-954c-a0f773df5487.png)

POST request after:
![image](https://user-images.githubusercontent.com/88130496/133391930-ae7058ac-afaa-4aaf-9c6e-542a7fd061d7.png)
