### PR TITLE
UIU-2541 warn if user-edit actions fail

### DIFF
--- a/src/views/UserEdit/UserEditHelpers.js
+++ b/src/views/UserEdit/UserEditHelpers.js
@@ -1,0 +1,45 @@
+import { FormattedMessage } from 'react-intl';
+
+export function resourcesLoaded(obj, exceptions = []) {
+  for (const resource in obj) {
+    if (!exceptions.includes(resource)) {
+      if (Object.prototype.hasOwnProperty.call(obj, resource)) {
+        if (obj[resource] === null) {
+          return false;
+        }
+        if (typeof obj[resource] === 'object') {
+          if (Object.prototype.hasOwnProperty.call(obj[resource], 'isPending')) {
+            if (obj[resource].isPending) {
+              return false;
+            }
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * showErrorCallout
+ * Show an error in a callout.
+ * Set the timeout to 0 so it must be manually dismissed.
+ *
+ * @param {object} res HTTP response object from a rejected Promise
+ * @param {function} sendCallout function reference, likely this.context.sendCallout
+ */
+export function showErrorCallout(res, sendCallout) {
+  res.text()
+    .then(body => {
+      sendCallout({
+        type: 'error',
+        timeout: 0,
+        message: (
+          <div>
+            <div><strong><FormattedMessage id="ui-users.errors.permissionChangeFailed" /></strong></div>
+            <div>{body}</div>
+          </div>
+        )
+      });
+    });
+}

--- a/src/views/UserEdit/UserEditHelpers.test.js
+++ b/src/views/UserEdit/UserEditHelpers.test.js
@@ -1,0 +1,61 @@
+import { resourcesLoaded, showErrorCallout } from './UserEditHelpers';
+
+describe('resourcesLoaded', () => {
+  test('loaded, no exceptions', async () => {
+    const res = {
+      foo: { isPending: false },
+      bar: { isPending: false },
+    };
+
+    expect(resourcesLoaded(res)).toBe(true);
+  });
+
+  test('loaded, with exceptions', async () => {
+    const res = {
+      foo: { isPending: false },
+      bar: { isPending: true },
+    };
+
+    expect(resourcesLoaded(res, ['bar'])).toBe(true);
+  });
+
+  test('loaded (not an object)', async () => {
+    const res = {
+      foo: { isPending: false },
+      bar: () => { },
+    };
+
+    expect(resourcesLoaded(res)).toBe(true);
+  });
+
+  test('unloaded (null)', async () => {
+    const res = {
+      foo: { isPending: false },
+      bar: null,
+    };
+
+    expect(resourcesLoaded(res)).toBe(false);
+  });
+
+  test('unloaded (pending)', async () => {
+    const res = {
+      foo: { isPending: false },
+      bar: { isPending: true },
+    };
+
+    expect(resourcesLoaded(res)).toBe(false);
+  });
+});
+
+describe('showErrorCallout', () => {
+  it('calls the callout', async () => {
+    const res = {
+      text: jest.fn().mockReturnValue(Promise.resolve()),
+    };
+    const sendCallout = jest.fn();
+
+    await showErrorCallout(res, sendCallout);
+
+    expect(sendCallout).toHaveBeenCalled();
+  });
+});

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -339,6 +339,7 @@
   "errors.reviewBeforeRenewal": "{message} Please review {policyName} before retrying renewal.",
   "errors.loanNotRenewedReason": "Loan cannot be renewed because: {message}.",
   "errors.userNotFound": "User not found",
+  "errors.permissionChangeFailed": "Permissions were not changed",
   "hide": "Hide",
   "show": "Show",
   "active": "Active",


### PR DESCRIPTION
If a user-edit action such as updating user attributes, changing
permissions, or changing request attributes fails, show an error callout
instead of failing silently.

Refs [UIU-2541](https://issues.folio.org/browse/UIU-2541)