### PR TITLE
UIU-2645: Confirm button is not disabled after the click and each click on this button sends the request to the server

### DIFF
--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -89,13 +89,17 @@ class ModalContent extends React.Component {
     onClose: PropTypes.func.isRequired,
     handleError: PropTypes.func.isRequired,
     declarationInProgress: PropTypes.bool.isRequired,
-    toggleButton: PropTypes.func.isRequired,
+    toggleButton: PropTypes.func,
     validateAction: PropTypes.func,
     itemRequestCount: PropTypes.number.isRequired,
     activeRecord: PropTypes.object,
     user: PropTypes.object,
     resources: PropTypes.object,
     okapi: PropTypes.object
+  };
+
+  static defaultProps = {
+    toggleButton: () => {},
   };
 
   constructor(props) {

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -1,4 +1,7 @@
-import _ from 'lodash';
+import {
+  get,
+  noop,
+} from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
@@ -99,7 +102,7 @@ class ModalContent extends React.Component {
   };
 
   static defaultProps = {
-    toggleButton: () => {},
+    toggleButton: noop,
   };
 
   constructor(props) {
@@ -180,7 +183,7 @@ class ModalContent extends React.Component {
     }
 
     const feeFines = [];
-    _.get(resources, ['feefineshistory', 'records'], []).forEach((currentFeeFine) => {
+    get(resources, ['feefineshistory', 'records'], []).forEach((currentFeeFine) => {
       if (currentFeeFine.loanId === loanId && currentFeeFine.status.name === 'Open' &&
         (currentFeeFine.feeFineType === refundClaimReturned.LOST_ITEM_FEE || currentFeeFine.feeFineType === refundClaimReturned.LOST_ITEM_PROCESSING_FEE)) {
         feeFines.push(currentFeeFine);

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -11,6 +11,7 @@ import {
   get,
   upperFirst,
   isEmpty,
+  noop,
 } from 'lodash';
 
 import { ChangeDueDateDialog } from '@folio/stripes/smart-components';
@@ -55,7 +56,6 @@ import css from './LoanDetails.css';
 
 class LoanDetails extends React.Component {
   static propTypes = {
-    toggleButton: PropTypes.func,
     isLoading: PropTypes.bool,
     stripes: PropTypes.object.isRequired,
     resources: PropTypes.shape({
@@ -88,6 +88,7 @@ class LoanDetails extends React.Component {
     declareLost: PropTypes.func,
     markAsMissing: PropTypes.func,
     claimReturned: PropTypes.func,
+    toggleButton: PropTypes.func,
     declarationInProgress: PropTypes.bool,
     patronBlocks: PropTypes.arrayOf(PropTypes.object),
     intl: PropTypes.object.isRequired,
@@ -97,7 +98,7 @@ class LoanDetails extends React.Component {
   };
 
   static defaultProps = {
-    toggleButton: () => {},
+    toggleButton: noop,
     loanAccountActions: [],
   };
 

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -55,7 +55,7 @@ import css from './LoanDetails.css';
 
 class LoanDetails extends React.Component {
   static propTypes = {
-    toggleButton: PropTypes.func.isRequired,
+    toggleButton: PropTypes.func,
     isLoading: PropTypes.bool,
     stripes: PropTypes.object.isRequired,
     resources: PropTypes.shape({
@@ -97,6 +97,7 @@ class LoanDetails extends React.Component {
   };
 
   static defaultProps = {
+    toggleButton: () => {},
     loanAccountActions: [],
   };
 


### PR DESCRIPTION
## Purpose
Return back `defaultProps` because in some cases components do not receive `toggleButton` prop.

## Refs
[UIU-2645](https://issues.folio.org/browse/UIU-2645)

Related PR - https://github.com/folio-org/ui-users/pull/2198