### PR TITLE
UIU-2563 immutable permission is necessary to manipulate sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
           "perms.permissions.item.post",
           "perms.permissions.item.delete",
           "settings.users.enabled",
+          "perms.users.assign.immutable",
           "perms.users.assign.mutable"
         ],
         "visible": true


### PR DESCRIPTION
Manipulating run-time (mutable) sets composed of build-time (immutable)
permissions requires (drumroll) permission to manage immutable
permissions.

Refs [UIU-2563](https://issues.folio.org/browse/UIU-2563)