### PR TITLE
UIU-2438: fix `refund` button issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Add Contributors field to account request. Refs UIU-2203.
 * Increment stripes to v7. Refs UIU-2250.
 * Create Jest/RTL test for BulkRenewedLoansList. Refs UIU-2259.
+* Fix issue when `refund` button became inactive before the user was returned entire amount of money. Refs UIU-2438.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -17,10 +17,12 @@ import CommentModal from './CommentModal';
 import WarningModal from './WarningModal';
 import ActionModal from './ActionModal';
 import { MAX_RECORDS } from '../../../constants';
-import { getFullName } from '../../util';
+import {
+  getFullName,
+  isRefundAllowed,
+} from '../../util';
 import {
   calculateSelectedAmount,
-  isRefundAllowed,
   loadServicePoints,
 } from '../accountFunctions';
 

--- a/src/components/Accounts/Actions/WarningModal.js
+++ b/src/components/Accounts/Actions/WarningModal.js
@@ -19,8 +19,10 @@ import {
   size,
 } from 'lodash';
 
-import { calculateSortParams } from '../../util';
-import { isRefundAllowed } from '../accountFunctions';
+import {
+  calculateSortParams,
+  isRefundAllowed,
+} from '../../util';
 
 import css from './modal.css';
 

--- a/src/components/Accounts/Menu.js
+++ b/src/components/Accounts/Menu.js
@@ -9,8 +9,10 @@ import {
 } from '@folio/stripes/components';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
-import { getFullName } from '../util';
-import { isRefundAllowed } from './accountFunctions';
+import {
+  getFullName,
+  isRefundAllowed,
+} from '../util';
 
 import { refundClaimReturned } from '../../constants';
 

--- a/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
+++ b/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
@@ -23,9 +23,9 @@ import { itemStatuses } from '../../../constants';
 import {
   calculateSortParams,
   nav,
+  isRefundAllowed,
 } from '../../util';
 import {
-  isRefundAllowed,
   isCancelAllowed,
 } from '../accountFunctions';
 import css from './ViewFeesFines.css';

