### PR TITLE
UIU-2557 - Missing interface dependency: tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Increase limit for servicePoints query in `<AccountDetailsContainer>`. Fixes UIU-2544.
 * Replace `onChange` with `onClick` when checkbox is clicked on MCL row. Fixes UIU-2543.
 * Correctly import from `stripes-components` via `@folio/stripes`. Refs UIU-2173.
+* Missing interface dependency: tags. Fixes UIU-2557.
 
 ## [8.0.0](https://github.com/folio-org/ui-users/tree/v8.0.0) (2022-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.1.0...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
       "configuration": "2.0",
       "permissions": "5.5",
       "login": "6.0 7.0",
-      "users-bl": "5.0 6.0"
+      "users-bl": "5.0 6.0",
+      "tags": "1.0"
     },
     "optionalOkapiInterfaces": {
       "automated-patron-blocks": "0.1",


### PR DESCRIPTION
## Overview
The ui-users package.json file doesn't declare a dependency on the tags interface.  When opening up the users app, you can clearly see a call being made to GET /tags in the browser tools.  It appears this call is made in order to populate the tags filter drop-down.

## Approach
Missing interface dependency has been added into the okapiInterfaces