### PR TITLE
UIU-2520 retrieve more than 10 loan policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Column selector dropdown does not match column headings. Refs UIU-2504.
 * Fee/Fine Type not showing/saving for first manual fee/fine created. Refs UIU-2508.
 * Add Jest/RTL tests for `CommentModal` business logic in `FeeFineActions` component. Refs UIU-2515.
+* Add `limit` clauses to `withRenew` queries to enable retrieval of more than 10 records. Refs UIU-2520.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/Wrappers/withRenew.js
+++ b/src/components/Wrappers/withRenew.js
@@ -11,7 +11,6 @@ import BulkRenewalDialog from '../BulkRenewalDialog';
 import isOverridePossible from '../Loans/OpenLoans/helpers/isOverridePossible';
 import {
   requestStatuses,
-  MAX_RECORDS,
   OVERRIDE_BLOCKS_FIELDS,
 } from '../../constants';
 
@@ -265,13 +264,12 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
 
     for (let i = 0; i < loans.length; i += step) {
       const loansSlice = loans.slice(i, i + step);
-      const q = loansSlice
+      const itemIdList = loansSlice
         .filter(loan => loan.itemId)
-        .map(loan => loan.itemId)
-        .join(' or ');
-      const query = `(itemId==(${q})) and status==(${statusList}) sortby requestDate desc`;
+        .map(loan => loan.itemId);
+      const query = `(itemId==(${itemIdList.join(' or ')})) and status==(${statusList}) sortby requestDate desc`;
       reset();
-      GET({ params: { query, limit: MAX_RECORDS } })
+      GET({ params: { query, limit: itemIdList.length } })
         .then((requestRecords) => {
           const requestCountObject = requestRecords.reduce((map, record) => {
             map[record.itemId] = map[record.itemId]
@@ -308,12 +306,12 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
     // the same policy; we only need to retrieve that policy once.
     const ids = [...new Set(this.state.loans
       .filter(loan => loan.loanPolicyId)
-      .map(loan => loan.loanPolicyId))]
-      .join(' or ');
+      .map(loan => loan.loanPolicyId))];
+    const query = `id==(${ids.join(' or ')})`;
 
     if (ids.length) {
       reset();
-      GET({ params: { query: `id==(${ids})` } })
+      GET({ params: { query, limit: `${ids.length}` } })
         .then((loanPolicies) => {
           const loanPolicyObject = loanPolicies.reduce((map, loanPolicy) => {
             map[loanPolicy.id] = loanPolicy.name;


### PR DESCRIPTION
Without an explicit `limit` clause, API queries will retrieve only 10
records. This change does not address the latent/potential too-long-query
problem if a patron has loans affiliated with > ~50 policies, but > 50
seems less likely to occur than > 10.

AFAIK, no tenants have hit either limitation in production, but thinking
about [MODUSERS-303](https://issues.folio.org/browse/MODUSERS-303) got me thinking about it.

Refs [UIU-2520](https://issues.folio.org/browse/UIU-2520)