### PR TITLE
UIU-2510 retrieve up to 50 proxies/sponsors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Correct calculation for expiration date. Refs UIU-2498.
 * Preserve invisible permissions during edit. Fixes UIU-2075.
 * Column selector dropdown does not match column headings. Refs UIU-2504.
+* Retrieve up to 50 proxies/sponsors. Refs UIU-2510.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/Wrappers/withProxy.js
+++ b/src/components/Wrappers/withProxy.js
@@ -141,13 +141,14 @@ const withProxy = WrappedComponent => class WithProxyComponent extends React.Com
       const resource = mutator[resourceName];
       const resourceFor = mutator[`${resourceName}For`];
       const query = `(${queryKey}=="${userId}")`;
+      const limit = '50';
       if (resources[resourceName] && !resources[resourceName].isPending) {
         resourceFor.reset();
         resource.reset();
-        resourceFor.GET({ params: { query } }).then((recordsFor) => {
+        resourceFor.GET({ params: { query, limit } }).then((recordsFor) => {
           if (!recordsFor.length) return;
           const ids = recordsFor.map(pf => `id=="${pf[recordKey]}"`).join(' or ');
-          resource.GET({ params: { query: `(${ids})` } });
+          resource.GET({ params: { query: `(${ids})`, limit } });
         });
       }
     }


### PR DESCRIPTION
Without a `limit` clause, the previous implementation defaulted to only
10 records. It wasn't enough. A more robust implementation would
implement paging, but we may be able to squeak by with 50 as that seems
likely to be the upper bound, and it's certainly a quick-fix.

Refs [UIU-2510](https://issues.folio.org/browse/UIU-2510)