### PR TITLE
eslint config should reflect test aliases

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,8 @@
       "alias": {
         "map": [
           ["__mock__", "./test/jest/__mock__"],
-          ["fixtures", "./test/jest/fixtures"]
+          ["fixtures", "./test/jest/fixtures"],
+          ["helpers", "./test/jest/helpers"]
         ]
       }
     }


### PR DESCRIPTION
`.eslintrc` needs to have the know about the aliases in use in test
files, otherwise it will complain about paths it can't handle.