### PR TITLE
UIU-2601 Search results with a single hit should automatically open the detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Guard against missing loan item record. FIXES UIU-2578.
 * Update permissions for linking to fine details in `<LoanDetails>`. Refs UIU-2481.
 * Add loans anonymized message with count of loans not anonymized. Refs UIU-2246.
+* Search results with a single hit should automatically open the detail view. Fixes UIU-2601.
 
 ## [8.0.0](https://github.com/folio-org/ui-users/tree/v8.0.0) (2022-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.1.0...v8.0.0)

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -175,6 +175,14 @@ class UserSearch extends React.Component {
       !this.props.resources.records.isPending) {
       this.onSearchComplete(this.props.resources.records);
     }
+
+    const { resources, source, history } = this.props;
+   
+    // Open the detail view when there's a single hit
+    if(resources.records.records[0] !== prevProps.resources.records.records[0]  && 
+      source.totalCount() === 1) {
+      history.push(this.getRowURL(resources.records.records[0].id))
+    }
   }
 
   componentWillUnmount() {

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -177,11 +177,10 @@ class UserSearch extends React.Component {
     }
 
     const { resources, source, history } = this.props;
-   
     // Open the detail view when there's a single hit
-    if(resources.records.records[0] !== prevProps.resources.records.records[0]  && 
+    if (resources.records.records[0] !== prevProps.resources.records.records[0] &&
       source.totalCount() === 1) {
-      history.push(this.getRowURL(resources.records.records[0].id))
+      history.push(this.getRowURL(resources.records.records[0].id));
     }
   }
 


### PR DESCRIPTION
## Description
Search results with a single hit should automatically open the detail view

## Approach
Added a code-block inside SearchAndSort.js file which is checking if showSingleResult behaviour is true and total results are 1. This code-block is calling onSelectRow function which is responsible for opening the detail pane.

## Issue
[UIU-2601](https://issues.folio.org/browse/UIU-2601)

## Screenshot
https://user-images.githubusercontent.com/101391438/167606090-903e500c-b934-41c3-b321-adaff0486b03.mp4