### PR TITLE
UIU-2473: Properly show service point name in fee/fine details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Also support `circulation` `12.0`. Refs UIU-2480.
 * Also support `request-storage` `4.0` (TLR). Refs UIU-2495, UIU-2480.
 * Fix problems with permissions for claim returned, renewals. Refs UIU-2256.
+* Properly show service point name in fee/fine details. Fixes UIU-2473.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/routes/AccountDetailsContainer.js
+++ b/src/routes/AccountDetailsContainer.js
@@ -105,6 +105,14 @@ class AccountDetailsContainer extends React.Component {
         return refresh || action.meta.path === 'accounts-bulk';
       },
     },
+    // Service points are needed here to properly display SP name in <AccountDetails>
+    // for fees/fines assigned to an item during checkout.
+    servicePoints: {
+      type: 'okapi',
+      records: 'servicepoints',
+      path: 'service-points',
+      limit: 10000,
+    },
   });
 
   static propTypes = {

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -76,6 +76,7 @@ class AccountDetails extends React.Component {
       accounts: PropTypes.object.isRequired,
       feefineactions: PropTypes.object.isRequired,
       loans: PropTypes.object.isRequired,
+      servicePoints: PropTypes.object.isRequired,
     }),
     mutator: PropTypes.shape({
       activeRecord: PropTypes.shape({
@@ -384,7 +385,7 @@ class AccountDetails extends React.Component {
       amount: action => (action.amountAction > 0 ? formatCurrencyAmount(action.amountAction) : '-'),
       balance: action => (action.balance > 0 ? formatCurrencyAmount(action.balance) : '-'),
       transactioninfo: action => action.transactionInformation || '-',
-      created: action => getServicePointOfCurrentAction(action, this.props.okapi.currentUser.servicePoints),
+      created: action => getServicePointOfCurrentAction(action, this.props.resources.servicePoints.records),
       source: action => action.source,
       comments: action => (action.comments ? (<div>{action.comments.split('\n').map(c => (<Row><Col>{c}</Col></Row>))}</div>) : ''),
     };


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2473

In order to get the correct service point name, we need to pull in the full list of service points to match against. As Zak stated in the issue comments, this code was previously trying to match based on the user's assigned service points, which could be just a small subset of the full list of SPs where the fine could have been assigned.

<img width="1175" alt="Screen Shot 2022-01-12 at 1 32 01 PM" src="https://user-images.githubusercontent.com/1322242/149202205-f7c9615a-aa7a-4984-837d-70a1c301dd67.png">

