### PR TITLE
UIU-2803 show an error if proxy record is corrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Use `updateUser` from `@folio/stripes-core` to update service-point data. Refs UIU-2788.
 * Show correct service points when navigating among users. Refs UIU-2790.
 * Make unavailable "Refund" option for cancelled fee/fine that was already refunded. Refs UIU-2700.
+* Show an error if the proxy record is corrupt, instead of an NPE. Refs UIU-2803.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/components/ProxyGroup/ProxyItem/ProxyItem.js
+++ b/src/components/ProxyGroup/ProxyItem/ProxyItem.js
@@ -3,12 +3,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedTime, FormattedDate } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { Row, Col, KeyValue, LayoutHeader } from '@folio/stripes/components';
+import { Row, Col, KeyValue, LayoutHeader, NoValue } from '@folio/stripes/components';
 
 import { getFullName } from '../../util';
 import css from './ProxyItem.css';
 
 const ProxyItem = ({ record }) => {
+  if (!record.user) {
+    return <FormattedMessage id="ui-users.errors.proxies.invalidUserLabel" />;
+  }
+
   const creationDateTime = <FormattedTime
     value={record.proxy.metadata.createdDate}
     day="numeric"
@@ -34,7 +38,7 @@ const ProxyItem = ({ record }) => {
   );
 
   const expirationDate = (record.proxy && record.proxy.expirationDate) ?
-    <FormattedDate value={record.proxy.expirationDate} /> : '-';
+    <FormattedDate value={record.proxy.expirationDate} /> : <NoValue />;
 
   return (
     <div className={css.item}>
@@ -45,8 +49,9 @@ const ProxyItem = ({ record }) => {
             <Row>
               <Col xs={12}>
                 <KeyValue
+                  data-testid="status"
                   label={<FormattedMessage id="ui-users.proxy.relationshipStatus" />}
-                  value={_.get(record, ['proxy', 'status'], '-')}
+                  value={_.get(record, ['proxy', 'status'], <NoValue />)}
                 />
               </Col>
             </Row>
@@ -55,6 +60,7 @@ const ProxyItem = ({ record }) => {
             <Row>
               <Col xs={12}>
                 <KeyValue
+                  data-testid="expirationDate"
                   label={<FormattedMessage id="ui-users.expirationDate" />}
                   value={expirationDate}
                 />
@@ -67,8 +73,9 @@ const ProxyItem = ({ record }) => {
             <Row>
               <Col xs={12}>
                 <KeyValue
+                  data-testid="requestForSponsor"
                   label={<FormattedMessage id="ui-users.proxy.requestForSponsor" />}
-                  value={_.get(record, ['proxy', 'requestForSponsor'], '-')}
+                  value={_.get(record, ['proxy', 'requestForSponsor'], <NoValue />)}
                 />
               </Col>
             </Row>
@@ -77,8 +84,9 @@ const ProxyItem = ({ record }) => {
             <Row>
               <Col xs={12}>
                 <KeyValue
+                  data-testid="notificationsTo"
                   label={<FormattedMessage id="ui-users.proxy.notificationsTo" />}
-                  value={_.get(record, ['proxy', 'notificationsTo'], '-')}
+                  value={_.get(record, ['proxy', 'notificationsTo'], <NoValue />)}
                 />
               </Col>
             </Row>
@@ -89,8 +97,9 @@ const ProxyItem = ({ record }) => {
             <Row>
               <Col xs={12}>
                 <KeyValue
+                  data-testid="accrueTo"
                   label={<FormattedMessage id="ui-users.proxy.accrueTo" />}
-                  value={_.get(record, ['proxy', 'accrueTo'], '-')}
+                  value={_.get(record, ['proxy', 'accrueTo'], <NoValue />)}
                 />
               </Col>
             </Row>

--- a/src/components/ProxyGroup/ProxyItem/ProxyItem.test.js
+++ b/src/components/ProxyGroup/ProxyItem/ProxyItem.test.js
@@ -31,7 +31,7 @@ describe('Render ProxyItem component', () => {
     expect(screen.getAllByText('ui-users.proxy.relationshipStatus')).toBeTruthy();
     expect(screen.getByText('ui-users.expirationDate')).toBeInTheDocument();
 
-    // we want to see the expiration date
+    // expiration date should match record.proxy
     const expirationDate = screen.getByTestId('expirationDate');
     expect(within(expirationDate).queryByText('11/23/2021')).toBeTruthy();
   });
@@ -58,11 +58,12 @@ describe('Render ProxyItem component', () => {
     expect(screen.getAllByText('ui-users.proxy.relationshipStatus')).toBeTruthy();
     expect(screen.getByText('ui-users.expirationDate')).toBeInTheDocument();
 
+    // expiration data should be empty
     const expirationDate = screen.getByTestId('expirationDate');
     expect(within(expirationDate).queryByText('stripes-components.noValue.noValueSet')).toBeTruthy();
   });
 
-  it('without proxy data', () => {
+  it('without proxy data shows an error', () => {
     const props = {
       record: {}
     };

--- a/src/components/ProxyGroup/ProxyItem/ProxyItem.test.js
+++ b/src/components/ProxyGroup/ProxyItem/ProxyItem.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import user from 'fixtures/okapiCurrentUser';
 
 import renderWithRouter from 'helpers/renderWithRouter';
@@ -8,7 +8,7 @@ jest.unmock('@folio/stripes/components');
 
 const renderProxyItem = (props) => renderWithRouter(<ProxyItem {...props} />);
 describe('Render ProxyItem component', () => {
-  it('When Proxies are given with expiration date', () => {
+  it('with expiration date', () => {
     const props = {
       record: {
         proxy : {
@@ -26,11 +26,17 @@ describe('Render ProxyItem component', () => {
       }
     };
     renderProxyItem(props);
+
     expect(screen.getAllByText('ui-users.proxy.notificationsTo')).toBeTruthy();
     expect(screen.getAllByText('ui-users.proxy.relationshipStatus')).toBeTruthy();
     expect(screen.getByText('ui-users.expirationDate')).toBeInTheDocument();
+
+    // we want to see the expiration date
+    const expirationDate = screen.getByTestId('expirationDate');
+    expect(within(expirationDate).queryByText('11/23/2021')).toBeTruthy();
   });
-  it('When Proxies are given without expiration date', () => {
+
+  it('without expiration date', () => {
     const props = {
       record: {
         proxy : {
@@ -47,6 +53,21 @@ describe('Render ProxyItem component', () => {
       }
     };
     renderProxyItem(props);
-    expect(screen.getAllByText('ui-users.proxy.requestForSponsor')).toBeTruthy();
+
+    expect(screen.getAllByText('ui-users.proxy.notificationsTo')).toBeTruthy();
+    expect(screen.getAllByText('ui-users.proxy.relationshipStatus')).toBeTruthy();
+    expect(screen.getByText('ui-users.expirationDate')).toBeInTheDocument();
+
+    const expirationDate = screen.getByTestId('expirationDate');
+    expect(within(expirationDate).queryByText('stripes-components.noValue.noValueSet')).toBeTruthy();
+  });
+
+  it('without proxy data', () => {
+    const props = {
+      record: {}
+    };
+    renderProxyItem(props);
+
+    expect(screen.getByText('ui-users.errors.proxies.invalidUserLabel')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Sometimes, it is possible to create a proxy record that has an invalid `proxyUserId` attribute, resulting in `ProxyItem` receiving a `record` prop with a null `user` attribute. It isn't totally clear how this happens, but it clearly does happen sometimes, and so the UI needs to handle the situation. e.g. it is possible to create a corrupt record by directly sending a PUT request to `/proxiesfor/${id}` with invalid data, even if it's not possible to create such a request in the UI.

Refs [UIU-2803](https://issues.folio.org/browse/UIU-2803)