### PR TITLE
UIU-2852- Success and Error toasts

### DIFF
--- a/src/components/UserDetailSections/UserAffiliations/UserAffiliations.js
+++ b/src/components/UserDetailSections/UserAffiliations/UserAffiliations.js
@@ -64,6 +64,7 @@ const UserAffiliations = ({
       } else {
         callout.sendCallout({
           type: 'error',
+          timeout: 0,
           message: (
             <div>
               <div>

--- a/src/components/UserDetailSections/UserAffiliations/util.js
+++ b/src/components/UserDetailSections/UserAffiliations/util.js
@@ -34,8 +34,6 @@ export function createErrorMessage({ message, code, userName }) {
 
   const tenantName = extractTenantNameFromErrorMessage(message);
 
-  if (!tenantName) return message;
-
   const formattedError = <FormattedMessage
     id={`ui-users.affiliations.manager.modal.changes.error.${errorMessageId}`}
     values={{

--- a/src/components/UserDetailSections/UserAffiliations/util.test.js
+++ b/src/components/UserDetailSections/UserAffiliations/util.test.js
@@ -65,7 +65,13 @@ describe('createErrorMessage', () => {
       code: 'HAS_PRIMARY_AFFILIATION_ERROR',
       userName: 'test user',
     });
-    expect(formattedError).toBe(errorMessage);
+    expect(formattedError.props).toEqual({
+      id: 'ui-users.affiliations.manager.modal.changes.error.hasPrimaryAffiliation',
+      values: {
+        tenantName: '',
+        userName: 'test user',
+      },
+    });
   });
 
   it('should return error message with tenant name `mobius`', () => {

--- a/src/hooks/useUserAffiliationsMutation/useUserAffiliationsMutation.js
+++ b/src/hooks/useUserAffiliationsMutation/useUserAffiliationsMutation.js
@@ -1,9 +1,8 @@
 import chunk from 'lodash/chunk';
 import { useCallback } from 'react';
 import { useMutation } from 'react-query';
-
 import { useOkapiKy } from '@folio/stripes/core';
-
+import { uniqBy } from 'lodash';
 import {
   CONSORTIA_API,
   CONSORTIA_USER_TENANTS_API,
@@ -86,9 +85,10 @@ const useUserAffiliationsMutation = () => {
     ]);
 
     const errors = await getResponseErrors(batchResponses);
-    if (errors.length) {
+    const uniqueErrorMessages = uniqBy(errors, 'message');
+    if (uniqueErrorMessages.length) {
       return {
-        errors,
+        errors: uniqueErrorMessages,
         success: false,
         responses: batchResponses,
       };

--- a/src/hooks/useUserAffiliationsMutation/useUserAffiliationsMutation.test.js
+++ b/src/hooks/useUserAffiliationsMutation/useUserAffiliationsMutation.test.js
@@ -121,6 +121,11 @@ describe('useUserAffiliationsMutation', () => {
       'message': 'Some error message',
       'type': '-1',
       'code': 'GENERIC_ERROR'
+    },
+    {
+      'message': 'Some error message',
+      'type': '-1',
+      'code': 'GENERIC_ERROR'
     }]);
     const { result } = renderHook(() => useUserAffiliationsMutation(), { wrapper });
 
@@ -132,6 +137,6 @@ describe('useUserAffiliationsMutation', () => {
     const { success, errors } = await result.current.handleAssignment(payload);
 
     expect(success).toBe(false);
-    expect(errors.length).toBe(2);
+    expect(errors.length).toBe(2); // 1 error is filtered out due to uniqueness
   });
 });


### PR DESCRIPTION
- change error toast message timeout 0 until users close it
- make error messages unique if the same error messages are received from the backend response
- remove if `tenantName` exist conditional check dues to some error messages that don't require tenant names.