### PR TITLE
UIU-2631 accurately count loans > 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.2.0 IN PROGRESS
 
 * Spread out the fields on the new Fee/Fine modal. Fixes UIU-2620.
+* Accurately count open-loans when there are > 1000. Refs UIU-2631.
 
 ## [8.1.0](https://github.com/folio-org/ui-users/tree/v8.1.0) (2022-06-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.0.0...v8.1.0)

--- a/src/components/UserDetailSections/UserLoans/UserLoans.js
+++ b/src/components/UserDetailSections/UserLoans/UserLoans.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { stripesConnect } from '@folio/stripes/core';
 import {
@@ -23,10 +23,8 @@ import {
  * number of open-loans in the preview.
  */
 class UserLoans extends React.Component {
-  // "limit=1" on the openLoansCount and closedLoansCount fields is a hack
-  // to get at the "totalRecords" field without pulling down too much other
-  // data. Instead we should be able to construct a query to retrieve this
-  // metadata directly without pulling any item records.
+  // "limit=0" on the openLoansCount and closedLoansCount fields is a hack
+  // to get at the "totalRecords" field without pulling down any other data
   // see https://issues.folio.org/browse/FOLIO-773
   static manifest = Object.freeze({
     loansHistory: {
@@ -42,7 +40,7 @@ class UserLoans extends React.Component {
         path: 'circulation/loans',
         params: {
           query: `(userId==:{id} and status.name<>${loanStatuses.CLOSED})`,
-          limit: '1',
+          limit: '0',
         },
       },
     },
@@ -52,7 +50,7 @@ class UserLoans extends React.Component {
         path: 'circulation/loans',
         params: {
           query: `userId==:{id} and status.name<>${loanStatuses.CLOSED} and action==${loanActions.CLAIMED_RETURNED}`,
-          limit: '1',
+          limit: '0',
         },
       },
     },
@@ -62,7 +60,7 @@ class UserLoans extends React.Component {
         path: 'circulation/loans',
         params: {
           query: `userId==:{id} and status.name==${loanStatuses.CLOSED}`,
-          limit: '1',
+          limit: '0',
         },
       },
     },
@@ -116,7 +114,7 @@ class UserLoans extends React.Component {
     const claimedReturnedCount = resources?.claimedReturnedCount?.records?.[0]?.totalRecords ?? 0;
     const closedLoansCount = resources?.closedLoansCount?.records?.[0]?.totalRecords ?? 0;
     const loansLoaded = !this.isLoading();
-    const displayWhenClosed = loansLoaded ? (<Badge>{openLoansCount}</Badge>) : (<Icon icon="spinner-ellipsis" width="10px" />);
+    const displayWhenClosed = loansLoaded ? (<Badge><FormattedNumber value={openLoansCount} /></Badge>) : (<Icon icon="spinner-ellipsis" width="10px" />);
 
     const items = [
       {


### PR DESCRIPTION
The open-loan count on the "Loans" accordion could be inaccurate when
there were more than 1000 loans because it used a `limit=1` query
parameter (which still allows for an [estimated `totalRecords` value](https://github.com/folio-org/raml-module-builder#estimated-totalrecords))
instead of `limit=0` which forces an accurate count.

Display the badge value on the closed accordion with `<FormattedNumber>`
so it will be correctly formatted when the value is > 999.

Refs [UIU-2631](https://issues.folio.org/browse/UIU-2631)