### PR TITLE
UIU-2496: Fix problems with permissions duplication in PermissionsModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * Column selector dropdown does not match column headings. Refs UIU-2504.
 * Fee/Fine Type not showing/saving for first manual fee/fine created. Refs UIU-2508.
 * Add Jest/RTL tests for `CommentModal` business logic in `FeeFineActions` component. Refs UIU-2515.
-* Prevent duplication of permissions in `PermissionsModal` and related logic. Fixes UIU-2486, UIU-2496.
+* Prevent duplication of permissions in `<PermissionsModal>` and related logic. Fixes UIU-2486, UIU-2496.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Column selector dropdown does not match column headings. Refs UIU-2504.
 * Fee/Fine Type not showing/saving for first manual fee/fine created. Refs UIU-2508.
 * Add Jest/RTL tests for `CommentModal` business logic in `FeeFineActions` component. Refs UIU-2515.
+* Prevent duplication of permissions in `PermissionsModal` and related logic. Fixes UIU-2486, UIU-2496.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -117,7 +117,7 @@ class PermissionsModal extends React.Component {
       filterPaneIsVisible: true,
       permissions: [],
       filters: getInitialFiltersState(props.filtersConfig),
-      assignedPermissionIds: props.assignedPermissions.map(({ id }) => id)
+      assignedPermissionIds: []
     };
   }
 
@@ -139,7 +139,10 @@ class PermissionsModal extends React.Component {
     // don't set state if the component has unmounted,
     // which it may have since this function is async
     if (this._isMounted) {
-      this.setState({ permissions });
+      this.setState({
+        permissions,
+        assignedPermissionIds: this.props.assignedPermissions.map(({ id }) => id)
+      });
     }
   }
 

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -113,10 +113,17 @@ class PermissionsModal extends React.Component {
     this._isMounted = false;
 
     this.state = {
-      filterPaneIsVisible: true,
+      // There are two 'permissions' vars in play here:
+      // `allPermissions` is intended to be a fixed copy of the records from the
+      // availablePermissions resource. Using this as a source of truth prevents
+      // the permissions duplication problem specified in UIU-2496.
+      // `permissions` begins as a second copy of the resource records, but it can
+      // change in response to a search query.
+      allPermissions: [],
       permissions: [],
-      filters: getInitialFiltersState(props.filtersConfig),
-      assignedPermissionIds: []
+      assignedPermissionIds: [],
+      filterPaneIsVisible: true,
+      filters: getInitialFiltersState(props.filtersConfig)
     };
   }
 

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  get,
   mapKeys,
   pickBy,
   remove,
@@ -140,6 +139,7 @@ class PermissionsModal extends React.Component {
     // which it may have since this function is async
     if (this._isMounted) {
       this.setState({
+        allPermissions: permissions,
         permissions,
         assignedPermissionIds: this.props.assignedPermissions.map(({ id }) => id)
       });
@@ -152,7 +152,7 @@ class PermissionsModal extends React.Component {
 
   // Search for permissions
   onSubmitSearch = (searchText) => {
-    const permissions = this.props.resources?.availablePermissions?.records || [];
+    const permissions = this.state.allPermissions || [];
     // Need a bit of extra work to search for terms that might appear only in a translated label
     const translationResults = this.getMatchedTranslations(searchText, permissions);
 
@@ -240,14 +240,16 @@ class PermissionsModal extends React.Component {
   };
 
   onSave = () => {
-    const { assignedPermissionIds } = this.state;
+    const {
+      allPermissions,
+      assignedPermissionIds,
+    } = this.state;
     const {
       addPermissions,
       assignedPermissions,
       onClose,
     } = this.props;
-    const permissions = get(this.props, 'resources.availablePermissions.records', []);
-    const filteredPermissions = permissions.filter(({ id }) => assignedPermissionIds.includes(id));
+    const filteredPermissions = allPermissions.filter(({ id }) => assignedPermissionIds.includes(id));
 
     // Invisible permissions assigned to a user are lost in the permissions selection process,
     // so we want to make sure that they get saved along with any visible selections. This renders
@@ -276,7 +278,7 @@ class PermissionsModal extends React.Component {
   };
 
   resetSearchForm = () => {
-    const permissions = get(this.props, 'resources.availablePermissions.records', []);
+    const permissions = this.state.allPermissions || [];
 
     this.setState({
       filters: {},

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -285,12 +285,14 @@ class PermissionsModal extends React.Component {
   };
 
   resetSearchForm = () => {
-    const permissions = this.state.allPermissions || [];
+    this.setState(prevState => {
+      const permissions = prevState.allPermissions || [];
 
-    this.setState({
-      filters: {},
-      permissions,
-      assignedPermissionIds: this.props.assignedPermissions.map(({ id }) => id),
+      return ({
+        filters: {},
+        permissions,
+        assignedPermissionIds: this.props.assignedPermissions.map(({ id }) => id)
+      });
     });
   };
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2486
https://issues.folio.org/browse/UIU-2496

Most of the bugs and weird behaviors around permissions selection and assignment in `<PermissionsModal>` were the result of double-dipping from the `availablePermissions` resource. I've fixed this by adding a new state variable to hold the complete list of permissions; the existing state `permissions` variable actually changes during searches, which was confusing the issue.

I've also fixed another (unreported?) bug: when the modal was opened for a user who already had assigned permissions, none of the assigned perms were checked/selected. Then, unless you carefully re-selected all of the extant assignments before saving, you'd lose the old ones because they weren't selected in the list. (I hadn't realized at first that that _was_ a bug and thought it was by design, so I found the behavior baffling!)