### PR TITLE
UIU-2452: Fix FeeFineAction and FeeFineCharge notice templates not appearing in Manual Charges settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Create Jest/RTL test for `withProxy`. Refs UIU-2315.
 * Fix the oldest manual Patron block is always removed first. Refs UIU-2442.
 * Do not label fees without loans as "Anonymized". Refs UIU-2449.
+* Fix FeeFineAction and FeeFineCharge notice templates not appearing in Manual Charges settings. Refs UIU-2452.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -21,6 +21,10 @@ import {
   ChargeNotice,
 } from './FeeFinesTable';
 
+import {
+  MAX_RECORDS,
+} from '../constants';
+
 const columnMapping = {
   feeFineType: (
     <Label
@@ -58,7 +62,7 @@ class FeeFineSettings extends React.Component {
     templates: {
       type: 'okapi',
       records: 'templates',
-      path: 'templates?limit=50&query=cql.allRecords=1 AND category=""',
+      path: `templates?limit=${MAX_RECORDS}&query=cql.allRecords=1 AND category=""`,
       accumulate: 'true',
     },
     activeRecord: {},


### PR DESCRIPTION
## Purpose
Fix FeeFineAction and FeeFineCharge notice templates not appearing in Manual Charges settings

## Refs
https://issues.folio.org/browse/UIU-2452