### PR TITLE
UIU-2790 show users' service points correctly (#2339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 8.2.5 IN PROGRESS
+
+* Show correct service points when navigating among users. Refs UIU-2790.
+
 ## [8.2.4](https://github.com/folio-org/ui-users/tree/v8.2.4) (2022-12-08)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.2.3...v8.2.4)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/users",
-  "version": "8.2.4",
+  "version": "8.2.5",
   "description": "User management",
   "repository": "folio-org/ui-users",
   "publishConfig": {


### PR DESCRIPTION
Correctly update the list of service points for each user when navigating among users by making sure local state is updated whenever the user changes. Previous comparisons between state and resources were insufficient.

Refs [UIU-2790](https://issues.folio.org/browse/UIU-2790), [UIU-2796](https://issues.folio.org/browse/UIU-2796)