### PR TITLE
UIU-2794: Fix problem with an additional information comment that can't  be added after a page reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Use `updateUser` from `@folio/stripes-core` to update service-point data. Refs UIU-2788.
 * Show correct service points when navigating among users. Refs UIU-2790.
 * Make unavailable "Refund" option for cancelled fee/fine that was already refunded. Refs UIU-2700.
+* Fix problem with additional information comment that can't be added after a page reload. Refs UIU-2794.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/components/Accounts/Actions/FeeFineActions.js
+++ b/src/components/Accounts/Actions/FeeFineActions.js
@@ -47,6 +47,9 @@ class Actions extends React.Component {
       type: 'okapi',
       records: 'feefineactions',
       path: `feefineactions?query=(userId==%{user.id})&limit=${MAX_RECORDS}`,
+      POST: {
+        path: 'feefineactions',
+      },
       shouldRefresh: (resource, action, refresh) => {
         const { path } = action.meta;
 


### PR DESCRIPTION
## Purpose
Fix problem with an additional information comment that can't be added after a page reload

## Refs
https://issues.folio.org/browse/UIU-2794