### PR TITLE
UIU-2500: Display preferred name in the search result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Prevent duplication of permissions in `<PermissionsModal>` and related logic. Fixes UIU-2486, UIU-2496.
 * Add Service Point modal: Ensure every form element has label. Refs UIU-1699.
 * Create/Edit Patron Blocks: Required fields are not using the right prop and cannot be read by screenreader. Refs UIU-1688.
+* Display preferred name in the search result. Refs UIU-2500.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -51,9 +51,14 @@ const VISIBLE_COLUMNS_STORAGE_KEY = 'users-visible-columns';
 const NON_TOGGLEABLE_COLUMNS = ['name'];
 
 function getFullName(user) {
-  const lastName = get(user, ['personal', 'lastName'], '');
-  const firstName = get(user, ['personal', 'firstName'], '');
-  const middleName = get(user, ['personal', 'middleName'], '');
+  let firstName = user?.personal?.firstName ?? '';
+  const lastName = user?.personal?.lastName ?? '';
+  const middleName = user?.personal?.middleName ?? '';
+  const preferredFirstName = user?.personal?.preferredFirstName ?? '';
+
+  if (preferredFirstName && firstName) {
+    firstName = `${preferredFirstName} (${firstName})`;
+  }
 
   return `${lastName}${firstName ? ', ' : ' '}${firstName} ${middleName}`;
 }


### PR DESCRIPTION
## Purpose
- Display preferred name in the search result
- If user has `preferredFirstName` then display `LastName`, `PreferredFirstName` `(FirstName)` `MiddleName` in result list
- if user doesn't have  `preferredFirstName` then display `LastName`, `FirstName` `MiddleName` in result list
- Refs: https://issues.folio.org/browse/UIU-2500

## Approach
- Refactor `getFullName` function to include `preferredFirstName`

## Screenshots
<img src="https://user-images.githubusercontent.com/89512426/154673571-9859ef78-9fa6-4c44-b7c6-bf860f744b53.png" width="200" height="150" />