### PR TITLE
UIU-1161: Newly created address record should be in focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * Display preferred name in the search result. Refs UIU-2500.
 * Display preferred name in the header and body of the user record. Refs UIU-2501.
 * Display preferred name in the top of the edit view of the user record. Refs UIU-2502.
+* Newly Created Address Record Should be In Focus. Refs UIU-1161.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.js
@@ -42,6 +42,7 @@ const EditContactInfo = ({
       props: {
         dataOptions: toAddressTypeOptions(addressTypes),
         fullWidth: true,
+        autoFocus: true,
         placeholder: intl.formatMessage({ id: 'ui-users.contact.selectAddressType' }),
       },
     },


### PR DESCRIPTION
## Purpose
- Newly created `address` record should be in focus
- Refs: https://issues.folio.org/browse/UIU-1161

## Approach
- Add `autoFocus` prop to `Select` component to move focus on it on `mount`