### PR TITLE
UIU-2498: Fix calcualtion for expiration date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Also support `circulation` `12.0`. Refs UIU-2480.
 * Also support `request-storage` `4.0` (TLR). Refs UIU-2495, UIU-2480.
 * Fix problems with permissions for claim returned, renewals. Refs UIU-2256.
+* Correct calcualtion for expiration date. Refs UIU-2498.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -72,17 +72,9 @@ class EditUserInfo extends React.Component {
   }
 
   calculateNewExpirationDate = () => {
-    const { initialValues } = this.props;
-    const expirationDate = new Date(initialValues.expirationDate);
-    const now = Date.now();
     const offsetOfSelectedPatronGroup = this.state.selectedPatronGroup ? this.getPatronGroupOffset() : '';
-    let recalculatedDate;
+    const recalculatedDate = (moment().add(offsetOfSelectedPatronGroup, 'd').format('YYYY-MM-DD'));
 
-    if (initialValues.expirationDate === undefined || expirationDate <= now) {
-      recalculatedDate = (moment().add(offsetOfSelectedPatronGroup, 'd').format('YYYY-MM-DD'));
-    } else {
-      recalculatedDate = (moment(expirationDate).add(offsetOfSelectedPatronGroup, 'd').format('YYYY-MM-DD'));
-    }
     return recalculatedDate;
   }
 

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -73,9 +73,8 @@ class EditUserInfo extends React.Component {
 
   calculateNewExpirationDate = () => {
     const offsetOfSelectedPatronGroup = this.state.selectedPatronGroup ? this.getPatronGroupOffset() : '';
-    const recalculatedDate = (moment().add(offsetOfSelectedPatronGroup, 'd').format('YYYY-MM-DD'));
 
-    return recalculatedDate;
+    return moment().add(offsetOfSelectedPatronGroup, 'd').format('YYYY-MM-DD');
   }
 
   getPatronGroupOffset = () => {


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2498

**Overview:** 
With UXPROD-2389, a default expiration date can be filled in when a new user is created, a user is changed from inactive to active, re-set or, the case here, a patron group is changed.

The default expiartion period for the patron group is either added to the current expiration date or the current date. 

In the case of a change of patron group, it should be added to the current date.

**Steps to Reproduce:**
1.     Set default expiration date for a patron group X.
2.     Open a user with a set expiration date.
3.     Change the patron group

**Expected Results:**
The expiration date should be changed to expiration date = today + expiration period.

**Actual Results:**
It is changed to expiration date = current expiration date + expiration period.

**Additional Information:**
 See Uschis comment (https://issues.folio.org/browse/UXPROD-2389?focusedCommentId=116868&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-116868). 