### PR TITLE
UIU-2610 treat empty-string values as null in name-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * "Remaining amount" doesn't have the correct value when the field "Payment amount" is emptied. Refs UIU-2644.
 * Support `notes` interface version `3.0`. Refs UIU-2647.
 * Confirm button is not disabled after the click and each click on this button sends the request to the server. Refs UIU-2645.
+* When formatting names, correctly treat empty-strings as missing. Refs UIU-2610.
 
 ## [8.1.0](https://github.com/folio-org/ui-users/tree/v8.1.0) (2022-06-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.0.0...v8.1.0)

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -17,9 +17,9 @@ import {
  * @returns string
  */
 export function getFullName(user) {
-  let fullName = user?.personal?.lastName ?? '';
-  let givenName = user?.personal?.preferredFirstName ?? user?.personal?.firstName ?? '';
-  const middleName = user?.personal?.middleName ?? '';
+  let fullName = user?.personal?.lastName || '';
+  let givenName = user?.personal?.preferredFirstName || user?.personal?.firstName || '';
+  const middleName = user?.personal?.middleName || '';
   if (middleName) {
     givenName += `${givenName ? ' ' : ''}${middleName}`;
   }

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -152,6 +152,19 @@ describe('getFullName', () => {
     expect(getFullName(user)).toBe(`${lastName}, ${firstName} ${middleName}`);
   });
 
+  it('handles empty preferred first name', () => {
+    const user = {
+      personal: {
+        firstName,
+        middleName,
+        lastName,
+        preferredFirstName: '',
+      },
+    };
+
+    expect(getFullName(user)).toBe(`${lastName}, ${firstName} ${middleName}`);
+  });
+
   it('handles missing middle name', () => {
     const user = {
       personal: {


### PR DESCRIPTION
When formatting a name object where some values could be present but
empty, treat such values as empty. Previously, the formatter only
checked if values were null or undefined; empty-string was ignored. This
led objects like
```
{
  firstName: "Andrea",
  preferredFirstName: "",
  lastName: "Andromeda"
}
```
to be formatted as "Andromeda" instead of "Andromeda, Andrea" because
`preferredFirstName` was non-null. Now, undefined, null, and empty
string will all be treated as falsy.

Refs [UIU-2610](https://issues.folio.org/browse/UIU-2610)