### PR TITLE
UIU-1996: User Information page 'Patron block' accordion should be op…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Create Jest/RTL test for `contactTypes`. Refs UIU-2368.
 * Create Jest/RTL test for `withMarkAsMissing`. Refs UIU-2265.
 * Create Jest/RTL test for `ActionsBar`. Refs UIU-2301.
+* Fix issue User Information page 'Patron block' accordion should be open if patron block exists and closed if not. Refs UIU-1996.
 
 ## [6.1.0](https://github.com/folio-org/ui-users/tree/v6.1.0) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.0.0...v6.1.0)

--- a/src/routes/PatronBlockContainer.js
+++ b/src/routes/PatronBlockContainer.js
@@ -18,7 +18,6 @@ class PatronBlockContainer extends React.Component {
       type: 'okapi',
       records: 'manualblocks',
       path:'manualblocks',
-      fetch: false,
       PUT: {
         path: 'manualblocks/%{activeRecord.blockid}',
       },

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -43,17 +43,16 @@ class UserRecordContainer extends React.Component {
     hasManualPatronBlocks: {
       type: 'okapi',
       records: 'manualblocks',
-      path: 'manualblocks?query=(userId==:{id})&limit=2000',
-      permissionsRequired: 'manualblocks.collection.get',
-      fetch: props => (!!props.stripes.hasInterface('feesfines')),
+      path: `manualblocks?query=(userId==:{id})&limit=${MAX_RECORDS}`,
+      accumulate: true,
+      fetch: false,
     },
     hasAutomatedPatronBlocks: {
       type: 'okapi',
       records: 'automatedPatronBlocks',
       path: 'automated-patron-blocks/:{id}',
-      params: { limit: '2000' },
-      permissionsRequired: 'automated-patron-blocks.collection.get',
-      fetch: props => (!!props.stripes.hasInterface('automated-patron-blocks')),
+      accumulate: true,
+      fetch: false,
     },
     loansHistory: {
       type: 'okapi',

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -5,6 +5,7 @@ import {
   keyBy,
   cloneDeep,
   concat,
+  orderBy,
 } from 'lodash';
 import moment from 'moment';
 import { injectIntl, FormattedMessage } from 'react-intl';
@@ -72,6 +73,7 @@ import ErrorPane from '../../components/ErrorPane';
 class UserDetail extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
+      hasInterface: PropTypes.func.isRequired,
       hasPerm: PropTypes.func.isRequired,
       connect: PropTypes.func.isRequired,
       locale: PropTypes.string.isRequired,
@@ -79,6 +81,20 @@ class UserDetail extends React.Component {
         log: PropTypes.func.isRequired,
       }).isRequired,
     }).isRequired,
