### PR TITLE
UIU-2205 Suspended fees/fines total counts incorrect on User Details

### DIFF
--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -74,7 +74,7 @@ const UserAccounts = ({
     const openTotal = open.reduce((acc, { remaining }) => (acc + parseFloat(remaining)), 0) - claimTotal;
 
     setTotals({
-      openAccountsCount: open.length,
+      openAccountsCount: open.length - claim.length,
       closedAccountsCount: closed.length,
       claimAccountsCount: claim.length,
       refundedAccountsCount: refunded.length,


### PR DESCRIPTION
# Story:
https://issues.folio.org/browse/UIU-2205

Fix of: Suspended fees/fines total counts incorrect on User Details


# Result:
6 items to age lost and be billed 125.00 in fees (100.00 set cost Lost Item Fee and a 25.00 Lost Item Processing Fee). that is, 12 fines are generated.

<img width="589" alt="Step 8" src="https://user-images.githubusercontent.com/7461514/133337418-b15063f9-be4d-4c11-a616-6b27b295aa58.png">

## After 3 items are marked as "Claimed returned."

<img width="589" alt="Step 8" src="https://user-images.githubusercontent.com/7461514/133336658-f0ea7edc-57b3-427b-9f9e-4cb615488ca2.png">


## The remaining 3 items are marked as "Claimed returned".

<img width="586" alt="Step 11" src="https://user-images.githubusercontent.com/7461514/133337301-f5e5f1f3-6650-4e60-8137-cd97bdcffd3a.png">
