### PR TITLE
UIU-2490: Do not push to history if the url didn't change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Reset offset when sort values change. Fixes UIU-2466.
 * Prompt if changing permissions will remove those with `visible: false`. Refs UIU-2409.
 * Unassign all permissions from a user with one click. Refs UIU-2477.
+* Do not push to history if the url didn't change. Fixes UIU-2490.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -254,6 +254,8 @@ class UserSearchContainer extends React.Component {
     const url = buildUrl(location, nsValues);
     const { pathname, search } = locationProp;
 
+    // Do not push to history if the url didn't change
+    // https://issues.folio.org/browse/UIU-2490
     if (`${pathname}${search}` !== url) {
       history.push(url);
     }

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -252,7 +252,11 @@ class UserSearchContainer extends React.Component {
     }
 
     const url = buildUrl(location, nsValues);
-    history.push(url);
+    const { pathname, search } = locationProp;
+
+    if (`${pathname}${search}` !== url) {
+      history.push(url);
+    }
   }
 
   queryGetter = () => {


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2490

Only use `history.push` if the url is actually different from the current one.

I noticed this bug when working on lazy loading. The ui-users would just go into infinitive loop and keep re-rendering `UserSearchContainer` reloading all resources. This doesn't happen when everything is bundled into one single module in webpack. It almost seems like a timing issue. 