### PR TITLE
UIU-2544: Increase limit for servicePoints query in AccountDetailsContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [8.1.0] IN PROGRESS
 
+* Increase limit for servicePoints query in `<AccountDetailsContainer>`. Fixes UIU-2544.
 
 ## [8.0.0](https://github.com/folio-org/ui-users/tree/v8.0.0) (2022-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.1.0...v8.0.0)

--- a/src/routes/AccountDetailsContainer.js
+++ b/src/routes/AccountDetailsContainer.js
@@ -111,7 +111,10 @@ class AccountDetailsContainer extends React.Component {
       type: 'okapi',
       records: 'servicepoints',
       path: 'service-points',
-      limit: 10000,
+      params: {
+        query: 'cql.allRecords=1',
+        limit: MAX_RECORDS,
+      },
     },
   });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2544

The limit was set incorrectly and only first 10 service points were returned which was causing issues with not finding correct one on the `AccountDetailsContainer` under `Create at` column:

![created_at](https://user-images.githubusercontent.com/63545/159613752-d09539dd-84cd-4856-a6ca-32d7d85045c5.png)

