### PR TITLE
UIU-2788: Use updateUser from @folio/stripes-core to update service-point data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * *BREAKING* Upgrade `react-redux` to `v8`. Refs UIU-2775.
 * Create Jest/RTL test for UserDetailFullscreen.js. Refs UIU-2429.
 * Add support for checkbox custom field filter. Fixes UIU-2759.
+* Use `updateUser` from `@folio/stripes-core` to update service-point data. Refs UIU-2788.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/components/Wrappers/withServicePoints.js
+++ b/src/components/Wrappers/withServicePoints.js
@@ -4,8 +4,7 @@ import { get, keyBy } from 'lodash';
 
 import {
   stripesShape,
-  setServicePoints,
-  setCurServicePoint,
+  updateUser,
   HandlerManager,
   coreEvents as events,
 } from '@folio/stripes/core';
@@ -175,11 +174,11 @@ const withServicePoints = WrappedComponent => class WithServicePointsComponent e
     setCurrentServicePoint(servicePoints, defaultServicePointId) {
       const { stripes: { store } } = this.props;
 
-      setServicePoints(store, servicePoints);
+      updateUser(store, { servicePoints });
 
       if (defaultServicePointId) {
-        const sp = servicePoints.find(r => r.id === defaultServicePointId);
-        setCurServicePoint(store, sp);
+        const curServicePoint = servicePoints.find(r => r.id === defaultServicePointId);
+        updateUser(store, { curServicePoint });
       } else if (this._isMounted) {
         this.setState({
           showChangeServicePointHandler: true

--- a/src/components/Wrappers/withServicePoints.test.js
+++ b/src/components/Wrappers/withServicePoints.test.js
@@ -10,8 +10,7 @@ import withServicePoints from './withServicePoints';
 jest.mock('@folio/stripes/core', () => {
   return {
     ...jest.requireActual('@folio/stripes/core'),
-    setServicePoints: () => jest.fn(),
-    setCurServicePoint: () => jest.fn(),
+    updateUser: () => jest.fn(),
     HandlerManager: () => <div>HandlerManagerMock</div>
   };
 });
@@ -48,51 +47,48 @@ const props = {
   resources,
   stripes: {
     hasPerm: jest.fn().mockReturnValue(true),
+    hasInterface: jest.fn().mockReturnValue(true),
     user: {
       user: {
         id: '1'
       }
-    }
+    },
+    clone: jest.fn()
   },
 };
 
 const MockComponent = ({ getUserServicePoints, getPreferredServicePoint, updateServicePoints }) => {
   useEffect(() => {
-    const isMounted = true;
-    if (isMounted) {
-      getUserServicePoints();
-      getPreferredServicePoint();
-      updateServicePoints(okapiCurrentUser.servicePoints, '-');
-    }
-  });
+    getUserServicePoints();
+    getPreferredServicePoint();
+    updateServicePoints(okapiCurrentUser.servicePoints, '-');
+  }, [getUserServicePoints, getPreferredServicePoint, updateServicePoints]);
 
   return (
-    <>
-      <div data-testid="userService">Test Mock Component</div>
-    </>
+    <div data-testid="userService">Test Mock Component</div>
   );
 };
 
 MockComponent.propTypes = {
   getUserServicePoints: PropTypes.func,
   getPreferredServicePoint: PropTypes.func,
-  updateServicePoints: PropTypes.bool,
+  updateServicePoints: PropTypes.func,
 };
 
 const WrappedComponent = withServicePoints(MockComponent);
-const renderwithServicePoints = () => render(<WrappedComponent {...props} />);
+const renderWithServicePoints = () => render(<WrappedComponent {...props} />);
 
 describe('withDeclareLost', () => {
   test('render wrapped component', () => {
-    renderwithServicePoints();
+    renderWithServicePoints();
     expect(screen.getByText('Test Mock Component')).toBeInTheDocument();
   });
   test('Check if update is called', () => {
-    renderwithServicePoints();
+    renderWithServicePoints();
     expect(mockPut).toHaveBeenCalled();
   });
   test('Check if service points are called', () => {
-    renderwithServicePoints();
+    renderWithServicePoints();
     expect(mockGet).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2788

The `setServicePoints` and  `setCurServicePoint` were removed from `stripes-core` in https://issues.folio.org/browse/UIU-2788

Instead, a new API was introduced called `updateUser` to modify user session data.

This PR replaces `setServicePoints` and  `setCurServicePoint` with `updateUser` to align with the recent changes in stripes-core.