### PR TITLE
UIU-2499 suppress edit of some users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Also support `circulation` `12.0`. Refs UIU-2480.
 * Also support `request-storage` `4.0` (TLR). Refs UIU-2495, UIU-2480.
 * Fix problems with permissions for claim returned, renewals. Refs UIU-2256.
+* Suppress edit of users stored in a configuration entry. Refs UIU-2499.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -179,6 +179,11 @@ class UserRecordContainer extends React.Component {
         },
       }
     },
+    suppressEdit: {
+      type: 'okapi',
+      path: 'configurations/entries?query=module=="@folio/users" AND configName=="suppressEdit"',
+      records: 'configs',
+    },
   });
 
   static propTypes = {

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -436,6 +436,7 @@ class UserDetail extends React.Component {
         }
       } catch (e) {
         console.error("could not parse JSON", this.props.resources.suppressEdit?.records?.[0])
+        console.error(e);
       }
     }
 

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -424,7 +424,7 @@ class UserDetail extends React.Component {
    *
    * @returns component
    */
-  actionMenuEditButton() {
+  actionMenuEditButton(onToggle) {
     const { resources, match: { params: { id } } } = this.props;
 
     let suppress = false;
@@ -432,7 +432,10 @@ class UserDetail extends React.Component {
       try {
         const value = this.props.resources.suppressEdit?.records?.[0]?.value;
         if (value) {
-          suppress = !!JSON.parse(value).list.find(i => i === id);
+          const list = JSON.parse(value);
+          if (Array.isArray(list)) {
+            suppress = !!list.find(i => i === id);
+          }
         }
       } catch (e) {
         console.error("could not parse JSON", this.props.resources.suppressEdit?.records?.[0])
@@ -505,7 +508,7 @@ class UserDetail extends React.Component {
               userId={this.props.match.params.id}
             />
           </IfInterface>
-          {this.actionMenuEditButton()}
+          {this.actionMenuEditButton(onToggle)}
           <IfInterface name="feesfines">
             <ExportFeesFinesReportButton
               feesFinesReportData={feesFinesReportData}

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -435,7 +435,7 @@ class UserDetail extends React.Component {
           suppress = !!JSON.parse(value).list.find(i => i === id);
         }
       } catch (e) {
-        console.error("could not parse JSON", value)
+        console.error("could not parse JSON", this.props.resources.suppressEdit?.records?.[0])
       }
     }
 

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -69,6 +69,7 @@ import OpenTransactionModal from './components/OpenTransactionModal';
 import DeleteUserModal from './components/DeleteUserModal';
 import ExportFeesFinesReportButton from './components';
 import ErrorPane from '../../components/ErrorPane';
+import ActionMenuEditOption from './components/ActionMenuEditOption';
 
 class UserDetail extends React.Component {
   static propTypes = {
@@ -409,65 +410,6 @@ class UserDetail extends React.Component {
       });
   }
 
-  /**
-   * actionMenuEditButton
-   * Handle display of the "Edit" button in the Action menu.
-   * Some users should not be editable in the UI; these are stored in a
-   * serialized array in a configuration entry:
-   * {
-   *   "module": "@folio/users",
-   *   "configName": "suppressEdit",
-   *   "value": "SERIALIZED_JSON_ARRAY"
-   * }
-   *
-   * This function checks the ID from the URL against that list.
-   *
-   * @returns component
-   */
-  actionMenuEditButton(onToggle) {
-    const { resources, match: { params: { id } } } = this.props;
-
-    let suppress = false;
-    if (this.props.resources.suppressEdit?.records?.[0]) {
-      try {
-        const value = this.props.resources.suppressEdit?.records?.[0]?.value;
-        if (value) {
-          const list = JSON.parse(value);
-          if (Array.isArray(list)) {
-            suppress = !!list.find(i => i === id);
-          }
-        }
-      } catch (e) {
-        console.error("could not parse JSON", this.props.resources.suppressEdit?.records?.[0])
-        console.error(e);
-      }
-    }
-
-    let button = <></>;
-    if (!suppress) {
-      button = (
-        <IfPermission perm="ui-users.edit">
-          <Button
-            buttonStyle="dropdownItem"
-            data-test-actions-menu-edit
-            id="clickable-edituser"
-            onClick={() => {
-              onToggle();
-              this.goToEdit();
-            }}
-            buttonRef={this.editButton}
-          >
-            <Icon icon="edit">
-              <FormattedMessage id="ui-users.edit" />
-            </Icon>
-          </Button>
-        </IfPermission>
-      );
-    }
-
-    return button;
-  }
-
   getActionMenu = barcode => ({ onToggle }) => {
     const {
       okapi: {
@@ -508,7 +450,13 @@ class UserDetail extends React.Component {
               userId={this.props.match.params.id}
             />
           </IfInterface>
-          {this.actionMenuEditButton(onToggle)}
+          <ActionMenuEditOption
+            id={this.props.match.params.id}
+            suppressEdit={this.props.resources.suppressEdit}
+            onToggle={onToggle}
+            goToEdit={this.goToEdit}
+            editButton={this.editButton}
+          />
           <IfInterface name="feesfines">
             <ExportFeesFinesReportButton
               feesFinesReportData={feesFinesReportData}

--- a/src/views/UserDetail/components/ActionMenuEditOption/ActionMenuEditOption.js
+++ b/src/views/UserDetail/components/ActionMenuEditOption/ActionMenuEditOption.js
@@ -1,0 +1,62 @@
+import { FormattedMessage } from 'react-intl';
+import { IfPermission } from '@folio/stripes/core';
+import { Button, Icon } from '@folio/stripes/components';
+
+/**
+ * actionMenuEditButton
+ * Handle display of the "Edit" button in the Action menu.
+ * Some users should not be editable in the UI; these are stored in a
+ * serialized array in a configuration entry:
+ * {
+ *   "module": "@folio/users",
+ *   "configName": "suppressEdit",
+ *   "value": "SERIALIZED_JSON_ARRAY"
+ * }
+ *
+ * This function checks the ID from the URL against that list.
+ *
+ * @returns component
+ */
+const ActionMenuEditButton = ({ id, suppressEdit, onToggle, goToEdit, editButton }) => {
+  let suppress = false;
+  if (suppressEdit?.records?.[0]) {
+    try {
+      const value = suppressEdit?.records?.[0]?.value;
+      if (value) {
+        const list = JSON.parse(value);
+        if (Array.isArray(list)) {
+          suppress = !!list.find(i => i === id);
+        }
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(`could not parse JSON: ${suppressEdit?.records?.[0]}`, e);
+    }
+  }
+
+  let button = <></>;
+  if (!suppress) {
+    button = (
+      <IfPermission perm="ui-users.edit">
+        <Button
+          buttonStyle="dropdownItem"
+          data-test-actions-menu-edit
+          id="clickable-edituser"
+          onClick={() => {
+            onToggle();
+            goToEdit();
+          }}
+          buttonRef={editButton}
+        >
+          <Icon icon="edit">
+            <FormattedMessage id="ui-users.edit" />
+          </Icon>
+        </Button>
+      </IfPermission>
+    );
+  }
+
+  return button;
+};
+
+export default ActionMenuEditButton;

--- a/src/views/UserDetail/components/ActionMenuEditOption/ActionMenuEditOption.test.js
+++ b/src/views/UserDetail/components/ActionMenuEditOption/ActionMenuEditOption.test.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { IfPermission } from '@folio/stripes/core';
+
+import ActionMenuEditOption from './ActionMenuEditOption';
+
+describe('render ActionMenuEditOption', () => {
+  IfPermission.mockImplementation(({ children }) => children);
+
+  describe('renders', () => {
+    test('if suppressEdit resource is empty', async () => {
+      const props = {
+        id: '123',
+        onToggle: jest.fn(),
+        goToEdit: jest.fn(),
+        editButton: jest.fn(),
+      };
+
+      render(<ActionMenuEditOption {...props} />);
+
+      expect(screen.getByText('ui-users.edit')).toBeTruthy();
+    });
+
+    test('if suppressEdit records array is empty', async () => {
+      const props = {
+        id: '123',
+        suppressEdit: { records: [] },
+        onToggle: jest.fn(),
+        goToEdit: jest.fn(),
+        editButton: jest.fn(),
+      };
+
+      render(<ActionMenuEditOption {...props} />);
+
+      expect(screen.getByText('ui-users.edit')).toBeTruthy();
+    });
+
+    test('if suppressEdit records array does not contain match', async () => {
+      const props = {
+        id: '123',
+        suppressEdit: { records: '["456"]' },
+        onToggle: jest.fn(),
+        goToEdit: jest.fn(),
+        editButton: jest.fn(),
+      };
+
+      render(<ActionMenuEditOption {...props} />);
+
+      expect(screen.getByText('ui-users.edit')).toBeTruthy();
+    });
+
+    test('onclick callbacks fire', async () => {
+      const props = {
+        id: '123',
+        onToggle: jest.fn(),
+        goToEdit: jest.fn(),
+        editButton: jest.fn(),
+      };
+
+      render(<ActionMenuEditOption {...props} />);
+      userEvent.click(screen.getByText('ui-users.edit'));
+
+      expect(props.onToggle).toHaveBeenCalled();
+      expect(props.goToEdit).toHaveBeenCalled();
+    });
+
+    describe('logs error on invalid JSON', () => {
+      beforeAll(() => {
+        console.error = jest.fn()
+      });
+      afterAll(() => {
+        console.error.mockRestore();
+      });
+
+      test('value is incorrectly serialize', () => {
+        const props = {
+          id: '123',
+          suppressEdit: { records: [{ value: '["123", 456"]' }] },
+          onToggle: jest.fn(),
+          goToEdit: jest.fn(),
+          editButton: jest.fn(),
+        };
+
+        render(<ActionMenuEditOption {...props} />);
+
+        expect(console.error).toHaveBeenCalledTimes(1);
+
+      });
+
+    })
+  });
+
+  describe('does not render', () => {
+    test('if supress records value matches', async () => {
+      const props = {
+        id: '123',
+        suppressEdit: { records: [{ value: '["123", "456"]' }] },
+        onToggle: jest.fn(),
+        goToEdit: jest.fn(),
+        editButton: jest.fn(),
+      };
+
+      render(<ActionMenuEditOption {...props} />);
+
+      expect(screen.queryByText('ui-users.edit')).not.toBeInTheDocument();
+    });
+
+    test('if user lacks permission', async () => {
+      IfPermission.mockImplementation(() => <></>);
+
+      const props = {
+        id: '123',
+        onToggle: jest.fn(),
+        goToEdit: jest.fn(),
+        editButton: jest.fn(),
+      };
+
+      render(<ActionMenuEditOption {...props} />);
+
+      expect(screen.queryByText('ui-users.edit')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/views/UserDetail/components/ActionMenuEditOption/index.js
+++ b/src/views/UserDetail/components/ActionMenuEditOption/index.js
@@ -1,0 +1,1 @@
+export { default } from './ActionMenuEditOption';


### PR DESCRIPTION
Suppress edit of users whose IDs are specified in an array stored in mod-configuration. 

Create a configurations entry by sending a POST request to `/configurations/entries` with a body like
```
{
  "module": "@folio/users",
  "configName": "suppressEdit",
  "default": true,
  "enabled": true,
  "value": "[\"SOME_UUID\", \"OTHER_UUID\"]",
}
```
Users whose UUIDs match array values will not have an "Edit" button when viewing the "Actions" menu from the user-details pane. This is a bit kludgey; all it does is remove the "Edit" button from the Action menu, so a determined user could still directly access the edit screen by manually entering a URL like `/users/SOME_UUID/edit`. I could add a check there too if folks think this needs to be more robust. 

Refs [UIU-2499](https://issues.folio.org/browse/UIU-2499)