### PR TITLE
UIU-2165 search hidden fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix the issue when fee/fine is partially paid, then refunded, User Details show the full amount of the fee/fine as refunded. Refs UIU-2455.
 * Fix the issue when a fee/fine is refunded due to a CLAIMED RETURNED, the refund amount does not appear in User Details. Refs UIU-2469.
 * Correctly check permissions for accounts routes. Refs UIU-2474.
+* Search operates on custom fields. Refs UIU-2165.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -19,10 +19,18 @@ import { MAX_RECORDS } from '../constants';
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
 
-const compileQuery = template(
-  '(username="%{query}*" or personal.firstName="%{query}*" or personal.preferredFirstName="%{query}*" or personal.lastName="%{query}*" or personal.email="%{query}*" or barcode="%{query}*" or id="%{query}*" or externalSystemId="%{query}*")',
-  { interpolate: /%{([\s\S]+?)}/g }
-);
+const searchFields = [
+  'username="%{query}*"',
+  'personal.firstName="%{query}*"',
+  'personal.preferredFirstName="%{query}*"',
+  'personal.lastName="%{query}*"',
+  'personal.email="%{query}*"',
+  'barcode="%{query}*"',
+  'id="%{query}*"',
+  'externalSystemId="%{query}*"',
+  'customFields="%{query}*"'
+];
+const compileQuery = template(`(${searchFields.join(' or ')})`, { interpolate: /%{([\s\S]+?)}/g });
 
 class UserSearchContainer extends React.Component {
   static manifest = Object.freeze({


### PR DESCRIPTION
Search hidden fields along with all the other fields. This is not
_exactly_ what UIU-2165 asked for (which was a drop-down menu with
different options, similar to the different search options in
ui-inventory) but this was the simplest possible implementation, so I
just went for it (with Patty's blessing). 

Refs [UIU-2165](https://issues.folio.org/browse/UIU-2165)