### PR TITLE
UIU-2842 run tests on multiple cores

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -88,8 +88,12 @@ jobs:
         run: yarn lint
         continue-on-error: true
 
+      - name: Get number of CPU cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@v1
+
       - name: Run yarn test
-        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS
+        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS --max-workers ${{ steps.cpu-cores.outputs.count }}
 
       - name: Run yarn formatjs-compile
         if : ${{ env.COMPILE_TRANSLATION_FILES == 'true' }}

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -18,7 +18,7 @@ on: [push, pull_request]
 jobs:
   build-npm:
     env:
-      YARN_TEST_OPTIONS: '--ci --coverage --colors'
+      YARN_TEST_OPTIONS: '--ci --coverage --colors --runInBand'
       SQ_ROOT_DIR: './src'
       PUBLISH_MOD_DESCRIPTOR: 'true'
       COMPILE_TRANSLATION_FILES: 'true'

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -67,8 +67,12 @@ jobs:
         run: yarn lint
         continue-on-error: true
 
+      - name: Get number of CPU cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@v1
+
       - name: Run yarn test
-        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS
+        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS  --max-workers ${{ steps.cpu-cores.outputs.count }}
 
       - name: Run yarn formatjs-compile
         if : ${{ env.COMPILE_TRANSLATION_FILES == 'true' }}

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -18,7 +18,7 @@ on: [push, pull_request]
 jobs:
   build-npm:
     env:
-      YARN_TEST_OPTIONS: '--ci --coverage --colors'
+      YARN_TEST_OPTIONS: '--ci --coverage --colors -i'
       SQ_ROOT_DIR: './src'
       PUBLISH_MOD_DESCRIPTOR: 'true'
       COMPILE_TRANSLATION_FILES: 'true'
@@ -67,12 +67,8 @@ jobs:
         run: yarn lint
         continue-on-error: true
 
-      - name: Get number of CPU cores
-        id: cpu-cores
-        uses: SimenB/github-actions-cpu-cores@v1
-
       - name: Run yarn test
-        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS  --max-workers ${{ steps.cpu-cores.outputs.count }}
+        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS
 
       - name: Run yarn formatjs-compile
         if : ${{ env.COMPILE_TRANSLATION_FILES == 'true' }}

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -18,7 +18,7 @@ on: [push, pull_request]
 jobs:
   build-npm:
     env:
-      YARN_TEST_OPTIONS: '--ci --coverage --colors --runInBand'
+      YARN_TEST_OPTIONS: '--ci --coverage --colors'
       SQ_ROOT_DIR: './src'
       PUBLISH_MOD_DESCRIPTOR: 'true'
       COMPILE_TRANSLATION_FILES: 'true'

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -18,7 +18,7 @@ on: [push, pull_request]
 jobs:
   build-npm:
     env:
-      YARN_TEST_OPTIONS: '--ci --coverage --colors -i'
+      YARN_TEST_OPTIONS: '--ci --coverage --colors'
       SQ_ROOT_DIR: './src'
       PUBLISH_MOD_DESCRIPTOR: 'true'
       COMPILE_TRANSLATION_FILES: 'true'
@@ -67,8 +67,12 @@ jobs:
         run: yarn lint
         continue-on-error: true
 
+      - name: Get number of CPU cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@v1
+
       - name: Run yarn test
-        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS
+        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS  --max-workers ${{ steps.cpu-cores.outputs.count }}
 
       - name: Run yarn formatjs-compile
         if : ${{ env.COMPILE_TRANSLATION_FILES == 'true' }}


### PR DESCRIPTION
Based on comments from https://jestjs.io/docs/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server: 

> While Jest is most of the time extremely fast on modern multi-core computers with fast SSDs, it may be slow on certain setups as our users [have](https://github.com/facebook/jest/issues/1395) [discovered](https://github.com/facebook/jest/issues/1524#issuecomment-260246008).
> [...]
> ...
> If you use GitHub Actions, you can use [github-actions-cpu-cores](https://github.com/SimenB/github-actions-cpu-cores) to detect number of CPUs, and pass that to Jest.

Refs [UIU-2842](https://issues.folio.org/browse/UIU-2842), [STRIPES-854](https://issues.folio.org/browse/STRIPES-854)