### PR TITLE
UIU-2673: Change Fees/Fines History to use an ACTIONS menu instead of buttons

### DIFF
--- a/src/components/Accounts/Menu.js
+++ b/src/components/Accounts/Menu.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button,
   Col,
   PaneHeader,
   Row,
@@ -11,7 +10,6 @@ import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import {
   getFullName,
-  isRefundAllowed,
 } from '../util';
 
 import { refundClaimReturned } from '../../constants';
@@ -25,9 +23,6 @@ const Menu = (props) => {
     match: { params },
     filters,
     selected,
-    selectedAccounts,
-    feeFineActions,
-    actions,
     accounts
   } = props;
 
@@ -49,8 +44,6 @@ const Menu = (props) => {
 
   const showSelected = (selected !== 0 && selected !== parseFloat(0).toFixed(2))
     && outstanding > parseFloat(0).toFixed(2);
-  const buttonDisabled = !props.stripes.hasPerm('ui-users.feesfines.actions.all');
-  const canRefund = selectedAccounts.some((a) => isRefundAllowed(a, feeFineActions));
 
   const type = <FormattedMessage id={`ui-users.accounts.${params.accountstatus}`} />;
 
@@ -95,65 +88,8 @@ const Menu = (props) => {
       </Row>
     </div>);
 
-  const lastMenu = (
-    <div id="actions">
-      <Button
-        id="open-closed-all-charge-button"
-        marginBottom0
-        disabled={buttonDisabled}
-        to={`/users/${params.id}/charge`}
-      >
-        <FormattedMessage id="ui-users.accounts.button.new" />
-      </Button>
-      <Button
-        id="open-closed-all-pay-button"
-        marginBottom0
-        disabled={!((actions.regularpayment === true) && (buttonDisabled === false))}
-        buttonStyle="primary"
-        onClick={() => { props.onChangeActions({ regular: true }); }}
-      >
-        <FormattedMessage id="ui-users.accounts.history.button.pay" />
-      </Button>
-      <Button
-        id="open-closed-all-wave-button"
-        marginBottom0
-        disabled={!((actions.waive === true) && (buttonDisabled === false))}
-        buttonStyle="primary"
-        onClick={() => { props.onChangeActions({ waiveMany: true }); }}
-      >
-        <FormattedMessage id="ui-users.accounts.history.button.waive" />
-      </Button>
-      <Button
-        id="open-closed-all-refund-button"
-        marginBottom0
-        disabled={!((actions.refund === true) && (buttonDisabled === false) && (canRefund === true))}
-        buttonStyle="primary"
-        onClick={() => { props.onChangeActions({ refundMany: true }); }}
-      >
-        <FormattedMessage id="ui-users.accounts.history.button.refund" />
-      </Button>
-      <Button
-        id="open-closed-all-transfer-button"
-        marginBottom0
-        disabled={!((actions.transfer === true) && (buttonDisabled === false))}
-        buttonStyle="primary"
-        onClick={() => { props.onChangeActions({ transferMany: true }); }}
-      >
-        <FormattedMessage id="ui-users.accounts.history.button.transfer" />
-      </Button>
-      <Button
-        id="fee-fine-report-export-button"
-        marginBottom0
-        disabled={_.isEmpty(feeFineActions)}
-        buttonStyle="primary"
-        onClick={props.onExportFeesFinesReport}
-      >
-        <FormattedMessage id="ui-users.export.button" />
-      </Button>
-    </div>);
-
   return (
-    <PaneHeader firstMenu={firstMenu} lastMenu={lastMenu} />
+    <PaneHeader firstMenu={firstMenu} />
   );
 };
 
@@ -165,14 +101,9 @@ Menu.propTypes = {
   showFilters: PropTypes.bool,
   selected: PropTypes.number,
   filters: PropTypes.object,
-  actions: PropTypes.object,
   match: PropTypes.object,
   patronGroup: PropTypes.object,
-  selectedAccounts: PropTypes.arrayOf(PropTypes.object).isRequired,
-  feeFineActions: PropTypes.arrayOf(PropTypes.object).isRequired,
   accounts: PropTypes.arrayOf(PropTypes.object).isRequired,
-  onChangeActions: PropTypes.func,
-  onExportFeesFinesReport: PropTypes.func.isRequired,
 };
 
 export default Menu;

--- a/src/components/Accounts/Menu.test.js
+++ b/src/components/Accounts/Menu.test.js
@@ -1,5 +1,3 @@
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
 import account from 'fixtures/account';
 
@@ -49,43 +47,11 @@ const props = (accountData, filter, status) => {
   };
 };
 
