### PR TITLE
UIU-1638: Open Loans List: Form does not include label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Add Jest/RTL tests for `CommentModal` business logic in `FeeFineActions` component. Refs UIU-2515.
 * Add `limit` clauses to `withRenew` queries to enable retrieval of more than 10 records. Refs UIU-2520.
 * Accessibility: Document has multiple static elements with the same ID attribute. Refs UIU-1688.
+* Open Loans List: Form does not include label. Refs UIU-1638.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.js
@@ -153,6 +153,7 @@ class OpenLoansWithStaticData extends React.Component {
               type="checkbox"
               checked={allChecked}
               name="check-all"
+              aria-label="Select all loans"
               onChange={toggleAll}
             />
           );

--- a/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.js
@@ -133,6 +133,7 @@ class OpenLoansWithStaticData extends React.Component {
   };
 
   getColumnMapping = () => {
+    const { intl:{ formatMessage } } = this.props;
     return Object.keys(this.tableData).reduce(
       (columnMapping, objKey) => {
         const {
@@ -153,7 +154,7 @@ class OpenLoansWithStaticData extends React.Component {
               type="checkbox"
               checked={allChecked}
               name="check-all"
-              aria-label="Select all loans"
+              aria-label={formatMessage({ id: 'ui-users.loans.selectAllLoans' })}
               onChange={toggleAll}
             />
           );

--- a/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
+++ b/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
@@ -34,7 +34,7 @@ export default function getListDataFormatter(
           onClick={e => toggleItem(e, loan)}
           onChange={e => toggleItem(e, loan)}
           type="checkbox"
-          aria-label="Select loan"
+          aria-label={formatMessage({ id: 'ui-users.loans.rows.select' })}
         />
       ),
     },

--- a/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
+++ b/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
@@ -34,6 +34,7 @@ export default function getListDataFormatter(
           onClick={e => toggleItem(e, loan)}
           onChange={e => toggleItem(e, loan)}
           type="checkbox"
+          aria-label="Select loan"
         />
       ),
     },

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -108,6 +108,8 @@
   "loans.history": "Loan action history",
   "loans.resolveClaim": "Resolve claim",
   "loans.action.source.system": "System",
+  "loans.rows.select": "Select loan",
+  "loans.selectAllLoans": "Select all loans",
   "settings.label": "Users",
   "settings.general": "General",
   "settings.feefine": "Fee/fine",


### PR DESCRIPTION
## Purpose
- Open Loans List: Form does not include label.

## Approach
- Add `aria-label` attribute to `input` elements.

## Refs
- https://issues.folio.org/browse/UIU-1638

## Screenshot
<img src="https://user-images.githubusercontent.com/89512426/153600398-36d56f6e-c672-4e02-baab-7f34e95d7af6.png" width="250" height="200" />