### PR TITLE
UIU-2804 allow proxy/sponor lists to be emptied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Use `updateUser` from `@folio/stripes-core` to update service-point data. Refs UIU-2788.
 * Show correct service points when navigating among users. Refs UIU-2790.
 * Make unavailable "Refund" option for cancelled fee/fine that was already refunded. Refs UIU-2700.
+* Allow proxy/sponsor lists to be emptied completely. Refs UIU-2804.
 
 ## [8.2.0](https://github.com/folio-org/ui-users/tree/v8.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v8.2.0)

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -217,8 +217,8 @@ class UserEdit extends React.Component {
     const { proxies, sponsors, permissions, servicePoints, preferredServicePoint } = user;
 
     if (stripes.hasPerm('proxiesfor.item.put,proxiesfor.item.post')) {
-      if (proxies) updateProxies(proxies);
-      if (sponsors) updateSponsors(sponsors);
+      updateProxies(proxies || []);
+      updateSponsors(sponsors || []);
     }
 
     if (permissions) {


### PR DESCRIPTION
Allow the proxy and sponsor lists to be completely emptied. The previous incarnation only called the update handlers if the lists were defined, thus the handler would only be called if the list had at least one item on it. This made it impossible to empty the lists. Whoops.

Refs [UIU-2804](https://issues.folio.org/browse/UIU-2804)