### PR TITLE
include jest helper renderWithRouter.js

### DIFF
--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -6,6 +6,7 @@ babelOptions.plugins.push([
     'alias': {
       '__mock__': './test/jest/__mock__',
       'fixtures': './test/jest/fixtures',
+      'helpers': './test/jest/helpers',
     },
   },
 ]);

--- a/test/jest/helpers/renderWithRouter.js
+++ b/test/jest/helpers/renderWithRouter.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+
+const history = createMemoryHistory();
+const renderWithRouter = children => render(<Router history={history}>{children}</Router>);
+
+export default renderWithRouter;


### PR DESCRIPTION
Test scaffolding has been evolving rapidly. It appears that some feature
relies on test scaffolding (`renderWithRouter`) that was added in a
separate PR.