### PR TITLE
UIU-2812: Fix problem with remaining amount (not shown correct value after filling the payment amount)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 9.1.0 IN PROGRESS
 
 * Add STATUS FILTER to LOST ITEMS REQUIRING ACTUAL COST processing page. Refs UIU-2748.
+* Fix problem with remaining amount (not shown correct value after filling the payment amount). Refs UIU-2812.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/Accounts/Actions/ActionModal.js
+++ b/src/components/Accounts/Actions/ActionModal.js
@@ -62,7 +62,6 @@ class ActionModal extends React.Component {
     this.state = {
       actionAllowed: false,
       accountRemainingAmount: '0.00',
-      prevValidatedAmount: null,
       prevValidationError: '',
     };
 
@@ -258,8 +257,6 @@ class ActionModal extends React.Component {
 
     const {
       actionAllowed,
-      accountRemainingAmount,
-      prevValidatedAmount,
       prevValidationError,
     } = this.state;
 
@@ -268,10 +265,9 @@ class ActionModal extends React.Component {
 
       this.setState({
         accountRemainingAmount: selectedAmount,
-        prevValidatedAmount: null,
       });
       error = <FormattedMessage id="ui-users.accounts.error.field" />;
-    } else if (value !== prevValidatedAmount && this._isMounted) {
+    } else if (this._isMounted) {
       const response = await this.triggerCheckEndpoint(value, accounts);
       const {
         allowed,
@@ -279,14 +275,12 @@ class ActionModal extends React.Component {
         remainingAmount,
       } = await response.json();
 
-      this.setState({ prevValidatedAmount: value });
-
       if (!_.isUndefined(errorMessage)) {
         this.setState({ prevValidationError: errorMessage });
         error = errorMessage;
       }
 
-      if (actionAllowed !== allowed || accountRemainingAmount !== remainingAmount) {
+      if (actionAllowed !== allowed || remainingAmount) {
         this.setState({
           actionAllowed: allowed,
           accountRemainingAmount: remainingAmount,


### PR DESCRIPTION
## Purpose
Fix problem with remaining amount (not shown correct value after filling the payment amount)

## Approach
Validate amount do not called when we input the same value this mean that we don't need check for comparisons current and previous value. 

## Refs
https://issues.folio.org/browse/UIU-2812