### PR TITLE
Fix failed test

### DIFF
--- a/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
@@ -47,7 +47,12 @@ const props = {
   form: {
     change: changeMock,
     getFieldState: jest.fn(() => {
-      return { value: '2100-08-16T02:01:15.606+00:00' };
+      const dateIncrement = 1;
+      const tomorrow = new Date();
+
+      tomorrow.setDate(tomorrow.getDate() + dateIncrement);
+
+      return { value: tomorrow.toJSON() };
     })
   },
   accordionId: 'editUserInfo',

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
@@ -47,7 +47,7 @@ const props = {
   form: {
     change: changeMock,
     getFieldState: jest.fn(() => {
-      return { value: '2022-08-16T02:01:15.606+00:00' };
+      return { value: '2100-08-16T02:01:15.606+00:00' };
     })
   },
   accordionId: 'editUserInfo',


### PR DESCRIPTION
## Purpose
Due to the incorrectly implemented mocked date, we have failed test after 2022-08-16.
2022-08-16 date was hardcoded and if the test is executed after this date - it fails.
The mocked date should always be in the future.

## Approach
Next day date was used for mocks. 
As a result, we have an expiration date which is always the next day.

## Refs
[UIU-2668](https://issues.folio.org/browse/UIU-2668)