### PR TITLE
UIU-1695 Accessibility: Headings must not be empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Preserve search filters during user edit. Fixes UIU-2484.
 * Retrieve up to 50 proxies/sponsors. Refs UIU-2510.
 * Open Loans List: Form does not include label. Refs UIU-1638.
+* Accessibility: Headings must not be empty. Refs UIU-1695.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -329,13 +329,15 @@ class UserForm extends React.Component {
               onClose={onCancel}
               defaultWidth="fill"
             >
-              <Headline
-                size="xx-large"
-                tag="h2"
-                data-test-header-title
-              >
-                {fullName}
-              </Headline>
+              {fullName && (
+                <Headline
+                  size="xx-large"
+                  tag="h2"
+                  data-test-header-title
+                >
+                  {fullName}
+                </Headline>
+              )}
               <AccordionStatus ref={this.accordionStatusRef}>
                 <Row end="xs">
                   <Col xs>


### PR DESCRIPTION
Refs https://issues.folio.org/browse/UIU-1695
Approach: don't render empty component when it's redundant