### PR TITLE
UIU-2548: fix the issue when unable to edit manual patron blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [7.2.0] IN PROGRESS
 
 * Show an error toast when saving user-changes fails for any reason. Refs UIU-2541.
+* Unable to edit Manual Patron Blocks. Refs UIU-2548.
 
 ## [7.1.0](https://github.com/folio-org/ui-users/tree/v7.1.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.0.1...v7.1.0)

--- a/src/routes/PatronBlockContainer.js
+++ b/src/routes/PatronBlockContainer.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { stripesConnect } from '@folio/stripes/core';
 import { PatronBlockLayer } from '../components/PatronBlock';
+import { MAX_RECORDS } from '../constants';
 
 class PatronBlockContainer extends React.Component {
   static manifest = Object.freeze({
@@ -18,20 +19,24 @@ class PatronBlockContainer extends React.Component {
       type: 'okapi',
       records: 'manualblocks',
       path:'manualblocks',
+      params: {
+        limit: MAX_RECORDS,
+        query: 'userId==:{id}',
+      },
       PUT: {
         path: 'manualblocks/%{activeRecord.blockid}',
       },
       DELETE: {
         path: 'manualblocks/%{activeRecord.blockid}',
-      }
+      },
     },
     blockTemplates: {
       type: 'okapi',
       records: 'manualBlockTemplates',
       path:'manual-block-templates',
       params: {
-        limit: '100'
-      }
+        limit: '100',
+      },
     },
     activeRecord: {},
   });
@@ -41,7 +46,7 @@ class PatronBlockContainer extends React.Component {
       manualPatronBlocks: PropTypes.shape({
         POST: PropTypes.func.isRequired,
         PUT: PropTypes.func.isRequired,
-        DELETE: PropTypes.func.isRequired
+        DELETE: PropTypes.func.isRequired,
       }),
       activeRecord: PropTypes.object,
     }).isRequired,


### PR DESCRIPTION
## Purpose
We should be able to edit Manual Patron Blocks.

## Approach
This issue appears when we have a more than 10 active manual patron blocks. Before changes we fetch them all, find neccesary by id and prefill data from responce. But when we have more than 10 records, and our block doesn't appears in them, there are no any prefilled data. I added patron id to request, and raize records limit. It helped.

## Refs
https://issues.folio.org/browse/UIU-2548