### PR TITLE
UIU-2823: New fee/fine modal: Notify patron checkbox not checked correctly when fee/fine owner has default notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * View affiliation associated permissions. Refs UIU-2800.
 * Confirmation modal for manual anonymization. Refs UIU-1631.
 * Fixed bug with certain accordions not closing in edit view. Refs UIU-2811.
+* Notify patron checkbox not checked correctly when fee/fine owner has default notice. Refs UIU-2823.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeFeeFine.js
@@ -484,7 +484,7 @@ class ChargeFeeFine extends React.Component {
     const initialOwnerId = ownerId !== '0' ? ownerId : servicePointOwnerId;
     const selectedFeeFine = feefines.find(f => f.id === feeFineTypeId);
     const currentOwnerFeeFineTypes = feefines.filter(f => f.ownerId === initialOwnerId || f.ownerId === resources.activeRecord.shared);
-    const selectedOwner = owners.find(o => (o.id === initialOwnerId || o.id === resources.activeRecord.shared));
+    const selectedOwner = owners.find(o => o.id === initialOwnerId) ?? owners.find(o => o.id === resources.activeRecord.shared);
 
     const initialChargeValues = {
       ownerId: initialOwnerId,


### PR DESCRIPTION
## Purpose
"Notify patron" checkbox is not checked when fee/fine owner has default notice. But if fee/fine owner has a default notice and the appropriate owner is selected "Notify patron" checkbox should be checked.

## Refs
[UIU-2823](https://issues.folio.org/browse/UIU-2823)