### PR TITLE
UIU-2736: Refactor code for disable 'Declare lost' button after click to prevent multiple submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Disable 'Claimed return' button after click to prevent multiple submissions. Refs UIU-2732.
 * Cover Actual cost functionality by jest/RTL tests. Refs UIU-2727.
 * Fix problem with Fee/Fine list loading. Refs UIU-2735.
+* Refactor code for disable 'Declare lost' button after click to prevent multiple submissions. Refs UIU-2736.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -91,7 +91,6 @@ class ModalContent extends React.Component {
     loan: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
     handleError: PropTypes.func.isRequired,
-    declarationInProgress: PropTypes.bool.isRequired,
     isInProgress: PropTypes.bool,
     toggleButton: PropTypes.func,
     validateAction: PropTypes.func,
@@ -239,7 +238,6 @@ class ModalContent extends React.Component {
       loanAction,
       onClose,
       itemRequestCount,
-      declarationInProgress,
       isInProgress,
     } = this.props;
 
@@ -251,7 +249,7 @@ class ModalContent extends React.Component {
     //  - either to determine the content of the message about open requests
     //  - or whether to show this message at all.
     const countIndex = stripes.hasPerm('ui-users.requests.all') ? itemRequestCount : -1;
-    const isConfirmButtonDisabled = !additionalInfo || isInProgress || declarationInProgress;
+    const isConfirmButtonDisabled = !additionalInfo || isInProgress;
 
     return (
       <div>

--- a/src/components/ModalContent/ModalContent.test.js
+++ b/src/components/ModalContent/ModalContent.test.js
@@ -228,7 +228,7 @@ const renderModalContent = (props) => render(<ModalContent {...props} />);
 describe('Modal Content', () => {
   const commonProps = {
     isLoading: false,
-    declarationInProgress: false,
+    isInProgress: false,
     resources: {},
     mutator,
     loanAction: 'declareLost',

--- a/src/components/Wrappers/withDeclareLost.js
+++ b/src/components/Wrappers/withDeclareLost.js
@@ -13,7 +13,7 @@ const withDeclareLost = WrappedComponent => class WithDeclareLost extends React.
       declareLostDialogOpen: false,
       loan: null,
       itemRequestCount: 0,
-      declarationInProgress: false,
+      declareLostInProgress: false,
     };
   }
 
@@ -29,14 +29,14 @@ const withDeclareLost = WrappedComponent => class WithDeclareLost extends React.
     this.setState({ declareLostDialogOpen: false });
   }
 
-  toggleButton = (declarationInProgress) => {
-    this.setState({ declarationInProgress });
+  setDeclareLostInProgress = (declareLostInProgress) => {
+    this.setState({ declareLostInProgress });
   };
 
   render() {
     const {
       declareLostDialogOpen,
-      declarationInProgress,
+      declareLostInProgress,
       loan,
       itemRequestCount,
     } = this.state;
@@ -47,8 +47,8 @@ const withDeclareLost = WrappedComponent => class WithDeclareLost extends React.
       <>
         <WrappedComponent
           declareLost={this.declareLost}
-          declarationInProgress={declarationInProgress}
-          toggleButton={this.toggleButton}
+          declareLostInProgress={declareLostInProgress}
+          setDeclareLostInProgress={this.setDeclareLostInProgress}
           {...this.props}
         />
         { loan &&
@@ -58,9 +58,9 @@ const withDeclareLost = WrappedComponent => class WithDeclareLost extends React.
             loanAction={loanActionMutators.DECLARE_LOST}
             modalLabel={modalLabel}
             open={declareLostDialogOpen}
-            declarationInProgress={declarationInProgress}
+            isInProgress={declareLostInProgress}
             onClose={this.hideDeclareLostDialog}
-            toggleButton={this.toggleButton}
+            toggleButton={this.setDeclareLostInProgress}
             {...this.props}
           />
         }

--- a/src/components/Wrappers/withDeclareLost.test.js
+++ b/src/components/Wrappers/withDeclareLost.test.js
@@ -23,18 +23,18 @@ LoanActionDialogMock.propTypes = {
 
 jest.mock('../LoanActionDialog', () => LoanActionDialogMock);
 
-const DeclareLost = ({ declareLost, declarationInProgress, toggleButton }) => (
+const DeclareLost = ({ declareLost, declareLostInProgress, setDeclareLostInProgress }) => (
   <>
-    <button type="button" data-testid="enable" onClick={() => toggleButton(false)}>Enable</button>
-    { !declarationInProgress ?
+    <button type="button" data-testid="enable" onClick={() => setDeclareLostInProgress(false)}>Enable</button>
+    { !declareLostInProgress ?
       <button type="button" data-testid="declareLost" onClick={() => declareLost(loans[0], 1)}>Declaration</button> : ''}
   </>
 );
 
 DeclareLost.propTypes = {
-  toggleButton: PropTypes.func,
+  setDeclareLostInProgress: PropTypes.func,
   declareLost: PropTypes.func,
-  declarationInProgress: PropTypes.bool,
+  declareLostInProgress: PropTypes.bool,
 };
 
 const WrappedComponent = withDeclareLost(DeclareLost);

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -88,8 +88,8 @@ class LoanDetails extends React.Component {
     declareLost: PropTypes.func,
     markAsMissing: PropTypes.func,
     claimReturned: PropTypes.func,
-    toggleButton: PropTypes.func,
-    declarationInProgress: PropTypes.bool,
+    setDeclareLostInProgress: PropTypes.func,
+    declareLostInProgress: PropTypes.bool,
     patronBlocks: PropTypes.arrayOf(PropTypes.object),
     intl: PropTypes.object.isRequired,
     match: PropTypes.object.isRequired,
@@ -99,7 +99,7 @@ class LoanDetails extends React.Component {
   };
 
   static defaultProps = {
-    toggleButton: noop,
+    setDeclareLostInProgress: noop,
     loanAccountActions: [],
   };
 
@@ -127,7 +127,7 @@ class LoanDetails extends React.Component {
     const prevItemStatus = prevProps.loan?.item?.status?.name;
     const thistItemStatus = this.props.loan?.item?.status?.name;
     if (prevItemStatus && prevItemStatus !== thistItemStatus) {
-      this.props.toggleButton(false);
+      this.props.setDeclareLostInProgress(false);
     }
   }
 
@@ -346,7 +346,7 @@ class LoanDetails extends React.Component {
       declareLost,
       markAsMissing,
       claimReturned,
-      declarationInProgress,
+      declareLostInProgress,
       loanIsMissing,
       isLoading,
       showErrorCallout,
@@ -544,7 +544,7 @@ class LoanDetails extends React.Component {
                 <IfPermission perm="ui-users.loans.declare-item-lost">
                   <Button
                     data-test-declare-lost-button
-                    disabled={declarationInProgress || buttonDisabled || isDeclaredLostItem}
+                    disabled={declareLostInProgress || buttonDisabled || isDeclaredLostItem}
                     buttonStyle="primary"
                     onClick={() => declareLost(loan, itemRequestCount)}
                   >


### PR DESCRIPTION
## Purpose
Refactor code for disable 'Declare lost' button after click to prevent multiple submissions.

## Approach
UIU-2372 introduced a generic isInProgress prop which should be used in lieu of props like claimedReturnInProgress or declarationInProgress that pollute this generic component with business logic they don't need to know about.

## Refs
https://issues.folio.org/browse/UIU-2736