### PR TITLE
Fix comments "See openPermissionsModal"

### DIFF
--- a/src/components/PermissionsAccordion/PermissionsAccordion.js
+++ b/src/components/PermissionsAccordion/PermissionsAccordion.js
@@ -71,7 +71,7 @@ const PermissionsAccordion = (props) => {
    * be removed.
    *
    *
-   * See openPermissionsModal for a detailed explanation.
+   * See openPermissionModal for a detailed explanation.
    */
   const confirmEdit = () => {
     setConfirmEditModalOpen(false);
@@ -84,7 +84,7 @@ const PermissionsAccordion = (props) => {
    * to cancel editing of permissions since it would result in the removal of
    * permissions with `visible: false`.
    *
-   * See openPermissionsModal for a detailed explanation.
+   * See openPermissionModal for a detailed explanation.
    */
   const cancelEdit = () => {
     setConfirmEditModalOpen(false);


### PR DESCRIPTION
Generally typos in comments don't matter, but this one (it's "openPermissionModal", not "Permission**s**") is actually a minor problem, because "see X" implies you can search on X to find the implementation, and that fails when it's typo'ed.