### PR TITLE
UIU-2501 - Display preferred name in the header and body of the user record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
 * Add Service Point modal: Ensure every form element has label. Refs UIU-1699.
 * Create/Edit Patron Blocks: Required fields are not using the right prop and cannot be read by screenreader. Refs UIU-1688.
 * Display preferred name in the search result. Refs UIU-2500.
+* Display preferred name in the header and body of the user record. Refs UIU-2501.
+* Display preferred name in the top of the edit view of the user record. Refs UIU-2502.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -11,13 +11,14 @@ import {
 /**
  * getFullName
  * return "last, first middle", derived from user.personal.
+ * preferred first name should be shown instead first name if present
  *
  * @param {object} user
  * @returns string
  */
 export function getFullName(user) {
   let fullName = user?.personal?.lastName ?? '';
-  let givenName = user?.personal?.firstName ?? '';
+  let givenName = user?.personal?.preferredFirstName ?? user?.personal?.firstName ?? '';
   const middleName = user?.personal?.middleName ?? '';
   if (middleName) {
     givenName += `${givenName ? ' ' : ''}${middleName}`;

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -10,8 +10,8 @@ import {
 
 /**
  * getFullName
- * return "last, first middle", derived from user.personal.
- * preferred first name should be shown instead first name if present
+ * return "last, first middle", derived from user.personal
+ * preferred first name should be shown instead first name if present.
  *
  * @param {object} user
  * @returns string

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -116,8 +116,22 @@ describe('getChargeFineToLoanPath', () => {
 describe('getFullName', () => {
   const firstName = 'John';
   const middleName = 'Jacob';
+  const preferredFirstName = 'Johnnie';
   const lastName = 'Jingle-Heimer-Schmidt';
   it('handles all names', () => {
+    const user = {
+      personal: {
+        firstName,
+        preferredFirstName,
+        middleName,
+        lastName,
+      },
+    };
+
+    expect(getFullName(user)).toBe(`${lastName}, ${preferredFirstName} ${middleName}`);
+  });
+
+  it('handles missing preferred first name', () => {
     const user = {
       personal: {
         firstName,


### PR DESCRIPTION
UIU-2502 - Display preferred name in the top of the edit view of the user record.
## Description
When a staff member searches for a user name, and selects a user record, the record header and the large display of the name lists the lastname, first name, and middle name or initial, regardless of whether the patron has selected a preferred first name.

In scope Revise the display to include preferred first name, so the result is Lastname, PreferredFirstName MiddleName

## Refs
https://issues.folio.org/browse/UIU-2501
https://issues.folio.org/browse/UIU-2502