### PR TITLE
UIU-2472 view-fees/fines pset includes view-loans

### DIFF
--- a/package.json
+++ b/package.json
@@ -512,7 +512,7 @@
       {
         "permissionName": "ui-users.feesfines.view",
         "displayName": "Users: Can view fees/fines and loans",
-        "description": "Also includes basic permissions to view users",
+        "description": "Also includes basic permissions to view users and loans",
         "subPermissions": [
           "ui-users.view",
           "accounts.collection.get",

--- a/package.json
+++ b/package.json
@@ -512,9 +512,10 @@
       {
         "permissionName": "ui-users.feesfines.view",
         "displayName": "Users: Can view fees/fines and loans",
-        "description": "Also includes basic permissions to view users and loans",
+        "description": "Also includes basic permissions to view users",
         "subPermissions": [
           "ui-users.view",
+          "ui-users.loans.view",
           "accounts.collection.get",
           "accounts.item.get",
           "comments.collection.get",

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -914,6 +914,7 @@
   "permission.edituserservicepoints": "Users: Can assign and unassign service points to users",
   "permission.feefineactions": "Fee/Fine Details: Can create, edit and remove fee/fine actions",
   "permission.feesfines.actions.all": "Users: Can create, edit and remove fees/fines",
+  "permission.feesfines.view": "Users: Can view fees/fines and loans",
   "permission.loans.all": "Users: User loans view, change due date, renew",
   "permission.loans.anonymize": "Users: User loans anonymize",
   "permission.loans.change-due-date": "Users: User loans change due date",

--- a/translations/ui-users/en_GB.json
+++ b/translations/ui-users/en_GB.json
@@ -603,6 +603,7 @@
     "permission.edituserservicepoints": "Users: Can assign and unassign service points to users",
     "permission.feefineactions": "Fee/Fine Details: Can create, edit and remove fee/fine actions",
     "permission.feesfines.actions.all": "Users: Can create, edit and remove fees/fines",
+    "permission.feesfines.view": "Users: Can view fees/fines and loans",
     "permission.loans.all": "Users: User loans view, edit, renew (all)",
     "permission.loans.claim-item-returned": "Users: User loans claim returned",
     "permission.loans.declare-item-lost": "Users: User loans declare lost",

--- a/translations/ui-users/en_SE.json
+++ b/translations/ui-users/en_SE.json
@@ -603,6 +603,7 @@
     "permission.edituserservicepoints": "Users: Can assign and unassign service points to users",
     "permission.feefineactions": "Fee/Fine Details: Can create, edit and remove fee/fine actions",
     "permission.feesfines.actions.all": "Users: Can create, edit and remove fees/fines",
+    "permission.feesfines.view": "Users: Can view fees/fines and loans",
     "permission.loans.all": "Users: User loans view, edit, renew (all)",
     "permission.loans.claim-item-returned": "Users: User loans claim returned",
     "permission.loans.declare-item-lost": "Users: User loans declare lost",

--- a/translations/ui-users/en_US.json
+++ b/translations/ui-users/en_US.json
@@ -603,6 +603,7 @@
     "permission.edituserservicepoints": "Users: Can assign and unassign service points to users",
     "permission.feefineactions": "Fee/Fine Details: Can create, edit and remove fee/fine actions",
     "permission.feesfines.actions.all": "Users: Can create, edit and remove fees/fines",
+    "permission.feesfines.view": "Users: Can view fees/fines and loans",
     "permission.loans.all": "Users: User loans view, change due date, renew",
     "permission.loans.claim-item-returned": "Users: User loans claim returned",
     "permission.loans.declare-item-lost": "Users: User loans declare lost",


### PR DESCRIPTION
At the request of the RA SIG, permission to view fees and fines should
include permission to view loans.

(Including translation file updates here because I expect this PR to be cherry-picked into a patch release and there is a high probability of that happening before translations are updated.)

Refs [UIU-2472](https://issues.folio.org/browse/UIU-2472)