### PR TITLE
UIU-1257: Focus should be on pane header title when Loans list is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Display preferred name in the header and body of the user record. Refs UIU-2501.
 * Display preferred name in the top of the edit view of the user record. Refs UIU-2502.
 * Newly Created Address Record Should be In Focus. Refs UIU-1161.
+* Keyboard Navigation: Accessing open loans/closed loans list : Initial focus should be on an element on the page. Refs UIU-1257.
 
 ## [7.0.1](https://github.com/folio-org/ui-users/tree/v7.0.1) (2021-10-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v6.1.0...v7.0.1)

--- a/src/views/LoansListing/LoansListing.js
+++ b/src/views/LoansListing/LoansListing.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React from 'react';
+import React, { createRef } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -29,7 +29,16 @@ class LoansListing extends React.Component {
     match: PropTypes.object,
   };
 
-  /**
+    // eslint-disable-next-line react/sort-comp
+    paneTitleRef = createRef();
+
+    componentDidMount() {
+      if (this.paneTitleRef.current) {
+        this.paneTitleRef.current.focus();
+      }
+    }
+
+    /**
    * Segmented Control to swtich between open and closed loans
    */
   getSegmentedControls = () => {
@@ -99,6 +108,7 @@ class LoansListing extends React.Component {
           defaultWidth="100%"
           dismissible
           onClose={this.handleClose}
+          paneTitleRef={this.paneTitleRef}
           paneTitle={(
             <FormattedMessage id="ui-users.loans.title">
               {(title) => `${title} - ${getFullName(user)} (${_.upperFirst(patronGroup.group)})`}

--- a/src/views/LoansListing/LoansListing.js
+++ b/src/views/LoansListing/LoansListing.js
@@ -29,16 +29,19 @@ class LoansListing extends React.Component {
     match: PropTypes.object,
   };
 
-    // eslint-disable-next-line react/sort-comp
-    paneTitleRef = createRef();
+  constructor(props) {
+    super(props);
 
-    componentDidMount() {
-      if (this.paneTitleRef.current) {
-        this.paneTitleRef.current.focus();
-      }
+    this.paneTitleRef = createRef();
+  }
+
+  componentDidMount() {
+    if (this.paneTitleRef.current) {
+      this.paneTitleRef.current.focus();
     }
+  }
 
-    /**
+  /**
    * Segmented Control to swtich between open and closed loans
    */
   getSegmentedControls = () => {


### PR DESCRIPTION
## Purpose
- Currently when you access the Open/Closed Loans list, the initial focus is outside the page.
- Requirement: initial focus should be on pane header title.
- Refs: https://issues.folio.org/browse/UIU-1257

## Approach
- Pass `paneTitleRef` prop to `Pane` component to move focus on pane header on `Mount`
