### PR TITLE
UIU-2179 refactor from SafeHTMLMessage to FormattedMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix the issue when fee/fine is partially paid, then refunded, User Details show the full amount of the fee/fine as refunded. Refs UIU-2455.
 * Fix the issue when a fee/fine is refunded due to a CLAIMED RETURNED, the refund amount does not appear in User Details. Refs UIU-2469.
 * Correctly check permissions for accounts routes. Refs UIU-2474.
+* Refactor from `<SafeHTMLMessage>` to `<FormattedMessage>`. Refs UIU-2179.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/package.json
+++ b/package.json
@@ -888,7 +888,6 @@
     "sinon": "^7.1.1"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^3.0.0",
     "final-form-set-field-data": "^1.0.2",
     "hashcode": "^1.0.3",
     "jspdf": "^2.3.1",

--- a/src/components/Accounts/Actions/ActionModal.js
+++ b/src/components/Accounts/Actions/ActionModal.js
@@ -6,7 +6,6 @@ import { Field } from 'react-final-form';
 import setFieldData from 'final-form-set-field-data';
 
 import stripesFinalForm from '@folio/stripes/final-form';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   Row,
   Col,
@@ -99,7 +98,7 @@ class ActionModal extends React.Component {
       : formatMessage({ id: `ui-users.accounts.${action}.summary.fully` });
 
     return (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="ui-users.accounts.summary"
         values={{
           count: accounts.length,

--- a/src/components/Accounts/Actions/CancellationModal.js
+++ b/src/components/Accounts/Actions/CancellationModal.js
@@ -6,7 +6,6 @@ import { Field } from 'react-final-form';
 import setFieldData from 'final-form-set-field-data';
 
 import stripesFinalForm from '@folio/stripes/final-form';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   Modal,
   Button,
@@ -93,7 +92,7 @@ class CancellationModal extends React.Component {
           <Row>
             <Col xs>
               <span>
-                <SafeHTMLMessage
+                <FormattedMessage
                   id="ui-users.accounts.cancellation.feeFinewillBeCancelled"
                   values={{
                     amount: parseFloat(amount).toFixed(2),

--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -6,7 +6,6 @@ import {
   FormattedMessage,
   injectIntl,
 } from 'react-intl';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { stripesConnect } from '@folio/stripes/core';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import moment from 'moment';
@@ -245,7 +244,7 @@ class Actions extends React.Component {
     const fullName = getFullName(user);
 
     const message = (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="ui-users.accounts.actions.cancellation.success"
         values={{
           count: 1,
@@ -576,7 +575,7 @@ class Actions extends React.Component {
       this.paymentStatus = paymentStatus;
 
       return (
-        <SafeHTMLMessage
+        <FormattedMessage
           id="ui-users.accounts.confirmation.message"
           values={{ count: 1, amount, action: paymentStatus }}
         />
@@ -593,7 +592,7 @@ class Actions extends React.Component {
       this.paymentStatus = paymentStatus;
 
       return (
-        <SafeHTMLMessage
+        <FormattedMessage
           id="ui-users.accounts.confirmation.message"
           values={{ count: accounts.length, amount, action: paymentStatus }}
         />

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -12,7 +12,6 @@ import {
   FormattedMessage,
   injectIntl,
 } from 'react-intl';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import ChargeForm from './ChargeForm';
 import ItemLookup from './ItemLookup';
 import ActionModal from '../Actions/ActionModal';
@@ -393,7 +392,7 @@ class ChargeFeeFine extends React.Component {
       ? formatMessage({ id: 'ui-users.accounts.status.partially' })
       : formatMessage({ id: 'ui-users.accounts.status.fully' }))} ${paymentStatus}`;
     return (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="ui-users.accounts.confirmation.message"
         values={{ count: 1, amount, action: paymentStatus }}
       />

--- a/src/components/BulkOverrideDialog/BulkOverrideInfo.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideInfo.js
@@ -18,7 +18,6 @@ import {
 import { stripesShape } from '@folio/stripes/core';
 
 import { DueDatePicker } from '@folio/stripes/smart-components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import BulkOverrideLoansList from './BulkOverrideLoansList';
 
@@ -219,7 +218,7 @@ class BulkOverrideInfo extends React.Component {
 
     return (
       <div>
-        <SafeHTMLMessage
+        <FormattedMessage
           id="ui-users.brd.itemsSelected"
           values={{ count: selectedItems }}
         />

--- a/src/components/BulkRenewalDialog/BulkRenewInfo.js
+++ b/src/components/BulkRenewalDialog/BulkRenewInfo.js
@@ -8,7 +8,6 @@ import {
   Button,
   Layout,
 } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   stripesShape,
   IfPermission,
@@ -108,7 +107,7 @@ class BulkRenewInfo extends React.Component {
                   icon="exclamation-circle"
                   status="warn"
                 />
-                <SafeHTMLMessage
+                <FormattedMessage
                   id="ui-users.brd.itemNotRenewed"
                   tagName="span"
                   values={{
@@ -125,7 +124,7 @@ class BulkRenewInfo extends React.Component {
                   icon="check-circle"
                   status="success"
                 />
-                <SafeHTMLMessage
+                <FormattedMessage
                   id="ui-users.brd.itemSuccessfullyRenewed"
                   tagName="span"
                   values={{

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -6,7 +6,6 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import moment from 'moment-timezone';
 import { OnChange } from 'react-final-form-listeners';
 
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { ViewMetaData } from '@folio/stripes/smart-components';
 import {
   Button,
@@ -325,7 +324,7 @@ class EditUserInfo extends React.Component {
           open={this.state.showRecalculateModal}
         >
           <div>
-            <SafeHTMLMessage
+            <FormattedMessage
               id="ui-users.information.recalculate.modal.text"
               values={{ group, offset, date }}
             />

--- a/src/components/LoanActionDialog/LoanActionDialog.js
+++ b/src/components/LoanActionDialog/LoanActionDialog.js
@@ -7,7 +7,6 @@ import {
   Modal,
   ModalFooter,
 } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import ErrorModal from '../ErrorModal';
 import ModalContent from '../ModalContent';
@@ -46,9 +45,9 @@ class LoanActionDialog extends React.Component {
 
     const informativeErrorMessage = (
       <>
-        <SafeHTMLMessage id="ui-users.feefines.errors.notBilledMessage" />
+        <FormattedMessage id="ui-users.feefines.errors.notBilledMessage" />
         <br />
-        <SafeHTMLMessage id="ui-users.feefines.errors.updateOwnerMessage" />
+        <FormattedMessage id="ui-users.feefines.errors.updateOwnerMessage" />
       </>
     );
 

--- a/src/components/Loans/OpenLoans/components/BulkClaimReturnedModal/BulkClaimReturnedModal.js
+++ b/src/components/Loans/OpenLoans/components/BulkClaimReturnedModal/BulkClaimReturnedModal.js
@@ -15,7 +15,6 @@ import {
   Spinner,
   TextArea,
 } from '@folio/stripes-components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import { getOpenRequestsPath } from '../../../../util';
 import refundTransferClaimReturned from '../../../../util/refundTransferClaimReturned';
@@ -253,7 +252,7 @@ class BulkClaimReturnedModal extends React.Component {
     if (operationState === 'pre') {
       modalHeader = <FormattedMessage id="ui-users.bulkClaimReturned.preConfirm" />;
       statusMessage =
-        <SafeHTMLMessage
+        <FormattedMessage
           id="ui-users.bulkClaimReturned.summary"
           values={{ numLoans: loans.length }}
         />;
@@ -262,17 +261,17 @@ class BulkClaimReturnedModal extends React.Component {
       modalHeader = <FormattedMessage id="ui-users.bulkClaimReturned.postConfirm" />;
       statusMessage = unchangedLoans.length > 0 ?
         <>
-          <SafeHTMLMessage
+          <FormattedMessage
             id="ui-users.bulkClaimReturned.items.notOk"
             values={{ numItems: unchangedLoans.length }}
           />
           {' '}
-          <SafeHTMLMessage
+          <FormattedMessage
             id="ui-users.bulkClaimReturned.items.ok"
             values={{ numItems: numSuccessfulOperations }}
           />
         </> :
-        <SafeHTMLMessage
+        <FormattedMessage
           id="ui-users.bulkClaimReturned.items.ok"
           values={{ numItems: numSuccessfulOperations }}
         />;

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -12,7 +12,6 @@ import {
   Col,
 } from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import { getOpenRequestsPath } from '../util';
 
@@ -247,7 +246,7 @@ class ModalContent extends React.Component {
 
     return (
       <div>
-        <SafeHTMLMessage
+        <FormattedMessage
           id={`ui-users.loans.${loanAction}DialogBody`}
           values={{
             title: loan?.item?.title,

--- a/src/components/ProxyGroup/ProxyEditList/ProxyEditList.js
+++ b/src/components/ProxyGroup/ProxyEditList/ProxyEditList.js
@@ -5,7 +5,6 @@ import {
   FormattedMessage,
   injectIntl,
 } from 'react-intl';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import {
   Row,
   Col,
@@ -110,11 +109,11 @@ class ProxyEditList extends React.Component {
     const heading = (name === 'sponsors') ?
       <FormattedMessage id="ui-users.deleteSponsorPrompt" /> :
       <FormattedMessage id="ui-users.deleteProxyPrompt" />;
-    const sponsorsMsg = <SafeHTMLMessage
+    const sponsorsMsg = <FormattedMessage
       id="ui-users.proxyWillBeDeleted"
       values={{ name1: getFullName(initialValues), name2: getFullName(curRecord.user) }}
     />;
-    const proxyMsg = <SafeHTMLMessage
+    const proxyMsg = <FormattedMessage
       id="ui-users.proxyWillBeDeleted"
       values={{ name1: getFullName(curRecord.user), name2: getFullName(initialValues) }}
     />;

--- a/src/components/Wrappers/withRenew.js
+++ b/src/components/Wrappers/withRenew.js
@@ -6,7 +6,6 @@ import {
 } from 'lodash';
 
 import { Callout } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import BulkRenewalDialog from '../BulkRenewalDialog';
 import isOverridePossible from '../Loans/OpenLoans/helpers/isOverridePossible';
@@ -183,7 +182,7 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
   showSingleRenewCallout = (loan) => {
     const message = (
       <span>
-        <SafeHTMLMessage
+        <FormattedMessage
           id="ui-users.loans.item.renewed.callout"
           values={{ title: loan.item.title }}
         />

--- a/src/settings/patronBlocks/Conditions/Conditions.js
+++ b/src/settings/patronBlocks/Conditions/Conditions.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
 import { stripesConnect } from '@folio/stripes/core';
 import { Callout } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import ConditionsForm from './ConditionsForm';
 import css from '../patronBlocks.css';
@@ -60,7 +60,7 @@ class Conditions extends Component {
     }).then(() => {
       if (this.callout) {
         this.callout.current.sendCallout({
-          message: <SafeHTMLMessage
+          message: <FormattedMessage
             id="ui-users.settings.callout.message"
             values={{ name: value.name }}
           />

--- a/src/settings/patronBlocks/Limits/Limits.js
+++ b/src/settings/patronBlocks/Limits/Limits.js
@@ -12,7 +12,6 @@ import {
 
 import { stripesConnect } from '@folio/stripes/core';
 import { Callout } from '@folio/stripes/components';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import LimitsForm from './LimitsForm';
 
@@ -206,7 +205,7 @@ class Limits extends Component {
     const { patronGroup } = this.props;
     const limits = this.saveLimits(value);
     const showSuccessMessage = (
-      <SafeHTMLMessage
+      <FormattedMessage
         id="ui-users.settings.limits.callout.message"
         values={{ patronGroup }}
       />


### PR DESCRIPTION
`<SafeHTMLMessage>` is deprecated and its features subsumed by
`react-intl` as of `v5`.

Refs [UIU-2179](https://issues.folio.org/browse/UIU-2179), [STRIPES-754](https://issues.folio.org/browse/STRIPES-754)