### PR TITLE
UIU-2440: Display `contributors name` consistent with other modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Increment stripes to v7. Refs UIU-2250.
 * Create Jest/RTL test for BulkRenewedLoansList. Refs UIU-2259.
 * Fix issue when `refund` button became inactive before the user was returned entire amount of money. Refs UIU-2438.
+* Display `contributors name` consistent with other modules. Refs UIU-2440.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -172,5 +172,5 @@ export function checkUserActive(user) {
 export const getContributors = (account, instance) => {
   const contributors = account?.contributors || instance?.contributors;
 
-  return contributors && contributors.map(({ name }) => name.split(',').reverse().join(', '));
+  return contributors && contributors.map(({ name }) => name);
 };

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -255,12 +255,12 @@ describe('getContributors', () => {
 
   it('should return contributors from `account` if it passed', () => {
     const mockedAccount = {
-      contributors: [{ name: 'Bond,James' }, { name: 'Doe,John' }],
+      contributors: [{ name: 'Bond, James' }, { name: 'Doe, John' }],
     };
     const mockedInstance = {
       contributors: [{ name: 'test' }],
     };
-    const expectedResult = ['James, Bond', 'John, Doe'];
+    const expectedResult = ['Bond, James', 'Doe, John'];
 
     expect(getContributors(mockedAccount, mockedInstance)).toEqual(expectedResult);
   });
@@ -268,9 +268,9 @@ describe('getContributors', () => {
   it('should return contributors from `instance` if `account` have no contributors', () => {
     const mockedAccount = {};
     const mockedInstance = {
-      contributors: [{ name: 'Bond,James' }, { name: 'Doe,John' }],
+      contributors: [{ name: 'Bond, James' }, { name: 'Doe, John' }],
     };
-    const expectedResult = ['James, Bond', 'John, Doe'];
+    const expectedResult = ['Bond, James', 'Doe, John'];
 
     expect(getContributors(mockedAccount, mockedInstance)).toEqual(expectedResult);
   });


### PR DESCRIPTION
## Purpose
Display `contributors name` consistent with other modules.

## Refs
https://issues.folio.org/browse/UIU-2440