### PR TITLE
UIU-2506: Fix unexpected increase of fee/fine remaining balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Properly show service point name in fee/fine details. Fixes UIU-2473.
 * Suppress edit of users stored in a configuration entry. Refs UIU-2499.
 * Also support `circulation` `13.0`. Refs UIU-2483.
+* Fix unexpected increase of fee/fine remaining balance. Refs UIU-2506.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -357,7 +357,7 @@ class Actions extends React.Component {
     const account = this.props.accounts[0] || '';
     const id = this.props.accounts[0].id || '';
     const createAt = this.props.okapi.currentUser.curServicePoint.id;
-    const balance = this.props.balance || 0;
+    const balance = account.remaining;
     const tagStaff = formatMessage({ id: 'ui-users.accounts.actions.tag.staff' });
     const comment = `${tagStaff} : ${values.comment}`;
     this.props.mutator.activeRecord.update({ id });


### PR DESCRIPTION
## Purpose
Fix unexpected increase of fee/fine remaining balance.

## Approach
`this.props.balnce` was a overall calculated amount for all user fee/fines.
When we use `New staff info`, we update currnet fee/fine, so overall balance is not what we need.
`account.remaining` - is correct field.
I tested new behaviour with all posible actions - everything looks fine. 

## Refs
https://issues.folio.org/browse/UIU-2506

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/88130496/150777611-d07705f6-a87b-46ab-88a0-0128bd153b78.png)

Аfter:
![image](https://user-images.githubusercontent.com/88130496/150777881-a0b52151-0f48-4fac-82f9-ab7490f4dd90.png)