### PR TITLE
UIU-2759: Add support for checkbox custom field filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * *BREAKING* Upgrade to `@folio/stripes` `v8`. Refs UIU-2761.
 * *BREAKING* Upgrade `react-redux` to `v8`. Refs UIU-2775.
 * Create Jest/RTL test for UserDetailFullscreen.js. Refs UIU-2429.
+* Add support for checkbox custom field filter. Fixes UIU-2759.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/components/CustomFieldsFilters/CustomFieldsFilter.js
+++ b/src/components/CustomFieldsFilters/CustomFieldsFilter.js
@@ -15,6 +15,7 @@ const customFieldTypeToFilterMap = {
   MULTI_SELECT_DROPDOWN: MultiSelectionFilter,
   RADIO_BUTTON: CheckboxFilter,
   SINGLE_SELECT_DROPDOWN: MultiSelectionFilter,
+  SINGLE_CHECKBOX: CheckboxFilter,
 };
 
 const CustomFieldsFilter = ({
@@ -32,12 +33,11 @@ const CustomFieldsFilter = ({
   const {
     refId,
     name,
-    selectField: {
-      options: {
-        values,
-      },
-    },
+    selectField,
   } = customField;
+
+
+  const values = selectField?.options?.values ?? [{ id: 'true', value: name }];
   const filterName = `customFields-${refId}`;
   const selectedValues = activeFilters[filterName];
   const dataOptions = values.map(({ id: value, value: label }) => ({ label, value }));


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2759

The single checkbox custom field was not wired with the checkbox filter. This PR adds the mapping between  `SINGLE_CHECKBOX` custom field and `CheckboxFilter`.