### PR TITLE
UIU-2774: Add actual cost details to lost items requiring actual cost processing page

### DIFF
--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/ActualCostDetailsModal/ActualCostDetailsModal.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/ActualCostDetailsModal/ActualCostDetailsModal.js
@@ -23,6 +23,10 @@ import {
   LOST_ITEM_STATUSES,
 } from '../../../../../constants';
 
+export const getActualCostToBillViewValue = (value = 0) => (
+  value.toFixed(2)
+);
+
 const ActualCostDetailsModal = ({
   actualCostDetailsModal: {
     isOpen,
@@ -73,21 +77,21 @@ const ActualCostDetailsModal = ({
           {
             actualCostRecord.status === LOST_ITEM_STATUSES.BILLED
               ? <FormattedMessage
-                  id="ui-users.lostItems.modal.summaryMessageCharged"
-                  values={{
-                    actualCostToBill,
-                    patronName,
-                    instanceTitle,
-                    materialType,
-                  }}
+                id="ui-users.lostItems.modal.summaryMessageCharged"
+                values={{
+                  actualCostToBill: getActualCostToBillViewValue(actualCostToBill),
+                  patronName,
+                  instanceTitle,
+                  materialType,
+                }}
               />
               : <FormattedMessage
-                  id="ui-users.lostItems.modal.summaryMessageNotCharged"
-                  values={{
-                    patronName,
-                    instanceTitle,
-                    materialType,
-                  }}
+                id="ui-users.lostItems.modal.summaryMessageNotCharged"
+                values={{
+                  patronName,
+                  instanceTitle,
+                  materialType,
+                }}
               />
           }
         </Col>

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/ActualCostDetailsModal/ActualCostDetailsModal.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/ActualCostDetailsModal/ActualCostDetailsModal.test.js
@@ -10,7 +10,9 @@ import {
   ACTUAL_COST_DEFAULT,
   ACTUAL_COST_DETAILS_MODAL_DEFAULT,
 } from '../../../../../constants';
-import ActualCostDetailsModal from './ActualCostDetailsModal';
+import ActualCostDetailsModal, {
+  getActualCostToBillViewValue,
+} from './ActualCostDetailsModal';
 
 const initialProps = {
   actualCostDetailsModal: {
@@ -26,7 +28,7 @@ const initialProps = {
       status: 'Cancelled'
     },
     additionalInfo: {
-      actualCostToBill: 'actualCostToBill',
+      actualCostToBill: 10,
       additionalInformationForStaff: 'additionalInformationForStaff',
       additionalInformationForPatron: 'additionalInformationForPatron',
     },
@@ -46,6 +48,20 @@ const testIds = {
 };
 
 describe('ActualCostDetailsModal', () => {
+  describe('getActualCostToBillViewValue', () => {
+    it('should return 0 when value absent', () => {
+      expect(getActualCostToBillViewValue()).toEqual('0.00');
+    });
+
+    it('should return decimal value with 2 digits when digit part absent', () => {
+      expect(getActualCostToBillViewValue(0.1)).toEqual('0.10');
+    });
+
+    it('should return decimal value with 2 digits when digit part more than 2 digits', () => {
+      expect(getActualCostToBillViewValue(0.101)).toEqual('0.10');
+    });
+  });
+
   describe('when the record has "Cancelled" status', () => {
     beforeEach(() => {
       render(


### PR DESCRIPTION
## Purpose
Add actual cost details to lost items requiring actual cost processing page

## Approach
fee/fine amount should include decimal part

## Refs
https://issues.folio.org/browse/UIU-2774