### PR TITLE
Include perms.users.assign in ui-users.editperms UIU-2549

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change history for ui-users
 
-## [7.2.0] IN PROGRESS
+## [8.0.0] IN PROGRESS
 
 * Show an error toast when saving user-changes fails for any reason. Refs UIU-2541.
 * Unable to edit Manual Patron Blocks. Refs UIU-2548.
+* *BREAKING* Require okapi interface `permissions` `5.5` for permission-assignment permissions. Refs UIU-2549.
 
 ## [7.1.0](https://github.com/folio-org/ui-users/tree/v7.1.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.0.1...v7.1.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/users",
-  "version": "7.2.0",
+  "version": "8.0.0",
   "description": "User management",
   "repository": "folio-org/ui-users",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "okapiInterfaces": {
       "users": "15.0",
       "configuration": "2.0",
-      "permissions": "5.0",
+      "permissions": "5.5",
       "login": "6.0 7.0",
       "users-bl": "5.0 6.0"
     },
@@ -148,7 +148,9 @@
           "ui-users.viewperms",
           "perms.users.item.put",
           "perms.users.item.post",
-          "perms.users.item.delete"
+          "perms.users.item.delete",
+          "perms.users.assign.immutable",
+          "perms.users.assign.mutable"
         ],
         "visible": true
       },


### PR DESCRIPTION
Thus, users with ui-users.editperms can continue to grant
any permission to any user - except okapi permissions.