### PR TITLE
UIU-2469: fix issue when a fee/fine is refunded due to a CLAIMED RETU…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix FeeFineAction and FeeFineCharge notice templates not appearing in Manual Charges settings. Refs UIU-2452.
 * Fix the issue when fee/fine details doesn't open up in loans. Refs UIU-2459.
 * Fix the issue when fee/fine is partially paid, then refunded, User Details show the full amount of the fee/fine as refunded. Refs UIU-2455.
+* Fix the issue when a fee/fine is refunded due to a CLAIMED RETURNED, the refund amount does not appear in User Details. Refs UIU-2469.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -15,7 +15,12 @@ import {
 } from '@folio/stripes/components';
 import { useStripes } from '@folio/stripes/core';
 
-import { accountStatuses, refundStatuses, loanActions } from '../../../constants';
+import {
+  accountStatuses,
+  refundStatuses,
+  refundClaimReturned,
+  loanActions,
+} from '../../../constants';
 
 
 /**
@@ -64,7 +69,10 @@ const UserAccounts = ({
     const closed = records.filter(account => account?.status?.name === accountStatuses.CLOSED);
 
     // get refunded actions and refunds total amount
-    const refundStatusesValues = Object.values(refundStatuses);
+    const refundStatusesValues = [
+      ...Object.values(refundStatuses),
+      refundClaimReturned.REFUNDED_ACTION,
+    ];
     const feeFineActions = resources.feefineactions.records ?? [];
     const refunded = feeFineActions.filter((feeFineAction) => refundStatusesValues.includes(feeFineAction.typeAction));
     const refundedTotal = refunded.reduce((acc, { amountAction }) => (acc + amountAction), 0);

--- a/src/components/util/refundTransferClaimReturned.js
+++ b/src/components/util/refundTransferClaimReturned.js
@@ -89,11 +89,13 @@ refundTransfers = async (loan, props) => {
     const {
       okapi: {
         currentUser: {
-          id: currentUserId,
           curServicePoint: {
             id: servicePointId
           }
         },
+      },
+      user: {
+        id: userId,
       },
     } = props;
 
@@ -138,7 +140,7 @@ refundTransfers = async (loan, props) => {
           source: orderedActions[0].source,
           paymentMethod: '',
           accountId: orderedActions[0].accountId,
-          userId: currentUserId,
+          userId,
           createdAt: servicePointId,
         };
         return persistRefundAction(newAction);

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -44,7 +44,7 @@ jest.mock('@folio/stripes/core', () => {
     withOkapi: true,
   };
 
-      // eslint-disable-next-line react/prop-types
+  // eslint-disable-next-line react/prop-types
   const stripesConnect = Component => ({ mutator, resources, stripes, ...rest }) => {
     const fakeMutator = mutator || Object.keys(Component.manifest || {}).reduce((acc, mutatorName) => {
       const returnValue = Component.manifest[mutatorName].records ? [] : {};


### PR DESCRIPTION
## Purpose
Fix the issue when a fee/fine is refunded due to a CLAIMED RETURNED, the refund amount does not appear in User Details

## Approach
We should pass `id` of user who has fee/fine and to whom we refund money instead of `id` of user which is logged in in the application. This user `id` is used in `feefineaction` created on the frontend side.

This is temporary solution. There is already backend endpoint which will create `feefineaction` on the backend side instead of creating it on the frontend side. So we need to use this backend API instead and it would be right solution but it will be used in future and will take much more time.

## Refs
https://issues.folio.org/browse/UIU-2469

