### PR TITLE
UIU-2563 users manipulating psets need permission to do so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Missing interface dependency: tags. Fixes UIU-2557.
 * Error message "Enter comment" appears erroneously when entering New Staff Info on Fee/Fine Details. Refs UIU-2569.
 * Edit User Record: Using Enter key should Open Add Service points when focus is on the Add Service points button. Refs UIU-1256.
+* Users manipulating permissions sets need access to all permissions. Refs UIU-2563.
 
 ## [8.0.0](https://github.com/folio-org/ui-users/tree/v8.0.0) (2022-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.1.0...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -186,7 +186,6 @@
           "perms.permissions.item.post",
           "perms.permissions.item.delete",
           "settings.users.enabled",
-          "perms.users.assign.immutable",
           "perms.users.assign.mutable"
         ],
         "visible": true

--- a/package.json
+++ b/package.json
@@ -185,7 +185,9 @@
           "perms.permissions.item.put",
           "perms.permissions.item.post",
           "perms.permissions.item.delete",
-          "settings.users.enabled"
+          "settings.users.enabled",
+          "perms.users.assign.immutable",
+          "perms.users.assign.mutable"
         ],
         "visible": true
       },


### PR DESCRIPTION
Prior to `permissions` `5.5`, having `perms.users.items.put`, `...post`,
or `...delete` was a security vulnerability because it allowed any user
with the ability to assign permissions to assign permissions they did
not already have, e.g. for a user with `A` and `B` to grant `C` to
somebody else. That _is_ a useful feature, but the two should not be
coupled (assign own permissions; assign non-owned permissions).

Here, that same logic is applied to creation of permission sets: users
with the ability to create permission sets need the ability to create
sets with permissions they may not own.

Refs [UIU-2563](https://issues.folio.org/browse/UIU-2563)