-const acc = {
-  'id' : 'b6475706-4505-4b20-9ed0-aadcda2b72ee',
-  'paymentStatus': {
-    'name': 'Suspended claim returned'
-  },
-  'remaining' : 20,
-};
-
 describe('Menu component', () => {
   describe('Checking Menu', () => {
     it('if it renders', () => {
       renderMenu(props(account, true, 'Open'));
       expect(document.querySelector('[ id="outstanding-balance"]')).toBeInTheDocument();
-    });
-    it('Pay All feature', () => {
-      renderMenu(props(account, true, 'Open'));
-      userEvent.click(document.querySelector('[id="open-closed-all-pay-button"]'));
-      expect(onChangeMock).toHaveBeenCalled();
-    });
-    it('Waive feature', () => {
-      renderMenu(props(account, true, 'Open'));
-      userEvent.click(document.querySelector('[id="open-closed-all-wave-button"]'));
-      expect(onChangeMock).toHaveBeenCalled();
-    });
-    it('Tranfser feature', () => {
-      renderMenu(props(account, true, 'Open'));
-      userEvent.click(document.querySelector('[id="open-closed-all-transfer-button"]'));
-      expect(onChangeMock).toHaveBeenCalled();
-    });
-    it('Suspended Claim feature', () => {
-      renderMenu(props(acc, true, 'Open'));
-      expect(document.querySelector('[id="outstanding-balance"]')).toBeInTheDocument();
-    });
-    it('Filter feature', () => {
-      renderMenu(props(acc, false, 'closed'));
-      screen.debug();
-      expect(document.querySelector('[src="https://png.icons8.com/color/40/f39c12/filled-filter.png"]')).toBeInTheDocument();
     });
   });
 });

--- a/src/views/AccountsListing/AccountsListing.test.js
+++ b/src/views/AccountsListing/AccountsListing.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { createMemoryHistory } from 'history';
+
+import '__mock__/stripesCore.mock';
+import renderWithRouter from 'helpers/renderWithRouter';
+import account from 'fixtures/account';
+import okapiCurrentUser from 'fixtures/okapiCurrentUser';
+
+import AccountsHistory from './AccountsListing';
+
+jest.mock('../../components/Accounts/Actions/FeeFineActions', () => () => <></>);
+
+jest.unmock('@folio/stripes/components');
+
+const history = createMemoryHistory();
+
+const props = {
+  history,
+  location: history.location,
+  match: { params: {} },
+  isLoading: false,
+
+  resources: {
+    feefineshistory: { records: [] },
+    accountActions: {},
+    accounts: {},
+    feefineactions: {},
+    loans: {},
+    user: {
+      update: jest.fn(),
+    },
+    servicePoints: {},
+  },
+  mutator: {
+    activeRecord: {
+      update: jest.fn(),
+    },
+    feefineactions: {
+      POST: jest.fn(),
+    },
+    accountActions: {
+      GET: jest.fn(),
+    },
+    user: {
+      update: jest.fn(),
+    },
+  },
+  num: 42,
+  user: { id: '123' },
+  patronGroup: { group: 'Shiny happy people' },
+  itemDetails: {},
+  stripes: {
+    hasPerm: jest.fn().mockReturnValue(true),
+    connect: (Component) => Component,
+  },
+  account,
+  owedAmount: 45.67,
+  intl: {},
+  okapi: {
+    url: 'https://localhost:9130',
+    tenant: 'diku',
+    okapiReady: true,
+    authFailure: [],
+    bindings: {},
+    currentUser: okapiCurrentUser,
+  },
+};
+
+const renderAccountsListing = (extraProps = {}) => renderWithRouter(
+  <AccountsHistory {...props} {...extraProps} />
+);
+
+afterEach(() => jest.clearAllMocks());
+
+describe('Checking Action Menu', () => {
+  test('AccountListing pane should be present', async () => {
+    renderAccountsListing({ account });
+    expect(document.querySelector('#pane-account-listing')).toBeInTheDocument();
+  });
+
+  test('New fee/fine button should be present', () => {
+    renderAccountsListing({ account });
+    expect(document.querySelector('#open-closed-all-charge-button')).toBeInTheDocument();
+  });
+
+  test('Pay button should be present', () => {
+    renderAccountsListing({ account });
+    expect(document.querySelector('#open-closed-all-pay-button')).toBeInTheDocument();
+  });
+
+  test('Section show columns should be present', () => {
+    renderAccountsListing({ account });
+    expect(document.querySelector('#sectionShowColumns')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
The original work done in: https://github.com/folio-org/ui-users/pull/2259

[UIU-2673](https://issues.folio.org/browse/UIU-2673) Change Fees/Fines History to use an ACTIONS menu instead of buttons

![imagen](https://user-images.githubusercontent.com/39131594/194575820-d9d5d894-0fc3-4147-82dc-444f569fdd91.png)
