### PR TITLE
UIU-2466: Reset offset when sort values change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Correctly check permissions for accounts routes. Refs UIU-2474.
 * Search operates on custom fields. Refs UIU-2165.
 * Refactor from `<SafeHTMLMessage>` to `<FormattedMessage>`. Refs UIU-2179.
+* Reset offset when sort values change. Fixes UIU-2466.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -227,15 +227,28 @@ class UserSearchContainer extends React.Component {
   };
 
   querySetter = ({ nsValues, state }) => {
-    const { location : locationProp, history } = this.props;
+    const {
+      location: locationProp,
+      history,
+      mutator: { resultOffset },
+    } = this.props;
+
     if (nsValues.query) {
       nsValues.query = nsValues.query.replace('*', '');
     }
+
     let location = locationProp;
+
     // modifying the location hides the user detail view if a search/filter is triggered.
     if (state.changeType !== 'init.reset' && !location.pathname.endsWith('users')) {
       const pathname = '/users';
       location = { ...locationProp, pathname };
+    }
+
+    // reset offset when sort values change
+    // https://issues.folio.org/browse/UIU-2466
+    if (state.sortChanged) {
+      resultOffset.replace(0);
     }
 
     const url = buildUrl(location, nsValues);


### PR DESCRIPTION
Sorting was not working correctly after "Load more" option was used to fetch more data. This PR resets the offset when sort is used so only the first sorted page is loaded. 

https://issues.folio.org/browse/UIU-2466