### PR TITLE
UIU-2813: Add close button to "Lost items requiring actual cost" page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add "Status" column to LOST ITEMS REQUIRING ACTUAL COST processing page. Refs UIU-2772.
 * Add "Lost items requiring actual cost" to Actions dropdown in User details record. Refs UIU-2810.
 * Add "Fee/fine details" to LOST ITEMS REQUIRING ACTUAL COST processing page. Refs UIU-2773.
+* Add close button to "Lost items requiring actual cost" page. Refs UIU-2813
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/LostItemsLink/LostItemsLink.js
+++ b/src/components/LostItemsLink/LostItemsLink.js
@@ -1,4 +1,5 @@
 import { FormattedMessage } from 'react-intl';
+import { useHistory } from 'react-router-dom';
 
 import { IfPermission } from '@folio/stripes/core';
 import {
@@ -13,13 +14,20 @@ import {
 } from '../../views/LostItems/constants';
 
 const LostItemsLink = () => {
-  const lostItemsLink = `/users/lost-items?filters=${ACTUAL_COST_RECORD_FIELD_PATH[ACTUAL_COST_RECORD_FIELD_NAME.STATUS]}.${LOST_ITEM_STATUSES.OPEN}`;
+  const history = useHistory();
 
   return (
     <IfPermission perm="ui-users.lost-items.requiring-actual-cost">
       <Button
         data-testid="lostItemsLink"
-        to={lostItemsLink}
+        to={{
+          pathname: '/users/lost-items',
+          search: `?filters=${ACTUAL_COST_RECORD_FIELD_PATH[ACTUAL_COST_RECORD_FIELD_NAME.STATUS]}.${LOST_ITEM_STATUSES.OPEN}`,
+          state: {
+            pathname: history?.location?.pathname,
+            search: history?.location?.search,
+          },
+        }}
         buttonStyle="dropdownItem"
       >
         <Icon icon="edit">

--- a/src/components/LostItemsLink/LostItemsLink.test.js
+++ b/src/components/LostItemsLink/LostItemsLink.test.js
@@ -2,6 +2,9 @@ import {
   screen,
   render,
 } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
 import { Button } from '@folio/stripes/components';
 
 import '../../../test/jest/__mock__';
@@ -22,8 +25,12 @@ const labelIds = {
 
 describe('LostItemsLink', () => {
   beforeEach(() => {
+    const history = createMemoryHistory();
+
     render(
-      <LostItemsLink />
+      <Router history={history}>
+        <LostItemsLink />
+      </Router>
     );
   });
 
@@ -42,7 +49,14 @@ describe('LostItemsLink', () => {
   it('should trigger "Button" with correct props', () => {
     const expectedProps = {
       buttonStyle: 'dropdownItem',
-      to: `/users/lost-items?filters=${ACTUAL_COST_RECORD_FIELD_PATH[ACTUAL_COST_RECORD_FIELD_NAME.STATUS]}.${LOST_ITEM_STATUSES.OPEN}`,
+      to: {
+        pathname: '/users/lost-items',
+        search: `?filters=${ACTUAL_COST_RECORD_FIELD_PATH[ACTUAL_COST_RECORD_FIELD_NAME.STATUS]}.${LOST_ITEM_STATUSES.OPEN}`,
+        state: {
+          pathname: '/',
+          search: '',
+        },
+      }
     };
 
     expect(Button).toHaveBeenCalledWith(expect.objectContaining(expectedProps), {});

--- a/src/routes/LostItemsContainer.js
+++ b/src/routes/LostItemsContainer.js
@@ -201,6 +201,28 @@ class LostItemsContainer extends React.Component {
     return this.props?.resources?.query ?? {};
   }
 
+  onClose = () => {
+    const {
+      history,
+      history: {
+        location: {
+          state,
+        }
+      }
+    } = this.props;
+
+    if (state) {
+      const {
+        pathname,
+        search,
+      } = state;
+
+      history.push(`${pathname}${search}`);
+    } else {
+      history.push('/users');
+    }
+  }
+
   render() {
     const hasPermission = this.props.stripes.hasPerm('ui-users.lost-items.requiring-actual-cost');
 
@@ -227,6 +249,7 @@ class LostItemsContainer extends React.Component {
         resources={this.props.resources}
         mutator={this.props.mutator}
         okapi={this.props.okapi}
+        onClose={this.onClose}
       />
     );
   }

--- a/src/views/LostItems/LostItemsListContainer/LostItemsListContainer.js
+++ b/src/views/LostItems/LostItemsListContainer/LostItemsListContainer.js
@@ -35,6 +35,7 @@ import styles from './LostItemsListContainer.css';
 class LostItemsListContainer extends React.Component {
   static propTypes = {
     onNeedMoreData: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
     queryGetter: PropTypes.func,
     querySetter: PropTypes.func,
     resources: PropTypes.shape({
@@ -207,6 +208,7 @@ class LostItemsListContainer extends React.Component {
       queryGetter,
       source,
       onNeedMoreData,
+      onClose,
       resources,
       mutator: {
         resultOffset,
@@ -302,6 +304,8 @@ class LostItemsListContainer extends React.Component {
                 paneSub={resultPaneSub}
                 firstMenu={this.renderResultsFirstMenu(activeFilters)}
                 defaultWidth="fill"
+                dismissible
+                onClose={onClose}
                 padContent={false}
                 noOverflow
               >


### PR DESCRIPTION
## Purpose
Add close button to "Lost items requiring actual cost" page.

## Approach
If user came to "Lost items requiring actual cost" page via "Lost items requiring actual cost" button, redirect them to the previous page on close button click. Otherwise, redirect to /users

## Refs
(refs https://issues.folio.org/browse/UIU-2813)