### PR TITLE
UIU-2670: Duplicate Fee/Fine Type error message not being cleared after error corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add selected actual service points to "Financial Transaction Detail Report" title line. Refs UIU-2666.
 * Fix issue with Qindex select automatically triggering the search on change. Refs UIU-2665.
 * create Jest/RTL test for NoteEditPage.js. Refs UIU-2424
+* Clear Fee/Fine Type error message after changing owner. Refs UIU-2670.
 
 ## [8.1.0](https://github.com/folio-org/ui-users/tree/v8.1.0) (2022-06-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.0.0...v8.1.0)

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -342,6 +342,7 @@ class FeeFineSettings extends React.Component {
         validate={this.validate}
         visibleFields={['feeFineType', 'defaultAmount', 'chargeNoticeId', 'actionNoticeId']}
         formType="final-form"
+        shouldReinitialize
       />
     );
   }


### PR DESCRIPTION
## Purpose 
We had an issue with error messages which happen because we do not clear the local state of `EditableListForm` component.
Using `shouldReinitialize` property we will clear it.

## Refs
[UIU-2670](https://issues.folio.org/browse/UIU-2670)

[Related story PR #1286](https://github.com/folio-org/stripes-smart-components/pull/1286)