### PR TITLE
UIU-2540: Fix broken link to item in export fees fines report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Fix issue with Qindex select automatically triggering the search on change. Refs UIU-2665.
 * create Jest/RTL test for NoteEditPage.js. Refs UIU-2424
 * Clear Fee/Fine Type error message after changing owner. Refs UIU-2670.
+* Fix broken link to item in export fees fines report. Refs UIU-2540.
 
 ## [8.1.0](https://github.com/folio-org/ui-users/tree/v8.1.0) (2022-06-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.0.0...v8.1.0)

--- a/src/components/data/reports/FeeFineReport.js
+++ b/src/components/data/reports/FeeFineReport.js
@@ -15,7 +15,8 @@ import {
   calculateRemainingAmount,
 } from '../../util';
 
-const getValue = (value) => value || '';
+const EMPTY_VALUE = '';
+const getValue = (value) => value || EMPTY_VALUE;
 
 const extractComments = (action) => {
   const replacer = (comment, regexp) => comment.replace(regexp, '').trim();
@@ -92,8 +93,8 @@ class FeeFineReport {
         actionDate: formatDateAndTime(action.dateAction, this.formatTime),
         actionDescription: formatActionDescription(action),
         actionAmount: formatCurrencyAmount(action.amountAction),
-        actionBalance: formatCurrencyAmount(action.balance) > 0 ? formatCurrencyAmount(action.balance) : '',
-        actionTransactionInfo: action.transactionInformation !== '-' ? action.transactionInformation : '',
+        actionBalance: formatCurrencyAmount(action.balance) > 0 ? formatCurrencyAmount(action.balance) : EMPTY_VALUE,
+        actionTransactionInfo: action.transactionInformation !== '-' ? action.transactionInformation : EMPTY_VALUE,
         actionCreatedAt: getServicePointOfCurrentAction(action, servicePoints),
         actionSource: action.source,
         actionInfoStaff,
@@ -101,26 +102,26 @@ class FeeFineReport {
         type: account.feeFineType,
         owner: account.feeFineOwner,
         billedDate: formatDateAndTime(account.metadata.createdDate, this.formatTime),
-        billedAmount: account.amount ? formatCurrencyAmount(account.amount) : '',
+        billedAmount: account.amount ? formatCurrencyAmount(account.amount) : EMPTY_VALUE,
         remainingAmount: calculateRemainingAmount(account.remaining),
         latestPaymentStatus: account.paymentStatus.name,
         details: account.id,
         itemInstance: getValue(account.title),
         itemMaterialType: getValue(account.materialType),
-        itemBarcode: account.barcode ? account.barcode : '',
+        itemBarcode: account.barcode ? account.barcode : EMPTY_VALUE,
         itemId: getValue(account.itemId),
         itemInstanceId: getValue(account.instanceId),
         itemHoldingsRecordId: getValue(account.holdingsRecordId),
         itemCallNumber: getValue(account.callNumber),
         itemLocation: getValue(account.location),
-        itemDueDate: account.dueDate ? formatDateAndTime(account.dueDate, this.formatTime) : '',
-        itemReturnedDate: account.returnedDate ? formatDateAndTime(account.returnedDate, this.formatTime) : '',
-        itemOverduePolicy: loan?.overdueFinePolicy ? loan.overdueFinePolicy.name : '',
-        itemOverduePolicyId: loan?.overdueFinePolicyId ? loan.overdueFinePolicyId : '',
-        itemLostPolicy: loan?.lostItemPolicy ? loan.lostItemPolicy.name : '',
-        itemLostPolicyId: loan?.lostItemPolicyId ? loan.lostItemPolicyId : '',
+        itemDueDate: account.dueDate ? formatDateAndTime(account.dueDate, this.formatTime) : EMPTY_VALUE,
+        itemReturnedDate: account.returnedDate ? formatDateAndTime(account.returnedDate, this.formatTime) : EMPTY_VALUE,
+        itemOverduePolicy: loan?.overdueFinePolicy ? loan.overdueFinePolicy.name : EMPTY_VALUE,
+        itemOverduePolicyId: loan?.overdueFinePolicyId ? loan.overdueFinePolicyId : EMPTY_VALUE,
+        itemLostPolicy: loan?.lostItemPolicy ? loan.lostItemPolicy.name : EMPTY_VALUE,
+        itemLostPolicyId: loan?.lostItemPolicyId ? loan.lostItemPolicyId : EMPTY_VALUE,
         itemLoanDetail: getValue(loan?.id),
-        loanId: (!account?.loanId || account?.loanId === '0') ? '' : account.loanId,
+        loanId: (!account?.loanId || account?.loanId === '0') ? EMPTY_VALUE : account.loanId,
       };
 
       reportData.push(reportRowFormatter);
@@ -134,11 +135,21 @@ class FeeFineReport {
     const origin = window.location.origin;
 
     return this.reportData.map(row => {
+      let itemBarcode;
+
+      if (row.itemInstanceId && row.itemHoldingsRecordId && row.itemId && row.itemBarcode) {
+        itemBarcode = `=HYPERLINK("${origin}/inventory/view/${row.itemInstanceId}/${row.itemHoldingsRecordId}/${row.itemId}", "${row.itemBarcode}")`;
+      } else if (row.itemBarcode) {
+        itemBarcode = this.formatMessage({ id: 'ui-users.details.field.barcode.notFound' }, { barcode: row.itemBarcode });
+      } else {
+        itemBarcode = EMPTY_VALUE;
+      }
+
       return {
         ...row,
         patronBarcode: `=HYPERLINK("${origin}/users/preview/${row.patronId}", "${row.patronBarcode}")`,
         details: `=HYPERLINK("${origin}/users/${row.patronId}/accounts/view/${row.details}", "${row.details}")`,
-        itemBarcode: `=HYPERLINK("${origin}/inventory/view/${row.itemInstanceId}/${row.itemHoldingsRecordId}/${row.itemId}", "${row.itemBarcode}")`,
+        itemBarcode,
         itemOverduePolicy: `=HYPERLINK("${origin}/settings/circulation/fine-policies/${row.itemOverduePolicyId}", "${row.itemOverduePolicy}")`,
         itemLostPolicy: `=HYPERLINK("${origin}/settings/circulation/lost-item-fee-policy/${row.itemLostPolicyId}", "${row.itemLostPolicy}")`,
         itemLoanDetails: `=HYPERLINK("${origin}/users/${row.patronId}/loans/view/${row.loanId}", "${row.loanId}")`,


### PR DESCRIPTION
## Purpose
Fix broken link to item in export fees fines report

## Approach 
When we have all necessary data we render link 
When we have barcode with out other data, this mean that we can't find and navigate to item and we notify about that
Constant for empty value was added

## Refs
https://issues.folio.org/browse/UIU-2540