### PR TITLE
UIU-2569: fix error message appearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Replace `onChange` with `onClick` when checkbox is clicked on MCL row. Fixes UIU-2543.
 * Correctly import from `stripes-components` via `@folio/stripes`. Refs UIU-2173.
 * Missing interface dependency: tags. Fixes UIU-2557.
+* Error message "Enter comment" appears erroneously when entering New Staff Info on Fee/Fine Details. Refs UIU-2569.
 
 ## [8.0.0](https://github.com/folio-org/ui-users/tree/v8.0.0) (2022-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.1.0...v8.0.0)

--- a/src/components/Accounts/Actions/CommentModal.js
+++ b/src/components/Accounts/Actions/CommentModal.js
@@ -14,14 +14,6 @@ import {
 
 import css from './modal.css';
 
-const validate = (values) => {
-  const errors = {};
-  if (!values.comment) {
-    errors.comment = <FormattedMessage id="ui-users.accounts.comment.error.enterComment" />;
-  }
-  return errors;
-};
-
 class CommentModal extends React.Component {
   static propTypes = {
     open: PropTypes.bool,
@@ -30,27 +22,22 @@ class CommentModal extends React.Component {
     invalid: PropTypes.bool,
     onClose: PropTypes.func,
     handleSubmit: PropTypes.func,
-    form: PropTypes.object.isRequired,
   };
 
   onSubmit = () => {
     const {
       handleSubmit,
-      form: { reset },
     } = this.props;
 
     handleSubmit();
-    reset();
   }
 
   handleClose = () => {
     const {
       onClose,
-      form: { reset },
     } = this.props;
 
     onClose();
-    reset();
   }
 
   render() {
@@ -59,7 +46,7 @@ class CommentModal extends React.Component {
       submitting,
       invalid,
       open,
-      onClose
+      onClose,
     } = this.props;
 
     const submitButtonDisabled = pristine || submitting || invalid;
@@ -112,7 +99,7 @@ class CommentModal extends React.Component {
 }
 
 export default stripesFinalForm({
+  destroyOnUnregister: true,
   navigationCheck: true,
   subscription: { values: true },
-  validate,
 })(CommentModal);


### PR DESCRIPTION
## Purpose
Error message "Enter comment" appears erroneously when entering New Staff Info on Fee/Fine Details.

## Approach
Form was reseting before component fully unmout, that why we was able to see error message. With flag `destroyOnUnregister` we no more need to reset form manualy. This resolve first part of the issue. The second problem that when we type something, and than delete and try to click on cancel, in first turn works validation on blure, button runs away from under our cursor and we should click on it one more time to close the window. Regarding this I think we can remove our validation, because we can't save empty message with or without validation.

## Refs
https://issues.folio.org/browse/UIU-2569