### PR TITLE
UIU-2600: fix the issue when fee/fine amount unexpectedly resets on manual charge form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Update NodeJS to Active LTS. Refs UIU-2607.
 * Use single formatted message for successfully callout message. Refs UIU-1657.
 * create Jest/RTL test for DepartmentsNameEdit.js. Refs UIU-2326
+* Fee/fine amount unexpectedly resets on manual charge form. Refs UIU-2600.
 
 ## [8.0.0](https://github.com/folio-org/ui-users/tree/v8.0.0) (2022-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.1.0...v8.0.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.js
@@ -98,20 +98,20 @@ class ChargeForm extends React.Component {
     }
   }
 
-  async onChangeFeeFine(e) {
+  onChangeFeeFine(e) {
     const {
       feefines,
       form: { change },
     } = this.props;
 
     if (e?.target?.value) {
+      this.props.onChangeFeeFine(e);
+
       const feeFineId = e.target.value;
-      await this.props.onChangeFeeFine(e);
       const feefine = feefines.find(f => f.id === feeFineId) || {};
-      change('feeFineId', feefine.id);
-      this.amount = feefine.defaultAmount || 0;
-      this.amount = parseFloat(this.amount).toFixed(2);
       const defaultAmount = parseFloat(feefine.defaultAmount || 0).toFixed(2);
+
+      change('feeFineId', feefine.id);
       change('amount', defaultAmount);
     }
   }
@@ -166,7 +166,7 @@ class ChargeForm extends React.Component {
         feeFineId,
         ownerId,
         notify,
-      }
+      },
     } = getState();
 
     const selectedLoan = selectedLoanProp || {};
@@ -178,7 +178,7 @@ class ChargeForm extends React.Component {
       itemStatus: ((selectedLoan.item || {}).status || {}).name,
       callNumber: (selectedLoan.item || {}).callNumber,
       location: selectedLoan?.item?.effectiveLocation?.name,
-      type: ((selectedLoan.item || {}).materialType || {}).name
+      type: ((selectedLoan.item || {}).materialType || {}).name,
     };
     const item = (editable) ? this.props.item : itemLoan;
     const feefineList = [];

--- a/src/components/Accounts/ChargeFeeFine/FeeFineInfo.js
+++ b/src/components/Accounts/ChargeFeeFine/FeeFineInfo.js
@@ -24,12 +24,6 @@ class FeeFineInfo extends React.Component {
     isPending: PropTypes.object,
   };
 
-  constructor(props) {
-    super(props);
-    this.onChangeAmount = this.onChangeAmount.bind(this);
-    this.amount = 0;
-  }
-
   componentDidMount() {
     const {
       initialValues: {
@@ -43,14 +37,10 @@ class FeeFineInfo extends React.Component {
     }
   }
 
-  onChangeAmount(e) {
-    this.amount = parseFloat(e.target.value || 0).toFixed(2);
-    this.props.onChangeFeeFine(this.amount);
-  }
-
-  onBlurAmount = () => {
+  onBlurAmount = (e) => {
     const { form: { change } } = this.props;
-    change('amount', this.amount);
+
+    change('amount', parseFloat(e.target.value || 0).toFixed(2));
   }
 
   render() {
@@ -122,7 +112,6 @@ class FeeFineInfo extends React.Component {
                       fullWidth
                       required
                       aria-required="true"
-                      onChange={this.onChangeAmount}
                       onBlur={this.onBlurAmount}
                     />
                   </Col>


### PR DESCRIPTION
## Purpose
Fix the issue when fee/fine amount unexpectedly resets on manual charge form.

## Approach
1. We dont need `this.amount` at all, because final form should handle changing of values by it self.
2. Also I deleted `async ... await` from `onChangeFeeFine` because we don't need to wait `setState`. I rechecked the bug that was fixed by this construction [(in this pull)](https://github.com/folio-org/ui-users/pull/1571) - works fine.
3. `onChangeFeeFine` in `onChangeAmount` was not working at all because instead of `event` amount was passed, and if no `e?.target?.value` than nothing happend.

## Refs
https://issues.folio.org/browse/UIU-2600