### PR TITLE
UIU-2498: calculation expiration date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,12 @@
 * Also support `request-storage` `4.0` (TLR). Refs UIU-2495, UIU-2480.
 * Fix problems with permissions for claim returned, renewals. Refs UIU-2256.
 * Settings > Users > change focus. Refs UIU-2036.
-* Correct calcualtion for expiration date. Refs UIU-2498.
 * Add custom fields filters. Refs UIU-2170.
 * Properly show service point name in fee/fine details. Fixes UIU-2473.
 * Suppress edit of users stored in a configuration entry. Refs UIU-2499.
 * Also support `circulation` `13.0`. Refs UIU-2483.
 * Fix unexpected increase of fee/fine remaining balance. Refs UIU-2506.
+* Correct calcualtion for expiration date. Refs UIU-2498.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 * Suppress edit of users stored in a configuration entry. Refs UIU-2499.
 * Also support `circulation` `13.0`. Refs UIU-2483.
 * Fix unexpected increase of fee/fine remaining balance. Refs UIU-2506.
-* Correct calcualtion for expiration date. Refs UIU-2498.
+* Correct calculation for expiration date. Refs UIU-2498.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -63,18 +63,26 @@ class EditUserInfo extends React.Component {
     this.setState({ showRecalculateModal: false });
   }
 
-  setRecalculatedExpirationDate = () => {
+  setRecalculatedExpirationDate = (startCalcToday) => {
     const { form: { change } } = this.props;
-    const recalculatedDate = this.calculateNewExpirationDate();
+    const recalculatedDate = this.calculateNewExpirationDate(startCalcToday);
 
     change('expirationDate', recalculatedDate);
     this.setState({ showRecalculateModal: false });
   }
 
-  calculateNewExpirationDate = () => {
+  calculateNewExpirationDate = (startCalcToday) => {
+    const { initialValues } = this.props;
+    const expirationDate = new Date(initialValues.expirationDate);
+    const now = Date.now();
     const offsetOfSelectedPatronGroup = this.state.selectedPatronGroup ? this.getPatronGroupOffset() : '';
-
-    return moment().add(offsetOfSelectedPatronGroup, 'd').format('YYYY-MM-DD');
+    let recalculatedDate;
+    if (startCalcToday || initialValues.expirationDate === undefined || expirationDate <= now) {
+      recalculatedDate = (moment().add(offsetOfSelectedPatronGroup, 'd').format('YYYY-MM-DD'));
+    } else {
+      recalculatedDate = (moment(expirationDate).add(offsetOfSelectedPatronGroup, 'd').format('YYYY-MM-DD'));
+    }
+    return recalculatedDate;
   }
 
   getPatronGroupOffset = () => {
@@ -157,13 +165,13 @@ class EditUserInfo extends React.Component {
 
     const offset = this.getPatronGroupOffset();
     const group = _.get(this.props.patronGroups.find(i => i.id === this.state.selectedPatronGroup), 'group', '');
-    const date = moment(this.calculateNewExpirationDate()).format('LL');
+    const date = moment(this.calculateNewExpirationDate(true)).format('LL');
 
     const modalFooter = (
       <ModalFooter>
         <Button
           id="expirationDate-modal-recalculate-btn"
-          onClick={this.setRecalculatedExpirationDate}
+          onClick={() => this.setRecalculatedExpirationDate(true)}
         >
           <FormattedMessage id="ui-users.information.recalculate.modal.button" />
         </Button>
@@ -290,7 +298,7 @@ class EditUserInfo extends React.Component {
               {checkShowRecalculateButton() && (
                 <Button
                   id="recalculate-expirationDate-btn"
-                  onClick={this.setRecalculatedExpirationDate}
+                  onClick={() => this.setRecalculatedExpirationDate(false)}
                 >
                   <FormattedMessage id="ui-users.information.recalculate.expirationDate" />
                 </Button>
@@ -315,6 +323,7 @@ class EditUserInfo extends React.Component {
           open={this.state.showRecalculateModal}
         >
           <div>
+            das wird nur bei patron group gezeigt
             <FormattedMessage
               id="ui-users.information.recalculate.modal.text"
               values={{ group, offset, date }}

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -323,7 +323,6 @@ class EditUserInfo extends React.Component {
           open={this.state.showRecalculateModal}
         >
           <div>
-            das wird nur bei patron group gezeigt
             <FormattedMessage
               id="ui-users.information.recalculate.modal.text"
               values={{ group, offset, date }}


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2498


**Overview:** 
With UXPROD-2389, a default expiration date can be filled in when a new user is created, a user is changed from inactive to active, re-set or, the case here, a patron group is changed.

The default expiartion period for the patron group is either added to the current expiration date or the current date. 

In the case of a change of patron group, it should be added to the current date.

**Steps to Reproduce:**
1.  Set default expiration date for a patron group X.
2. Open a user with a set expiration date.
3. Change the patron group

**Expected Results:**
The expiration date should be changed to expiration date = today + expiration period.

**Actual Results:**
It is changed to expiration date = current expiration date + expiration period.

**Additional Information:**
 See Uschis comment (https://issues.folio.org/browse/UXPROD-2389?focusedCommentId=116868&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-116868). 


**Case 1: new User**
expiration date = today + expiration period

**Case 2/3: set inactive / set active**
expiration date does not change

**Case 4: Change Patron group**
should not be: expiration date = current expiration date + expiration period
should be like new user: expiration date = today + expiration period

**Case 5: Click Re-set**
expiration date = current expiration date + expiration period 
For Click Re-set see also:
https://issues.folio.org/browse/UIU-2046
(1) Current expiration date is in the past
-> calculate from today
(2) current expiration date is in the future or today
-> calculate from given expiration date
