### PR TITLE
UIU-2644: "Remaining amount" doesn't have the correct value when the field "Payment amount" is emptied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Accurately count open-loans when there are > 1000. Refs UIU-2631.
 * Fine detail page throws an error if item is missing. Refs UIU-2505.
 * After new fee/fine charged at Check-in, unable to get to Users app. Refs UIU-2626.
+* "Remaining amount" doesn't have the correct value when the field "Payment amount" is emptied. Refs UIU-2644.
 
 ## [8.1.0](https://github.com/folio-org/ui-users/tree/v8.1.0) (2022-06-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.0.0...v8.1.0)

--- a/src/components/Accounts/Actions/ActionModal.js
+++ b/src/components/Accounts/Actions/ActionModal.js
@@ -247,7 +247,11 @@ class ActionModal extends React.Component {
   validateAmount = async (value) => {
     let error;
 
-    const { accounts } = this.props;
+    const {
+      accounts,
+      feeFineActions,
+      action,
+    } = this.props;
 
     const {
       actionAllowed,
@@ -257,6 +261,11 @@ class ActionModal extends React.Component {
     } = this.state;
 
     if (_.isEmpty(value)) {
+      const selectedAmount = calculateSelectedAmount(accounts, this.isRefundAction(action), feeFineActions);
+
+      this.setState(() => ({
+        accountRemainingAmount: selectedAmount,
+      }));
       error = <FormattedMessage id="ui-users.accounts.error.field" />;
     } else if (value !== prevValidatedAmount && this._isMounted) {
       const response = await this.triggerCheckEndpoint(value, accounts);

--- a/src/components/Accounts/Actions/ActionModal.js
+++ b/src/components/Accounts/Actions/ActionModal.js
@@ -263,9 +263,9 @@ class ActionModal extends React.Component {
     if (_.isEmpty(value)) {
       const selectedAmount = calculateSelectedAmount(accounts, this.isRefundAction(action), feeFineActions);
 
-      this.setState(() => ({
+      this.setState({
         accountRemainingAmount: selectedAmount,
-      }));
+      });
       error = <FormattedMessage id="ui-users.accounts.error.field" />;
     } else if (value !== prevValidatedAmount && this._isMounted) {
       const response = await this.triggerCheckEndpoint(value, accounts);


### PR DESCRIPTION
## Purpose

"Remaining amount" field had an incorrect value when payment/waive/transfer/refund amount is empty. 

## Refs

[UIU-2644](https://issues.folio.org/browse/UIU-2644)