### PR TITLE
UIU-2672 Update permUserId before updating permissions. (#2235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## [8.1.4] IN PROGRESS
+
+* Update `permUserId` before updating permissions. Fixes UIU-2672/UIU-2789.
+
 ## [8.1.3](https://github.com/folio-org/ui-users/tree/v8.1.3) (2022-08-23)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.2...v8.1.3)
 

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -292,6 +292,7 @@ class UserEdit extends React.Component {
       // Create a new permissions user record first
       await permUserMutator.POST({ userId }).then(record => {
         record.permissions = permissionNames;
+        permUserId.replace(record.id);
         permissionsMutator
           .PUT(record)
           .catch((e) => showErrorCallout(e, this.context.sendCallout));


### PR DESCRIPTION
Check if permissions exist when adding new permissions to user record

Refs [UIU-2672](https://issues.folio.org/browse/UIU-2672) (the original fix) and [UIU-2789](https://issues.folio.org/browse/UIU-2789) (patch release for MG)