### PR TITLE
UIU-2735: Fix problem with Fee/Fine list loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix systems error when attempting to create a new fee/fine if logged in user isn't logged into a service point. Refs UIU-2728.
 * Disable 'Claimed return' button after click to prevent multiple submissions. Refs UIU-2732.
 * Cover Actual cost functionality by jest/RTL tests. Refs UIU-2727.
+* Fix problem with Fee/Fine list loading. Refs UIU-2735.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/routes/AccountsListingContainer.js
+++ b/src/routes/AccountsListingContainer.js
@@ -60,7 +60,6 @@ class AccountsListingContainer extends React.Component {
       type: 'okapi',
       records: 'accounts',
       path: 'accounts',
-      recordsRequired: '%{activeRecord.records}',
       perRequest: MAX_RECORDS,
       GET: {
         params: {


### PR DESCRIPTION
## Purpose
Fix problem with Fee/Fine list loading

## Approach
When we trying to open Fee/Fine list we don't get it.
This problem do not reproduce (or do not reproduce often) when we open Fee/Fine list from user page.
This problem reproduced when we refresh page or copy/past link to Fee/Fine list.
With `recordsRequired: '%{activeRecord.records}'`, we get in response (`resources.feefineshistory`) `hasLoaded : false` when we refresh page.

## Refs
https://issues.folio.org/browse/UIU-2735

#### TODOS and Open Questions
Do not merge until discussion will be finished and we will have full understanding for best approach for fix this bug.
Hello @zburke , @mkuklis , @JohnC-80 , @artem-blazhko I don't see any necessity in `recordsRequired` in `manifest`. Could you please correct me if i am wrong? Could you please describe your opinion about current pull for find best approach for resolve current problem?
