### PR TITLE
UIU-2603: "Cannot read properties of undefined (reading 'replace')" after Renew of user loan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Allow fee/fine to be cancelled if remaining balance equals billed amount. Refs UIU-2609.
 * Unpin `moment` from `~2.24.0` and move it to peer. Refs UIU-1900.
 * Create Jest/RTL test for OpenLoansSubHeader.js. Refs UIU-2340.
+* Get rid of console error if there is no `renewals`. Refs UIU-2603.
 
 ## [8.0.0](https://github.com/folio-org/ui-users/tree/v8.0.0) (2022-03-17)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v7.1.0...v8.0.0)

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -161,7 +161,7 @@ class LoanDetails extends React.Component {
 
     await renew([loan], user, additionalInfo);
 
-    return renewals.replace({ ts: new Date().getTime() });
+    return renewals?.replace({ ts: new Date().getTime() });
   }
 
   renew = async () => {


### PR DESCRIPTION
## Purpose

Get rid of console error if there is no renewals.

## Refs

[UIU-2603](https://issues.folio.org/browse/UIU-2603)

[e2e tests related PR](https://github.com/folio-org/stripes-testing/pull/410) - should be merged after merging of current PR

## Screenshots

**BEFORE**

![image](https://user-images.githubusercontent.com/42437614/172352804-330e2cce-e3a7-4f9c-ac19-a7a850ed013c.png)


**AFTER**

![image](https://user-images.githubusercontent.com/42437614/172336840-f367cb81-9769-4091-be6c-76f2163f0a0f.png)
