### PR TITLE
UIU-2790 show users' service points correctly (#2339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Use stable tests.
 * Update `permUserId` before updating permissions. Fixes UIU-2672/UIU-2789.
+* Show correct service points when navigating among users. Refs UIU-2790.
 
 ## [8.1.3](https://github.com/folio-org/ui-users/tree/v8.1.3) (2022-08-23)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.2...v8.1.3)


### PR DESCRIPTION
Correctly update the list of service points for each user when navigating among users by making sure local state is updated whenever the user changes. Previous comparisons between state and resources were insufficient.

Refs [UIU-2790](https://issues.folio.org/browse/UIU-2790), [UIU-2795](https://issues.folio.org/browse/UIU-2795)