### PR TITLE
UIU-2697: Remove password validation from UserForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Fix sorting by "Patron" column on the "Lost items requiring actual cost" page. Refs UIU-2691.
 * A long Instance title climbs out of popover boundaries on the "Lost items requiring actual cost" page. Refs UIU-2693.
 * Fix validation regression on user form. Fixes UIU-2696.
+* Remove password validation from `<UserForm>`. Fixes UIU-2697.
 
 ## [8.1.0](https://github.com/folio-org/ui-users/tree/v8.1.0) (2022-06-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.0.0...v8.1.0)

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -55,10 +55,6 @@ function validate(values) {
     errors.username = <FormattedMessage id="ui-users.errors.missingRequiredUsername" />;
   }
 
-  if (!values.id && (!values.creds || !values.creds.password) && values.username) {
-    errors.creds = { password: <FormattedMessage id="ui-users.errors.missingRequiredPassword" /> };
-  }
-
   if (!values.patronGroup) {
     errors.patronGroup = <FormattedMessage id="ui-users.errors.missingRequiredPatronGroup" />;
   }


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2697

This PR removed password validation from `UserForm`. The password field is no longer accessible from the form.