### PR TITLE
UIU-2472 view fees/fines does not include view loans

### DIFF
--- a/package.json
+++ b/package.json
@@ -512,7 +512,7 @@
       {
         "permissionName": "ui-users.feesfines.view",
         "displayName": "Users: Can view fees/fines and loans",
-        "description": "Also includes basic permissions to view users and loans",
+        "description": "Also includes basic permissions to view users",
         "subPermissions": [
           "ui-users.view",
           "accounts.collection.get",
@@ -531,7 +531,6 @@
           "transfers.collection.get",
           "waives.collection.get",
           "waives.item.get",
-          "circulation.loans.collection.get",
           "inventory-storage.service-points-users.collection.get"
         ],
         "visible": true

--- a/src/routes/AccountDetailsContainer.js
+++ b/src/routes/AccountDetailsContainer.js
@@ -63,10 +63,18 @@ class AccountDetailsContainer extends React.Component {
       instanceId: '',
       records: MAX_RECORDS,
     },
+    // Many fees and fines are associated with loans, so the loans are
+    // retrieved in order to show the corresponding policies (overdue
+    // fine policy, lost item policy) and the item's current status.
+    // But! Not _all_ fees and fines are associated with loans, and not
+    // all users may have permission to view loans. For that situation,
+    // using permissionRequired allows the AccountDetails page to function
+    // as-is; it simply doesn't receive any loan information.
     loans: {
       type: 'okapi',
       records: 'loans',
       path: 'circulation/loans?query=(userId==:{id})&limit=1000',
+      permissionsRequired: 'circulation.loans.collection.get',
     },
     instance: {
       type: 'okapi',

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -421,7 +421,7 @@ class AccountDetails extends React.Component {
     if (hasLoan) {
       if (isLoanAnonymized) {
         loanDetailsValue = <FormattedMessage id="ui-users.details.label.loanAnonymized" />;
-      } else if (stripes.hasPermission('ui-users.loans.view')) {
+      } else if (stripes.hasPerm('ui-users.loans.view')) {
         loanDetailsValue = (
           <Link
             to={`/users/${params.id}/loans/view/${loanId}`}

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -421,7 +421,7 @@ class AccountDetails extends React.Component {
     if (hasLoan) {
       if (isLoanAnonymized) {
         loanDetailsValue = <FormattedMessage id="ui-users.details.label.loanAnonymized" />;
-      } else {
+      } else if (stripes.hasPermission('ui-users.loans.view')) {
         loanDetailsValue = (
           <Link
             to={`/users/${params.id}/loans/view/${loanId}`}
@@ -429,6 +429,8 @@ class AccountDetails extends React.Component {
             <FormattedMessage id="ui-users.details.field.loan" />
           </Link>
         );
+      } else {
+        loanDetailsValue = <FormattedMessage id="ui-users.details.field.loan" />;
       }
     }
 


### PR DESCRIPTION
Permission to view fees and fines no longer includes any permissions
associated with viewing loans.

See discussion under [UICIRC-693](https://issues.folio.org/browse/UICIRC-693?focusedCommentId=116650&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-116650)

Refs [UIU-2472](https://issues.folio.org/browse/UIU-2472)