### PR TITLE
UIU-2642 correctly import from @folio/stripes/core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * When formatting names, correctly treat empty-strings as missing. Refs UIU-2610.
 * Additional updates to Pop-up note Refs UIU-2653
 * Modify error message when a Fee/Fine Owner enters a Fee/Fine Type that is duplicated by "Shared" Fee/Fine Owner. Refs UIU-2560.
+* Correctly import from `stripes/core` not `stripes-core`. Refs UIU-2642.
 
 ## [8.1.0](https://github.com/folio-org/ui-users/tree/v8.1.0) (2022-06-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.0.0...v8.1.0)

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -19,7 +19,7 @@ import {
   Paneset,
   Row,
 } from '@folio/stripes/components';
-import { IfPermission } from '@folio/stripes-core';
+import { IfPermission } from '@folio/stripes/core';
 
 import Actions from '../../components/Accounts/Actions/FeeFineActions';
 import {


### PR DESCRIPTION
Import from paths within `@folio/stripes`, which is provided at the
platform level, instead of directly from `@folio/stripes-core`, which is
not visible at the platform level.

Refs [UIU-2642](https://issues.folio.org/browse/UIU-2642)