### PR TITLE
UIU-2570: Fix inaccurate request counts in various open loan views & modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Missing interface dependency: tags. Fixes UIU-2557.
 * Error message "Enter comment" appears erroneously when entering New Staff Info on Fee/Fine Details. Refs UIU-2569.
 * Edit User Record: Using Enter key should Open Add Service points when focus is on the Add Service points button. Refs UIU-1256.
+* Fix inaccurate request counts in various open loan views & modals. Fixes UIU-2570, UIU-2574.
 
 ## [8.0.0](https://github.com/folio-org/ui-users/tree/v8.0.0) (2022-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.1.0...v8.0.0)

--- a/src/components/Wrappers/withRenew.js
+++ b/src/components/Wrappers/withRenew.js
@@ -10,8 +10,9 @@ import { Callout } from '@folio/stripes/components';
 import BulkRenewalDialog from '../BulkRenewalDialog';
 import isOverridePossible from '../Loans/OpenLoans/helpers/isOverridePossible';
 import {
-  requestStatuses,
+  MAX_RECORDS,
   OVERRIDE_BLOCKS_FIELDS,
+  requestStatuses,
 } from '../../constants';
 
 // HOC used to manage renew
@@ -269,7 +270,7 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
         .map(loan => loan.itemId);
       const query = `(itemId==(${itemIdList.join(' or ')})) and status==(${statusList}) sortby requestDate desc`;
       reset();
-      GET({ params: { query, limit: itemIdList.length } })
+      GET({ params: { query, limit: MAX_RECORDS } })
         .then((requestRecords) => {
           const requestCountObject = requestRecords.reduce((map, record) => {
             map[record.itemId] = map[record.itemId]


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2570
https://issues.folio.org/browse/UIU-2574

This fixes a couple of related bugs in which the number of open requests on a loaned item would never show more than 1 request. This only required an adjustment to the `limit` parameter for the query.

<img width="583" alt="Screen Shot 2022-04-06 at 4 03 41 PM" src="https://user-images.githubusercontent.com/1322242/162062797-17d862bb-01c8-4c4b-ae49-786b67e4d4a2.png">
<img width="1257" alt="Screen Shot 2022-04-06 at 4 03 32 PM" src="https://user-images.githubusercontent.com/1322242/162062828-cadde337-0d15-44ae-a182-7202012f8cec.png">
<img width="662" alt="Screen Shot 2022-04-06 at 4 06 18 PM" src="https://user-images.githubusercontent.com/1322242/162062844-18c2ffa1-65bd-4339-9647-c2ec02effe2c.png">
<img width="682" alt="Screen Shot 2022-04-06 at 4 06 28 PM" src="https://user-images.githubusercontent.com/1322242/162062846-64425b6d-7134-42d1-9978-cbaad5c5b2bf.png">

