### PR TITLE
UIU-2790 show users' service points correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Create Jest/RTL test for UserDetailFullscreen.js. Refs UIU-2429.
 * Add support for checkbox custom field filter. Fixes UIU-2759.
 * Use `updateUser` from `@folio/stripes-core` to update service-point data. Refs UIU-2788.
+* Show correct service points when navigating among users. Refs UIU-2790.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/components/Wrappers/withServicePoints.js
+++ b/src/components/Wrappers/withServicePoints.js
@@ -86,14 +86,25 @@ const withServicePoints = WrappedComponent => class WithServicePointsComponent e
       // Save the id of the record in the service-points-users table for later use when mutating it.
       const servicePointUserId = get(nextProps.resources.servicePointsUsers, ['records', 0, 'id'], '');
       const localServicePointUserId = nextProps.resources.servicePointUserId;
+
+      // Why this gross shouldUpdateState variable? It makes things easy:
+      // if the id is changing, then we know the SPs cached in state need
+      // to change too. The test below that compares servicePointsUsers
+      // with servicePoints is insufficient when transitioning between
+      // users with the same numbers of SPs assigned or if both queries
+      // are still in-progress. Thus, shouldUpdateState serves to clear
+      // out state when the ID changes, and then the array comparison
+      // serves to fill in state when the queries complete.
+      let shouldUpdateState = false;
       if (servicePointUserId && servicePointUserId !== localServicePointUserId) {
         nextProps.mutator.servicePointUserId.replace(servicePointUserId);
+        shouldUpdateState = true;
       }
 
       // Check if new user service points have been received and the list of all service points has also been received.
       const userServicePointsIds = get(nextProps.resources.servicePointsUsers, ['records', 0, 'servicePointsIds'], []);
       const servicePoints = get(nextProps.resources.servicePoints, ['records'], []);
-      if ((userServicePointsIds.length !== state.userServicePoints.length) && servicePoints.length) {
+      if (shouldUpdateState || ((userServicePointsIds.length !== state.userServicePoints.length) && servicePoints.length)) {
         const servicePointsById = keyBy(servicePoints, 'id');
         const userServicePoints = userServicePointsIds
           .filter(id => servicePointsById[id])


### PR DESCRIPTION
Correctly update the list of service points for each user when navigating among users by making sure local state is updated whenever the user changes. Previous comparisons between state and resources were insufficient.

Refs [UIU-2790](https://issues.folio.org/browse/UIU-2790)