### PR TITLE
UIU-2508: Fee/Fine Type not showing/saving for first manual fee/fine …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Correct calculation for expiration date. Refs UIU-2498.
 * Preserve invisible permissions during edit. Fixes UIU-2075.
 * Column selector dropdown does not match column headings. Refs UIU-2504.
+* Fee/Fine Type not showing/saving for first manual fee/fine created. Refs UIU-2508.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -111,7 +111,7 @@ class ChargeFeeFine extends React.Component {
 
   onFormAccountData(type) {
     const owners = _.get(this.props.resources, ['owners', 'records'], []);
-    const feefines = _.get(this.props.resources, ['feefines', 'records'], []);
+    const feefines = _.get(this.props.resources, ['allfeefines', 'records'], []);
     const selectedLoan = this.props.selectedLoan || {};
     const { intl: { formatMessage } } = this.props;
     const item = (selectedLoan.id) ? selectedLoan.item : this.item;
@@ -439,17 +439,19 @@ class ChargeFeeFine extends React.Component {
       pay,
     } = this.state;
     this.item = _.get(resources, ['items', 'records', [0]], {});
-    const allfeefines = _.get(resources, ['allfeefines', 'records'], []);
+    const feefines = _.get(resources, ['allfeefines', 'records'], []);
     const owners = _.get(resources, ['owners', 'records'], []);
     const list = [];
     const shared = owners.find(o => o.owner === 'Shared');
-    allfeefines.forEach(f => {
+    feefines.forEach(f => {
       if (!list.find(o => (o || {}).id === f.ownerId)) {
         const owner = owners.find(o => (o || {}).id === f.ownerId);
-        if (owner !== undefined) { list.push(owner); }
+
+        if (owner) {
+          list.push(owner);
+        }
       }
     });
-    const feefines = _.get(resources, ['allfeefines', 'records'], []);
     const payments = _.get(resources, ['payments', 'records'], []);
     const accounts = _.get(resources, ['accounts', 'records'], []);
     const settings = _.get(resources, ['commentRequired', 'records', 0], {});
@@ -477,7 +479,7 @@ class ChargeFeeFine extends React.Component {
 
     const isPending = {
       owners: _.get(resources, ['owners', 'isPending'], false),
-      feefines: _.get(resources, ['feefines', 'isPending'], false),
+      feefines: _.get(resources, ['allfeefines', 'isPending'], false),
       servicePoints: _.get(resources, ['curUserServicePoint', 'isPending'], true)
     };
 

--- a/src/components/PermissionsAccordion/PermissionsAccordion.js
+++ b/src/components/PermissionsAccordion/PermissionsAccordion.js
@@ -68,7 +68,7 @@ const PermissionsAccordion = (props) => {
    * callback from the ConfirmationModal to continue with editing permissions
    * even though this means permissions with `visible: false` settings will
    * be removed.
-   * 
+   *
    *
    * See openPermissionsModal for a detailed explanation.
    */
@@ -96,7 +96,7 @@ const PermissionsAccordion = (props) => {
    * permissions will be retained after editing (confirmation is handled by
    * confirmEdit and cancelEdit). If there are not any, i.e. all currently-assigned
    * permissions are `visible: true`, open PermissionModal.
-   * 
+   *
    * UPDATE: With the work done for UIU-2075, invisible permissions are no
    * longer removed, so showing the ConfirmationModal isn't necessary. Since we might
    * have need of a confirmation step in the future, leave the code in place for now;

--- a/src/components/PermissionsAccordion/PermissionsAccordion.test.js
+++ b/src/components/PermissionsAccordion/PermissionsAccordion.test.js
@@ -113,7 +113,7 @@ describe('PermissionsAccordion', () => {
     });
 
     // NOTE: The 'visible: false permissions' tests are being skipped because the
-    // confirmation modal is now being skipped in the actual code (because it's 
+    // confirmation modal is now being skipped in the actual code (because it's
     // not needed for the time being).
     describe.skip('when "visible: false" permissions are also assigned', () => {
       test('shows prompt', async () => {


### PR DESCRIPTION
## Purpose
Fee/Fine Type not showing/saving for first manual fee/fine created

## Approach
Wrong resource was used to calculate [fee fine type](https://github.com/folio-org/ui-users/blob/b10a8d4e5dfcc3ae04906a2df17ababeadb07971/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js#L126)

There are two resources `feefines` and `allfeefines`.
`allfeefines` is used to get all `fee fine types` and to populate `fee fine type` dropdown.
`feefines` is used to get `fee fine types` based on selected `fee fine owner`. Also it is used to calculate selected `fee fine type`.

We should use `allfeefines` resource to calculate selected `fee fine type` instead of `feefines` resource because `feefines` resource sometimes returns empty array in case when you open page to create new manual fee fine and you do not change `fee fine owner` dropdown value and this dropdown has selected value by default. As for `allfeefines` resource it does not care if you changed `fee fine owner` dropdown value or not, this resource just returns list of all fee fines we have on backend side.

## Refs
https://issues.folio.org/browse/UIU-2508