### PR TITLE
UIU-2492 don't choke when item record is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Column selector dropdown does not match column headings. Refs UIU-2504.
 * Fee/Fine Type not showing/saving for first manual fee/fine created. Refs UIU-2508.
 * Add Jest/RTL tests for `CommentModal` business logic in `FeeFineActions` component. Refs UIU-2515.
+* Handle display of loans whose item-records have been deleted. Refs UIU-2492.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/Loans/OpenLoans/OpenLoansControl.js
+++ b/src/components/Loans/OpenLoans/OpenLoansControl.js
@@ -293,17 +293,14 @@ class OpenLoansControl extends React.Component {
   };
 
   parseContributors(record) {
-    const {
-      item,
-      item: { contributors },
-    } = record;
+    const { item } = record;
 
-    return isArray(contributors) ?
+    return isArray(item?.contributors) ?
       {
         ...record,
         item: {
           ...item,
-          contributors: contributors
+          contributors: item.contributors
             .map((currentContributor) => currentContributor.name)
             .join('; ')
         }

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -21,6 +21,7 @@ import {
 } from '../../../../util';
 
 import { itemStatuses } from '../../../../../constants';
+import ItemDetailsOption from './ItemDetailsOption';
 
 class ActionsDropdown extends React.Component {
   static propTypes = {
@@ -50,21 +51,13 @@ class ActionsDropdown extends React.Component {
     } = this.props;
 
     const itemStatusName = loan?.item?.status?.name;
-    const itemDetailsLink = `/inventory/view/${loan.item.instanceId}/${loan.item.holdingsRecordId}/${loan.itemId}`;
     const loanPolicyLink = `/settings/circulation/loan-policies/${loan.loanPolicyId}`;
     const buttonDisabled = !stripes.hasPerm('ui-users.feesfines.actions.all');
     const isUserActive = checkUserActive(user);
 
     return (
       <DropdownMenu data-role="menu">
-        <IfPermission perm="inventory.items.item.get">
-          <Button
-            buttonStyle="dropdownItem"
-            to={itemDetailsLink}
-          >
-            <FormattedMessage id="ui-users.itemDetails" />
-          </Button>
-        </IfPermission>
+        <ItemDetailsOption loan={loan} />
         <IfPermission perm="ui-users.loans.renew">
           { isUserActive && itemStatusName !== itemStatuses.CLAIMED_RETURNED &&
           <Button

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ItemDetailsOption.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ItemDetailsOption.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { Button } from '@folio/stripes/components';
+import { IfPermission } from '@folio/stripes/core';
+
+const ItemDetailsOption = ({ loan }) => {
+  const itemDetailsLink = `/inventory/view/${loan.item?.instanceId}/${loan.item?.holdingsRecordId}/${loan.itemId}`;
+
+  return loan.item?.instanceId ? (
+    <IfPermission perm="inventory.items.item.get">
+      <Button
+        buttonStyle="dropdownItem"
+        to={itemDetailsLink}
+      >
+        <FormattedMessage id="ui-users.itemDetails" />
+      </Button>
+    </IfPermission>
+  )
+    :
+    <></>;
+};
+
+ItemDetailsOption.propTypes = {
+  loan: PropTypes.shape({
+    item: PropTypes.shape({
+      instanceId: PropTypes.string,
+      holdingsRecordId: PropTypes.string,
+    }),
+    itemId: PropTypes.string,
+  })
+};
+
+
+export default ItemDetailsOption;

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ItemDetailsOption.test.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ItemDetailsOption.test.js
@@ -1,0 +1,63 @@
+import { screen } from '@testing-library/react';
+
+
+import { IfPermission } from '@folio/stripes/core';
+
+//  import '__mock__/stripesCore.mock';
+import '__mock__/stripesSmartComponent.mock';
+import renderWithRouter from 'helpers/renderWithRouter';
+
+import ItemDetailsOption from './ItemDetailsOption';
+
+jest.unmock('@folio/stripes/components');
+
+const renderItemDetailsOption = (props) => renderWithRouter(<ItemDetailsOption {...props} />);
+
+describe('ItemDetailsOption component', () => {
+  describe('with permission', () => {
+    beforeEach(() => {
+      IfPermission.mockImplementation(({ _, children }) => children);
+    });
+    it('With loan item', () => {
+      const props = {
+        loan: {
+          item: {
+            instanceId: 'foo'
+          }
+        }
+      };
+
+      renderItemDetailsOption(props);
+      expect(screen.getByText('ui-users.itemDetails')).toBeTruthy();
+    });
+
+    it('Without loan item', () => {
+      const props = {
+        loan: {
+        }
+      };
+
+      renderItemDetailsOption(props);
+      expect(screen.queryByText('ui-users.itemDetails')).toBeFalsy();
+    });
+  });
+
+  describe('without permission', () => {
+    beforeEach(() => {
+      IfPermission.mockImplementation(() => null);
+    });
+
+    it('Without permission', () => {
+      const props = {
+        loan: {
+          item: {
+            instanceId: 'foo'
+          }
+        }
+      };
+
+      renderItemDetailsOption(props);
+      expect(screen.queryByText('ui-users.itemDetails')).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
Sometimes an item record for an active loan may be inadvertently
deleted. The display should not choke under that circumstance.

Refs [UIU-2492](https://issues.folio.org/browse/UIU-2492)