### PR TITLE
UIU-2577: Increase record limit for manual-block-templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Missing interface dependency: tags. Fixes UIU-2557.
 * Error message "Enter comment" appears erroneously when entering New Staff Info on Fee/Fine Details. Refs UIU-2569.
 * Edit User Record: Using Enter key should Open Add Service points when focus is on the Add Service points button. Refs UIU-1256.
+* Increase record limit for manual-block-templates. Refs UIU-2577.
 
 ## [8.0.0](https://github.com/folio-org/ui-users/tree/v8.0.0) (2022-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.1.0...v8.0.0)

--- a/src/settings/patronBlocks/BlockTemplates/BlockTemplates.js
+++ b/src/settings/patronBlocks/BlockTemplates/BlockTemplates.js
@@ -38,6 +38,7 @@ function BlockTemplates(props) {
       paneTitle={
         <FormattedMessage id="ui-users.settings.manualBlockTemplates.paneTitle" />
       }
+
       entryLabel={formatMessage({ id: 'ui-users.manualBlockTemplate' })}
       entryFormComponent={BlockTemplateForm}
       validate={validate}
@@ -55,7 +56,7 @@ BlockTemplates.manifest = Object.freeze({
   manualBlockTemplates: {
     type: 'okapi',
     records: 'manualBlockTemplates',
-    path: 'manual-block-templates',
+    path: 'manual-block-templates?limit=200',
   },
 });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2577

**Steps to Reproduce:**

1. Go to Settings- users - Patron blocks: Templates
2. Create more than 10 templates

**Expected Results:**
All templates should be visible in Patron blocks: Templates

**Actual Results:**
Just 10 templates are visible in Patron blocks: Templates

**Additional Information:**
URL: settings/users/manual-block-templates