### PR TITLE
UIU-2700: "Refund" option should not be available for cancelled fee/fine that was already refunded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix systems error when attempting to create a new fee/fine if logged in user isn't logged into a service point. Refs UIU-2728.
 * Disable 'Claimed return' button after click to prevent multiple submissions. Refs UIU-2732.
 * Cover Actual cost functionality by jest/RTL tests. Refs UIU-2727.
+* Make Refund button disabled if fee/fine was cancelled as an error. Refs UIU-2700.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -3,6 +3,7 @@ import {
   refundStatuses,
   outstandingStatus,
   waiveStatuses,
+  cancelStatuses,
 } from '../../constants';
 
 export function count(array) {
@@ -109,10 +110,11 @@ export function accountRefundInfo(account, feeFineActions = []) {
   const hasBeenPaid = accountFeeFinesActions.some(({ typeAction }) => {
     return paymentStatusesAllowedToRefund.includes(typeAction);
   });
+  const canceledAsError = accountFeeFinesActions.some(({ typeAction }) => typeAction === cancelStatuses.cancelledError);
 
   const paidAmount = (parseFloat(account.amount - account.remaining) * 100) / 100;
 
-  return { hasBeenPaid, paidAmount };
+  return { hasBeenPaid, paidAmount, canceledAsError };
 }
 
 export function calculateTotalPaymentAmount(accounts = [], feeFineActions = []) {

--- a/src/components/Accounts/accountFunctions.test.js
+++ b/src/components/Accounts/accountFunctions.test.js
@@ -1,6 +1,7 @@
 import account from 'fixtures/account';
 
-import { count,
+import {
+  count,
   calculateSelectedAmount,
   calculateRemainingAmount,
   loadServicePoints,
@@ -8,7 +9,11 @@ import { count,
   calculateTotalPaymentAmount,
   calculateOwedFeeFines,
   isCancelAllowed,
-  deleteOptionalActionFields } from './accountFunctions';
+  deleteOptionalActionFields,
+} from './accountFunctions';
+import {
+  paymentStatusesAllowedToRefund,
+} from '../../constants';
 
 
 const tempArray = [{
@@ -87,10 +92,45 @@ describe('Account Functions', () => {
     expect(ownerId1).toBe('a152c90d-e94d-4784-ab4f-4208a0672673');
     expect(ownerId2).toBe('a152c90d-e94d-4784-ab4f-4208a0672673');
   });
-  it('If accountRefundInfo works', async () => {
-    const data = accountRefundInfo(account);
-    expect(data.paidAmount).toBe(90);
+
+  describe('accountRefundInfo', () => {
+    const userAccount = {
+      id: 'id',
+      amount: 100,
+      remaining: 20,
+    };
+
+    describe('when "feeFineActions" is empty', () => {
+      it('should return correct data', () => {
+        const expectedResult = {
+          canceledAsError: false,
+          hasBeenPaid: false,
+          paidAmount: 80,
+        };
+        const result = accountRefundInfo(userAccount);
+
+        expect(result).toEqual(expectedResult);
+      });
+    });
+
+    describe('when "feeFineActions" is not empty', () => {
+      it('should return correct data', () => {
+        const expectedResult = {
+          canceledAsError: false,
+          hasBeenPaid: true,
+          paidAmount: 80,
+        };
+        const feeFineActions = [{
+          accountId: userAccount.id,
+          typeAction: paymentStatusesAllowedToRefund[0],
+        }];
+        const result = accountRefundInfo(userAccount, feeFineActions);
+
+        expect(result).toEqual(expectedResult);
+      });
+    });
   });
+
   it('If calculateTotalPaymentAmount works', async () => {
     const data = calculateTotalPaymentAmount([account]);
     expect(data).toBe(0);

--- a/src/components/util/isRefundAllowed.js
+++ b/src/components/util/isRefundAllowed.js
@@ -4,10 +4,10 @@ import {
 } from '../Accounts/accountFunctions';
 
 const isRefundAllowed = (account, feeFineActions) => {
-  const { hasBeenPaid, paidAmount } = accountRefundInfo(account, feeFineActions);
+  const { hasBeenPaid, paidAmount, canceledAsError } = accountRefundInfo(account, feeFineActions);
   const isAccountRefunded = calculateSelectedAmount([account], true, feeFineActions) <= 0;
 
-  return !isAccountRefunded && hasBeenPaid && paidAmount > 0;
+  return !isAccountRefunded && !canceledAsError && hasBeenPaid && paidAmount > 0;
 };
 
 export default isRefundAllowed;

--- a/src/components/util/isRefundAllowed.test.js
+++ b/src/components/util/isRefundAllowed.test.js
@@ -8,6 +8,7 @@ jest.mock('../Accounts/accountFunctions', () => ({
   accountRefundInfo: jest.fn(() => ({
     hasBeenPaid: true,
     paidAmount: 100,
+    canceledAsError: false,
   })),
   calculateSelectedAmount: jest.fn(() => 100),
 }));
@@ -51,6 +52,20 @@ describe('isRefundAllowed', () => {
 
   it('should return "false" if "paidAmount" more than 0, "calculateSelectedAmount" less or equal 0, and "hasBeenPaid" is true', () => {
     calculateSelectedAmount.mockReturnValueOnce(0);
+
+    expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(false);
+  });
+
+  it('should return true if fee/fine was not cancelled as an error', () => {
+    expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(true);
+  });
+
+  it('should return false if fee/fine was cancelled as an error', () => {
+    accountRefundInfo.mockReturnValueOnce({
+      hasBeenPaid: true,
+      paidAmount: 10,
+      canceledAsError: true,
+    });
 
     expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(false);
   });

--- a/src/constants.js
+++ b/src/constants.js
@@ -95,6 +95,10 @@ export const refundStatuses = {
   RefundedPartially: 'Refunded partially',
 };
 
+export const cancelStatuses = {
+  cancelledError: 'Cancelled as error',
+};
+
 export const outstandingStatus = 'Outstanding';
 
 export const FEE_FINE_ACTIONS = {


### PR DESCRIPTION
## Purpose
When the fee/fine is canceled as an Error it can not be refunded and "Refund" action button should be disabled. But it is not disabled.

## Approach
I check if the fee/fine was canceled as an error and in this case, I make "Refund" button disabled.

## Refs
[UIU-2700](https://issues.folio.org/browse/UIU-2700)