### PR TITLE
UIU-2732: Disable 'Claimed return' button after click to prevent multiple submissions

### DIFF
--- a/src/components/Wrappers/withClaimReturned.js
+++ b/src/components/Wrappers/withClaimReturned.js
@@ -115,8 +115,6 @@ const withClaimReturned = WrappedComponent => class withClaimReturnedComponent e
       <>
         <WrappedComponent
           claimReturned={this.openClaimReturnedDialog}
-          isInProgress={claimReturnedInProgress}
-          toggleButton={this.setClaimReturnedInProgress}
           {...this.props}
         />
         { loan &&


### PR DESCRIPTION
## Purpose
Disable 'Claimed return' button after click to prevent multiple submissions.

## Approach
Remove unused variables for remove possible get side effect

## Refs
https://issues.folio.org/browse/UIU-2732