### PR TITLE
UIU-2505: Fine detail page throws an error if item is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Spread out the fields on the new Fee/Fine modal. Fixes UIU-2620.
 * Accurately count open-loans when there are > 1000. Refs UIU-2631.
+* Fine detail page throws an error if item is missing. Refs UIU-2505.
 
 ## [8.1.0](https://github.com/folio-org/ui-users/tree/v8.1.0) (2022-06-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.0.0...v8.1.0)

--- a/src/routes/AccountDetailsContainer.js
+++ b/src/routes/AccountDetailsContainer.js
@@ -238,7 +238,7 @@ class AccountDetailsContainer extends React.Component {
     const overdueFinePolicyId = currentRecord[0]?.overdueFinePolicyId;
     const lostItemPolicyName = currentRecord[0]?.lostItemPolicy?.name;
     const lostItemPolicyId = currentRecord[0]?.lostItemPolicyId;
-    const statusItemName = currentRecord[0]?.item.status?.name;
+    const statusItemName = currentRecord[0]?.item?.status?.name;
 
     return {
       overdueFinePolicyId,

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -443,13 +443,22 @@ class AccountDetails extends React.Component {
     // was associated with has been anonymized, or the user in question simply
     // doesn't have permission to view inventory records.
     let itemBarcodeLink = <NoValue />;
+
     if (account.barcode && account.instanceId && account.holdingsRecordId && account.itemId) {
       itemBarcodeLink = (
         <Link
           to={`/inventory/view/${account.instanceId}/${account.holdingsRecordId}/${account.itemId}`}
         >
           {account.barcode}
-        </Link>);
+        </Link>
+      );
+    } else if (account.barcode && !itemDetails.statusItemName) {
+      itemBarcodeLink = <FormattedMessage
+        id="ui-users.details.field.barcode.notFound"
+        values={{
+          barcode: account.barcode,
+        }}
+      />;
     } else if (account.barcode) {
       itemBarcodeLink = account.barcode;
     }

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -506,6 +506,7 @@
   "details.field.instance.type": "Instance (Material type)",
   "details.field.type": "Item type",
   "details.field.barcode": "Barcode",
+  "details.field.barcode.notFound": "{barcode} (not found)",
   "details.field.callnumber": "Effective call number string",
   "details.field.location": "Location",
   "details.field.duedate": "Due date",


### PR DESCRIPTION
## Purpose
Fine detail page throws an error if item is missing

## Refs
https://issues.folio.org/browse/UIU-2505