### PR TITLE
UIU-2442: fix the oldest manual Patron block is always removed first.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Create Jest/RTL test for `RequestFeeFineBlockButtons`. Refs UIU-2287.
 * Restrict `loans.all` permissions. Refs UIU-2256.
 * Create Jest/RTL test for `withProxy`. Refs UIU-2315.
+* Fix the oldest manual Patron block is always removed first. Refs UIU-2442.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/PatronBlock/PatronBlockLayer.js
+++ b/src/components/PatronBlock/PatronBlockLayer.js
@@ -65,12 +65,10 @@ class PatronBlockLayer extends React.Component {
 
   onDeleteItem = () => {
     const { match: { params } } = this.props;
-    const selectedItem = (params.patronblockid) ?
-      _get(this.props.resources, ['manualPatronBlocks', 'records', 0], {})
-      : this.props.selectedPatronBlock;
+    const blockid = params.patronblockid || this.props.selectedPatronBlock.id;
 
-    this.props.mutator.activeRecord.update({ blockid: selectedItem.id });
-    return this.props.mutator.manualPatronBlocks.DELETE({ id: selectedItem.id })
+    this.props.mutator.activeRecord.update({ blockid });
+    return this.props.mutator.manualPatronBlocks.DELETE({ id: blockid })
       .then(() => { this.deleteItemResolve(); })
       .catch(() => { this.deleteItemReject(); })
       .finally(() => {


### PR DESCRIPTION
## Purpose
Fix the oldest manual Patron block is always removed first.

## Refs
https://issues.folio.org/browse/UIU-2442