### PR TITLE
UIU-2543: Replace onChange with onClick when checkbox is clicked on MCL row.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [8.1.0] IN PROGRESS
 
+* Replace `onChange` with `onClick` when checkbox is clicked on MCL row. Fixes UIU-2543.
 
 ## [8.0.0](https://github.com/folio-org/ui-users/tree/v8.0.0) (2022-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.1.0...v8.0.0)

--- a/src/components/Accounts/Actions/WarningModal.js
+++ b/src/components/Accounts/Actions/WarningModal.js
@@ -42,13 +42,13 @@ class WarningModal extends React.Component {
     this.state = {
       checkedAccounts: {},
       allChecked: true,
-      sortOrder: ['Alert details', 'Fee/Fine type', 'Remainig', 'Payment Status', 'Item'],
+      sortOrder: ['Alert details', 'Fee/Fine type', 'Remaining', 'Payment Status', 'Item'],
       sortDirection: ['desc', 'asc']
     };
     this.sortMap = {
       'Alert details': this.getAlertDetailsFormatter,
       'Fee/Fine type': a => a.feeFineType,
-      'Remainig': a => a.remaining,
+      'Remaining': a => a.remaining,
       'Payment Status': a => (a.paymentStatus || {}).name,
       'Item': a => a.title,
     };
@@ -132,7 +132,7 @@ class WarningModal extends React.Component {
       ' ': a => (
         <input
           checked={!!(checkedAccounts[a.id])}
-          onChange={e => this.toggleItem(e, a)}
+          onClick={e => this.toggleItem(e, a)}
           type="checkbox"
         />
       ),

--- a/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
+++ b/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
@@ -126,7 +126,8 @@ class ViewFeesFines extends React.Component {
 
   onRowClick(e, row) {
     const { history, match: { params } } = this.props;
-    if ((e.target.type !== 'button') && (e.target.tagName !== 'IMG')) {
+
+    if (row?.id && !e?.target?.type?.match(/checkbox|button/i) && e.target.tagName !== 'IMG') {
       nav.onClickViewAccountActionsHistory(e, row, history, params);
     }
   }
@@ -217,10 +218,16 @@ class ViewFeesFines extends React.Component {
   getAccountsFormatter() {
     const accounts = this.props.selectedAccounts;
     return {
+      // Changed onChange to onClick to make sure the click event is correctly propagated
+      // and the checkbox actually changes visually.
+      // There seems to be a bug in MCL where when the onRowClick is registered
+      // the even is being stopped from propagation:
+      // https://github.com/folio-org/stripes-components/blob/08fa633f7660869bc1a29c0f13d80deba62afc80/lib/MultiColumnList/MCLRenderer.js#L834
+      // which currently causes the checkbox to not be visually updated.
       '  ': f => (
         <input
           checked={(accounts.findIndex(a => a.id === f.id) !== -1)}
-          onChange={e => this.toggleItem(e, f)}
+          onClick={e => this.toggleItem(e, f)}
           type="checkbox"
         />
       ),


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2543

This PR replaces `onChange` with `onClick` so the events are correctly propagated. The `onChange` is currently not working correctly because MCL is stopping the propagation:

https://github.com/folio-org/stripes-components/blob/08fa633f7660869bc1a29c0f13d80deba62afc80/lib/MultiColumnList/MCLRenderer.js#L833-L834