### PR TITLE
UIU-2839: Display expirationDate based on the current timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * A result is not displayed in list of permissions after clicking on the 'Search' button. Refs UIU-2835.
 * Get rid of blinking list on lost items page. Refs UIU-2831.
 * Add actual cost details to lost items requiring actual cost processing page. Refs UIU-2774.
+* Display `expirationDate` based on the current timezone. Refs UIU-2839.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/UserDetailSections/UserInfo/UserInfo.js
+++ b/src/components/UserDetailSections/UserInfo/UserInfo.js
@@ -1,11 +1,10 @@
 import { get } from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, FormattedDate } from 'react-intl';
 import {
   Row,
   Col,
-  FormattedUTCDate,
   KeyValue,
   Accordion,
   Headline,
@@ -110,7 +109,7 @@ class UserInfo extends React.Component {
               <Col xs={3}>
                 <KeyValue
                   label={<FormattedMessage id="ui-users.information.expirationDate" />}
-                  value={user.expirationDate ? <FormattedUTCDate value={user.expirationDate} /> : '-'}
+                  value={user.expirationDate ? <FormattedDate value={user.expirationDate} /> : '-'}
                 />
               </Col>
               <Col xs={3}>


### PR DESCRIPTION
Display `expirationDate` based on the current timezone.

https://issues.folio.org/browse/UIU-2839

