### PR TITLE
UIU-2765: Add support for request-storage 5.0 around UserRequests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Enable dependabot. Refs UIU-2747, FOLIO-3664.
 * Suppress delete of users stored in a configuration entry. Refs UIU-2738.
 * Remove BigTest infrastructure including tests, deps, config. Refs UIU-2745.
+* Add support for `request-storage` version `5.0` for `<UserRequests>`. Refs UIU-2765.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -780,7 +780,7 @@ class UserDetail extends React.Component {
                 </IfPermission>
 
                 <IfPermission perm="ui-users.requests.all">
-                  <IfInterface name="request-storage" version="2.5 3.0 4.0">
+                  <IfInterface name="request-storage" version="2.5 3.0 4.0 5.0">
                     <IfInterface name="circulation">
                       <UserRequests
                         expanded={sections.requestsSection}


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2765

Add support for `request-storage` 5.0 around `UserRequests`.