+    mutator: PropTypes.shape({
+      hasManualPatronBlocks: PropTypes.shape({
+        GET: PropTypes.func,
+      }),
+      hasAutomatedPatronBlocks: PropTypes.shape({
+        GET: PropTypes.func,
+      }),
+      delUser: PropTypes.shape({
+        DELETE: PropTypes.func,
+      }),
+      openTransactions: PropTypes.shape({
+        GET: PropTypes.func,
+      }),
+    }),
     resources: PropTypes.shape({
       selUser: PropTypes.object,
       delUser: PropTypes.object,
@@ -129,7 +145,6 @@ class UserDetail extends React.Component {
     tagsEnabled: PropTypes.bool,
     paneWidth: PropTypes.string,
     intl: PropTypes.object.isRequired,
-    mutator: PropTypes.object,
   };
 
   static defaultProps = {
@@ -159,6 +174,7 @@ class UserDetail extends React.Component {
     ];
 
     this.state = {
+      patronBlocks: [],
       lastUpdate: null,
       showOpenTransactionModal: false,
       showDeleteUserModal: false,
@@ -179,6 +195,10 @@ class UserDetail extends React.Component {
     };
 
     this.callout = null;
+  }
+
+  componentDidMount() {
+    this.loadPatronBlocks();
   }
 
   getUser = () => {
@@ -508,6 +528,52 @@ class UserDetail extends React.Component {
     return this.props.resources?.selUser?.failed?.httpStatus === 404;
   }
 
+  loadPatronBlocks() {
+    const {
+      mutator: {
+        hasManualPatronBlocks,
+        hasAutomatedPatronBlocks,
+      },
+      stripes,
+    } = this.props;
+
+    const manualPatronBlocksResolver = stripes.hasInterface('feesfines')
+      && stripes.hasPerm('manualblocks.collection.get')
+      ? hasManualPatronBlocks
+        .GET().catch(() => [])
+      : Promise.resolve([]);
+    const automatedPatronBlocksResolver = stripes.hasInterface('automated-patron-blocks')
+      && stripes.hasPerm('automated-patron-blocks.collection.get')
+      ? hasAutomatedPatronBlocks
+        .GET().catch(() => [])
+      : Promise.resolve([]);
+
+    Promise.all([
+      manualPatronBlocksResolver,
+      automatedPatronBlocksResolver,
+    ]).then(([
+      manualPatronBlocks,
+      automatedPatronBlocks,
+    ]) => {
+      const { sections } = this.state;
+
+      let patronBlocks = concat(manualPatronBlocks, automatedPatronBlocks)
+        .filter((patronBlock) => {
+          return moment(patronBlock.expirationDate).endOf('day').isSameOrAfter(moment().endOf('day'));
+        });
+
+      patronBlocks = orderBy(patronBlocks, ['metadata.createdDate'], ['desc']);
+
+      this.setState({
+        patronBlocks,
+      });
+
+      if (!sections.patronBlocksSection && patronBlocks.length) {
+        this.handleSectionToggle({ id: 'patronBlocksSection' });
+      }
+    });
+  }
+
   render() {
     const {
       resources,
@@ -521,6 +587,7 @@ class UserDetail extends React.Component {
     const {
       sections,
       helperApp,
+      patronBlocks,
     } = this.state;
 
     const user = this.getUser();
@@ -536,12 +603,7 @@ class UserDetail extends React.Component {
     const proxies = this.props.getProxies();
     const servicePoints = this.props.getUserServicePoints();
     const preferredServicePoint = this.props.getPreferredServicePoint();
-    const manualPatronBlocks = get(resources, ['hasManualPatronBlocks', 'records'], [])
-      .filter(p => moment(moment(p.expirationDate).format()).isSameOrAfter(moment().format()));
-    const automatedPatronBlocks = get(resources, ['hasAutomatedPatronBlocks', 'records'], []);
-    const totalPatronBlocks = manualPatronBlocks.length + automatedPatronBlocks.length;
-    const patronBlocks = concat(automatedPatronBlocks, manualPatronBlocks);
-    const hasPatronBlocks = totalPatronBlocks > 0;
+    const hasPatronBlocks = !!patronBlocks.length;
     const hasPatronBlocksPermissions = stripes.hasPerm('automated-patron-blocks.collection.get') || stripes.hasPerm('manualblocks.collection.get');
     const patronGroup = this.getPatronGroup(user);
     const requestPreferences = get(resources, 'requestPreferences.records.[0].requestPreferences[0]', {});
@@ -641,17 +703,14 @@ class UserDetail extends React.Component {
                 />
                 <IfInterface name="feesfines">
                   {hasPatronBlocksPermissions &&
-                  <PatronBlock
-                    accordionId="patronBlocksSection"
-                    user={user}
-                    hasPatronBlocks={hasPatronBlocks}
-                    patronBlocks={patronBlocks}
-                    automatedPatronBlocks={automatedPatronBlocks}
-                    expanded={sections.patronBlocksSection}
-                    onToggle={this.handleSectionToggle}
-                    onClickViewPatronBlock={this.onClickViewPatronBlock}
-                    {...this.props}
-                  />
+                    <PatronBlock
+                      accordionId="patronBlocksSection"
+                      patronBlocks={patronBlocks}
+                      expanded={sections.patronBlocksSection}
+                      onToggle={this.handleSectionToggle}
+                      onClickViewPatronBlock={this.onClickViewPatronBlock}
+                      {...this.props}
+                    />
                   }
                 </IfInterface>
                 <ExtendedInfo


### PR DESCRIPTION
## Purpose
Fix issue User Information page 'Patron block' accordion should be open if patron block exists and closed if not

## Refs
https://issues.folio.org/browse/UIU-1996

## Notes
While fixing the issue one more issue was found.
When you click on manual patron block in the patron block list

<img width="551" alt="Screen Shot 2021-10-04 at 1 39 41 PM" src="https://user-images.githubusercontent.com/47976677/135837547-6c267a13-ba26-4cb2-898b-5d227ebe5538.png">

patron block page is opened with this patron block data

<img width="1259" alt="Screen Shot 2021-10-04 at 1 39 57 PM" src="https://user-images.githubusercontent.com/47976677/135837584-0ca1fc0f-8164-4c07-9cfa-adc1508f2776.png">

if you refresh the page, patron block data disappear

<img width="1262" alt="Screen Shot 2021-10-04 at 1 40 09 PM" src="https://user-images.githubusercontent.com/47976677/135837718-d0ed52d7-4f22-4b97-be9a-27e617e3d2b0.png">

This issue is fixed in this MR as well.