### PR TITLE
UIU-2747 enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore: 
+    ignore:
       - dependency-name: "faker"
       - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "react-intl"
       - dependency-name: "react-router"
       - dependency-name: "react-router-dom"
-      
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore: 
+      - dependency-name: "faker"
+      - dependency-name: "react"
+      - dependency-name: "react-router"
+      - dependency-name: "react-router-dom"
+      

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix problem with Fee/Fine list loading. Refs UIU-2735.
 * Refactor code for disable 'Declare lost' button after click to prevent multiple submissions. Refs UIU-2736.
 * Implement searching for "Lost items requiring actual cost" page. Refs UIU-1866.
+* Enable dependabot. Refs UIU-2747, FOLIO-3664.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)


### PR DESCRIPTION
Enable dependabot. This is a POC. This is only a POC. If this turns out to be overwhelming, we'll turn it off.

See https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates for configuration options, including ignoring certain libraries and automatically tagging certain contributors for review, among many other options.

Refs [UIU-2747](https://issues.folio.org/browse/UIU-2747), [FOLIO-3664](https://issues.folio.org/browse/FOLIO-3664)