### PR TITLE
UIU-2484: Preserve search filters during user edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Add Jest/RTL tests for `CommentModal` business logic in `FeeFineActions` component. Refs UIU-2515.
 * Add `limit` clauses to `withRenew` queries to enable retrieval of more than 10 records. Refs UIU-2520.
 * Accessibility: Document has multiple static elements with the same ID attribute. Refs UIU-1688.
+* Preserve search filters during user edit. Fixes UIU-2484.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -489,8 +489,8 @@ class UserDetail extends React.Component {
   checkScope = () => true;
 
   goToEdit = () => {
-    const { history, match: { params } } = this.props;
-    history.push(`/users/${params.id}/edit`);
+    const { history, location: { search }, match: { params } } = this.props;
+    history.push(`/users/${params.id}/edit${search}`);
   }
 
   shortcuts = [


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2484

Not much to say about this one; the `location.search` was being lost when edit mode was entered.