### PR TITLE
Bump moment-timezone from 0.5.41 to 0.5.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -918,7 +918,7 @@
     "jspdf": "^2.3.1",
     "jspdf-autotable": "^3.5.14",
     "lodash": "^4.17.4",
-    "moment-timezone": "^0.5.14",
+    "moment-timezone": "^0.5.43",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
     "react-final-form": "^6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8277,10 +8277,10 @@ moment-range@^4.0.2:
   dependencies:
     es6-symbol "^3.1.0"
 
-moment-timezone@^0.5.14, moment-timezone@^0.5.17:
-  version "0.5.41"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.41.tgz#a7ad3285fd24aaf5f93b8119a9d749c8039c64c5"
-  integrity sha512-e0jGNZDOHfBXJGz8vR/sIMXvBIGJJcqFjmlg9lmE+5KX1U7/RZNMswfD8nKnNCnQdKTIj50IaRKwl1fvMLyyRg==
+moment-timezone@^0.5.14, moment-timezone@^0.5.17, moment-timezone@^0.5.43:
+  version "0.5.43"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.43.tgz#3dd7f3d0c67f78c23cd1906b9b2137a09b3c4790"
+  integrity sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==
   dependencies:
     moment "^2.29.4"
 


### PR DESCRIPTION
PR #2386 doppelgänger

Bumps [moment-timezone](https://github.com/moment/moment-timezone) from 0.5.41 to 0.5.43.
- [Release notes](https://github.com/moment/moment-timezone/releases)
- [Changelog](https://github.com/moment/moment-timezone/blob/develop/changelog.md)
- [Commits](https://github.com/moment/moment-timezone/compare/0.5.41...0.5.43)

---
updated-dependencies:
- dependency-name: moment-timezone dependency-type: direct:production update-type: version-update:semver-patch ...