### PR TITLE
UIU-2700: "Refund" option should not be available for cancelled fee/fine that was already refunded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Add support for checkbox custom field filter. Fixes UIU-2759.
 * Use `updateUser` from `@folio/stripes-core` to update service-point data. Refs UIU-2788.
 * Show correct service points when navigating among users. Refs UIU-2790.
+* Make unavailable "Refund" option for cancelled fee/fine that was already refunded. Refs UIU-2700.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -3,6 +3,7 @@ import {
   refundStatuses,
   outstandingStatus,
   waiveStatuses,
+  cancelledStatus,
 } from '../../constants';
 
 export function count(array) {
@@ -109,10 +110,14 @@ export function accountRefundInfo(account, feeFineActions = []) {
   const hasBeenPaid = accountFeeFinesActions.some(({ typeAction }) => {
     return paymentStatusesAllowedToRefund.includes(typeAction);
   });
-
   const paidAmount = (parseFloat(account.amount - account.remaining) * 100) / 100;
+  const isCanceledAfterRefund = account.remaining === 0 && account.paymentStatus.name === cancelledStatus;
 
-  return { hasBeenPaid, paidAmount };
+  return {
+    hasBeenPaid,
+    paidAmount,
+    isCanceledAfterRefund,
+  };
 }
 
 export function calculateTotalPaymentAmount(accounts = [], feeFineActions = []) {

--- a/src/components/util/isRefundAllowed.js
+++ b/src/components/util/isRefundAllowed.js
@@ -4,10 +4,10 @@ import {
 } from '../Accounts/accountFunctions';
 
 const isRefundAllowed = (account, feeFineActions) => {
-  const { hasBeenPaid, paidAmount } = accountRefundInfo(account, feeFineActions);
+  const { hasBeenPaid, paidAmount, isCanceledAfterRefund } = accountRefundInfo(account, feeFineActions);
   const isAccountRefunded = calculateSelectedAmount([account], true, feeFineActions) <= 0;
 
-  return !isAccountRefunded && hasBeenPaid && paidAmount > 0;
+  return !isAccountRefunded && !isCanceledAfterRefund && hasBeenPaid && paidAmount > 0;
 };
 
 export default isRefundAllowed;

--- a/src/components/util/isRefundAllowed.test.js
+++ b/src/components/util/isRefundAllowed.test.js
@@ -8,6 +8,7 @@ jest.mock('../Accounts/accountFunctions', () => ({
   accountRefundInfo: jest.fn(() => ({
     hasBeenPaid: true,
     paidAmount: 100,
+    isCanceledAfterRefund: false,
   })),
   calculateSelectedAmount: jest.fn(() => 100),
 }));
@@ -27,23 +28,35 @@ describe('isRefundAllowed', () => {
     expect(calculateSelectedAmount).toHaveBeenCalledWith([mockedAccount], true, mockedActions);
   });
 
-  it('should return "true" if "paidAmount" and "calculateSelectedAmount" more than 0, and "hasBeenPaid" is true', () => {
+  it('should return "true" if "paidAmount" and "calculateSelectedAmount" more than 0, "isCanceledAfterRefund" is false, and "hasBeenPaid" is true', () => {
     expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(true);
   });
 
-  it('should return "false" if "paidAmount" and "calculateSelectedAmount" more than 0, and "hasBeenPaid" is false', () => {
+  it('should return "false" if "paidAmount" and "calculateSelectedAmount" more than 0, "isCanceledAfterRefund" is true, and "hasBeenPaid" is false', () => {
     accountRefundInfo.mockReturnValueOnce({
       hasBeenPaid: false,
       paidAmount: 100,
+      isCanceledAfterRefund: true,
     });
 
     expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(false);
   });
 
-  it('should return "false" if "paidAmount" less or equal 0, "calculateSelectedAmount" more than 0, and "hasBeenPaid" is true', () => {
+  it('should return "false" if "paidAmount" and "calculateSelectedAmount" more than 0, "isCanceledAfterRefund" is true, and "hasBeenPaid" is true', () => {
+    accountRefundInfo.mockReturnValueOnce({
+      hasBeenPaid: true,
+      paidAmount: 100,
+      isCanceledAfterRefund: true,
+    });
+
+    expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(false);
+  });
+
+  it('should return "false" if "paidAmount" less or equal 0, "calculateSelectedAmount" more than 0, "isCanceledAfterRefund" is true, and "hasBeenPaid" is true', () => {
     accountRefundInfo.mockReturnValueOnce({
       hasBeenPaid: true,
       paidAmount: 0,
+      isCanceledAfterRefund: true,
     });
 
     expect(isRefundAllowed(mockedAccount, mockedActions)).toBe(false);

--- a/src/constants.js
+++ b/src/constants.js
@@ -96,6 +96,8 @@ export const refundStatuses = {
   RefundedPartially: 'Refunded partially',
 };
 
+export const cancelledStatus = 'Cancelled as error';
+
 export const outstandingStatus = 'Outstanding';
 
 export const FEE_FINE_ACTIONS = {


### PR DESCRIPTION
## Purpose
Fee/fine that was refunded with the full amount and then canceled as an error can not be refunded one more time.

## Refs
[UIU-2700](https://issues.folio.org/browse/UIU-2700)