### PR TITLE
UIU-2446 correctly show fee/fine to unprivileged user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 7.something (IN PROGRESS)
+
+* Correctly show fee/fine for users without `ui-users.accounts` permission. Refs UIU-2446.
+
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)
 

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -199,7 +199,7 @@ class LoanDetails extends React.Component {
           { value }
         </button>
       :
-      { value };
+      value;
 
     return <>{ valueDisplay }<br />{ suspendedMessage }</>;
   }


### PR DESCRIPTION
This was subtle. In JSX, `<>{value}</>` returns a component, but in
plain ol' JS, `{value}` returns an object. Here, we need either a
component or a primitive, but we got an object. Whoops.

Introduced in #1613.

Refs [UIU-2446](https://issues.folio.org/browse/UIU-2446)