### PR TITLE
UIU-2474 correctly check permissions on accounts routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix the issue when fee/fine details doesn't open up in loans. Refs UIU-2459.
 * Fix the issue when fee/fine is partially paid, then refunded, User Details show the full amount of the fee/fine as refunded. Refs UIU-2455.
 * Fix the issue when a fee/fine is refunded due to a CLAIMED RETURNED, the refund amount does not appear in User Details. Refs UIU-2469.
+* Correctly check permissions for accounts routes. Refs UIU-2474.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/index.js
+++ b/src/index.js
@@ -205,7 +205,6 @@ class UsersRouting extends React.Component {
               <Route
                 path={`${base}/:id/accounts/:accountstatus`}
                 exact
-                component={Routes.AccountsListingContainer}
                 render={(props) => (
                   <IfPermission perm="ui-users.feesfines.actions.all">
                     <Routes.AccountsListingContainer {...props} />


### PR DESCRIPTION
The `<Route>` components accepts both `components` and a render-props
function to determine the component to render, but only one should be
provided. Here, both were provided, but only one (the render-props)
includes the necessary permissions check. This PR removes the former.

Refs [UIU-2474](https://issues.folio.org/browse/UIU-2474)