--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -1,9 +1,6 @@
-import { isEmpty } from 'lodash';
-
 import {
   paymentStatusesAllowedToRefund,
   waiveStatuses,
-  refundStatuses,
 } from '../../constants';
 
 export function count(array) {
@@ -114,21 +111,6 @@ export function accountRefundInfo(account, feeFineActions = []) {
   const paidAmount = (parseFloat(account.amount - account.remaining) * 100) / 100;
 
   return { hasBeenPaid, paidAmount };
-}
-
-export function hasBeenFullyRefunded(accountId, feeFineActions) {
-  const refundActions = feeFineActions.filter(action => {
-    return action.accountId === accountId && action.typeAction === refundStatuses.RefundedFully;
-  });
-
-  return !isEmpty(refundActions);
-}
-
-export function isRefundAllowed(account, feeFineActions) {
-  const { hasBeenPaid, paidAmount } = accountRefundInfo(account, feeFineActions);
-  const isAccountRefunded = hasBeenFullyRefunded(account.id, feeFineActions);
-
-  return !isAccountRefunded && hasBeenPaid && paidAmount > 0;
 }
 
 export function calculateTotalPaymentAmount(accounts = [], feeFineActions = []) {

--- a/src/components/util/index.js
+++ b/src/components/util/index.js
@@ -3,3 +3,4 @@ import * as nav from './navigationHandlers';
 export * from './util';
 export { default as getRenewalPatronBlocksFromPatronBlocks } from './patronBlocks';
 export { nav };
+export { default as isRefundAllowed } from './isRefundAllowed';

--- a/src/components/util/isRefundAllowed.js
+++ b/src/components/util/isRefundAllowed.js
@@ -1,0 +1,13 @@
+import {
+  accountRefundInfo,
+  calculateSelectedAmount,
+} from '../Accounts/accountFunctions';
+
+const isRefundAllowed = (account, feeFineActions) => {
+  const { hasBeenPaid, paidAmount } = accountRefundInfo(account, feeFineActions);
+  const isAccountRefunded = calculateSelectedAmount([account], true, feeFineActions) <= 0;
+
+  return !isAccountRefunded && hasBeenPaid && paidAmount > 0;
+};
+
+export default isRefundAllowed;

--- a/src/components/util/isRefundAllowed.test.js
+++ b/src/components/util/isRefundAllowed.test.js
@@ -1,0 +1,57 @@
+import isRefundAllowed from './isRefundAllowed';
+import {
+  accountRefundInfo,
+  calculateSelectedAmount,
+} from '../Accounts/accountFunctions';
+
+jest.mock('../Accounts/accountFunctions', () => ({
+  accountRefundInfo: jest.fn(() => ({
+    hasBeenPaid: true,
+    paidAmount: 100,
+  })),
+  calculateSelectedAmount: jest.fn(() => 100),
+}));
+
+describe('isRefundAllowed', () => {
+  const mockedAccount = {
+    id: 'testId',
+  };
+  const mockedActions = [{
+    action: 'testAction',
+  }];
+
+  it('should correctly pass props in the inner functions', () => {
+    isRefundAllowed(mockedAccount, mockedActions);
+
+    expect(accountRefundInfo).toHaveBeenCalledWith(mockedAccount, mockedActions);
+    expect(calculateSelectedAmount).toHaveBeenCalledWith([mockedAccount], true, mockedActions);
+  });
+
+  it('should return "true" if "paidAmount" and "calculateSelectedAmount" more than 0, and "hasBeenPaid" is true', () => {
+    expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(true);
+  });
+
+  it('should return "false" if "paidAmount" and "calculateSelectedAmount" more than 0, and "hasBeenPaid" is false', () => {
+    accountRefundInfo.mockReturnValueOnce({
+      hasBeenPaid: false,
+      paidAmount: 100,
+    });
+
+    expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(false);
+  });
+
+  it('should return "false" if "paidAmount" less or equal 0, "calculateSelectedAmount" more than 0, and "hasBeenPaid" is true', () => {
+    accountRefundInfo.mockReturnValueOnce({
+      hasBeenPaid: true,
+      paidAmount: 0,
+    });
+
+    expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(false);
+  });
+
+  it('should return "false" if "paidAmount" more than 0, "calculateSelectedAmount" less or equal 0, and "hasBeenPaid" is true', () => {
+    calculateSelectedAmount.mockReturnValueOnce(0);
+
+    expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(false);
+  });
+});

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -27,11 +27,11 @@ import {
   formatActionDescription,
   formatCurrencyAmount,
   getServicePointOfCurrentAction,
+  isRefundAllowed,
 } from '../../components/util';
 
 import {
   calculateTotalPaymentAmount,
-  isRefundAllowed,
   isCancelAllowed,
 } from '../../components/Accounts/accountFunctions';
 import FeeFineReport from '../../components/data/reports/FeeFineReport';


### PR DESCRIPTION
## Purpose
Fix issue when `refund` button became inactive before the user was returned entire amount of money.

## Approach
We should not more rely on `refundStatuses` when define should `refund` button be active or not. This was discussed with PO here https://issues.folio.org/browse/UIU-2438?focusedCommentId=111858&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-111858.

The `hasBeenFullyRefunded` function was deleted as unnecessary.

In the `isRefundAllowed` function the `isAccountRefunded` flag is calculating rely on  `calculateSelectedAmount` function now.

Also `isRefundAllowed` function was extracted into utils for two reasons:
- we use it in many places, so i think utils is the right place;
- extraction gives us the opportunity to test this function more comfortably by using mock of returning values for inner functions, that we don't want to test in scope of `isRefundAllowed` testing.

## Refs
https://issues.folio.org/browse/UIU-2438