### PR TITLE
UIU-2647 Support notes interface v3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Accurately count open-loans when there are > 1000. Refs UIU-2631.
 * Fine detail page throws an error if item is missing. Refs UIU-2505.
 * After new fee/fine charged at Check-in, unable to get to Users app. Refs UIU-2626.
+* Support `notes` interface version `3.0`. Refs UIU-2647.
 
 ## [8.1.0](https://github.com/folio-org/ui-users/tree/v8.1.0) (2022-06-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.0.0...v8.1.0)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "feesfines": "16.1 17.0",
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0 7.0",
-      "notes": "2.0",
+      "notes": "2.0 3.0",
       "request-storage": "2.5 3.0 4.0"
     },
     "permissionSets": [


### PR DESCRIPTION
`mod-notes` module was updated with breaking changes to `/note-types` endpoint and updated interface version to `3.0`
However, these changes don't affect `/notes` endpoint so `ui-users` can safely use either `2.0` or `3.0`
@zburke should I add anyone else to reviewers?