### PR TITLE
UIU-2866 import testing-library deps from jest-config-stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * "ui-users.settings.customfields.view" permission insufficient to view custom fields on user settings. Refs UIU-2863.
 * Align affiliation assignment with stripes-core updates (switch active affiliation). Refs UIU-2855.
 * Also support `circulation` `14.0`. Refs UIU-2858.
+* Import `@testing-library` deps from `jest-config-stripes`. Refs UIU-2866.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/Accounts/Actions/ActionModal.test.js
+++ b/src/components/Accounts/Actions/ActionModal.test.js
@@ -1,5 +1,5 @@
-import { act, waitFor, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { act, waitFor, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import ActionModal from './ActionModal';

--- a/src/components/Accounts/Actions/CancellationModal.test.js
+++ b/src/components/Accounts/Actions/CancellationModal.test.js
@@ -1,5 +1,5 @@
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import CancellationModal from './CancellationModal';

--- a/src/components/Accounts/Actions/CommentModal.test.js
+++ b/src/components/Accounts/Actions/CommentModal.test.js
@@ -1,5 +1,5 @@
-import { screen, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, cleanup } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import CommentModal from './CommentModal';

--- a/src/components/Accounts/Actions/FeeFineActions.test.js
+++ b/src/components/Accounts/Actions/FeeFineActions.test.js
@@ -6,7 +6,7 @@ import {
   screen,
   waitFor,
   fireEvent,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../test/jest/__mock__';
 

--- a/src/components/Accounts/Actions/WarningModal.test.js
+++ b/src/components/Accounts/Actions/WarningModal.test.js
@@ -1,5 +1,5 @@
-import { screen, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, cleanup } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import WarningModal from './WarningModal';

--- a/src/components/Accounts/ChargeFeeFine/ChargeForm.test.js
+++ b/src/components/Accounts/ChargeFeeFine/ChargeForm.test.js
@@ -1,5 +1,5 @@
-import userEvent from '@testing-library/user-event';
-import { screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+import { screen, waitFor, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/Accounts/ChargeFeeFine/FeeFineInfo.test.js
+++ b/src/components/Accounts/ChargeFeeFine/FeeFineInfo.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import { Form } from 'react-final-form';
-import userEvent from '@testing-library/user-event';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 

--- a/src/components/Accounts/ChargeFeeFine/ItemInfo.test.js
+++ b/src/components/Accounts/ChargeFeeFine/ItemInfo.test.js
@@ -1,5 +1,5 @@
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import ItemInfo from './ItemInfo';

--- a/src/components/Accounts/ChargeFeeFine/ItemLookup.test.js
+++ b/src/components/Accounts/ChargeFeeFine/ItemLookup.test.js
@@ -1,5 +1,5 @@
-import { screen, render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, render } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '__mock__/stripesCore.mock';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/components/Accounts/Filters/Filters.test.js
+++ b/src/components/Accounts/Filters/Filters.test.js
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 import { FormattedMessage } from 'react-intl';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/Accounts/ViewFeesFines/ViewFeesFines.test.js
+++ b/src/components/Accounts/ViewFeesFines/ViewFeesFines.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { beforeEach } from '@jest/globals';
+import { screen, waitFor, within } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import renderWithRouter from 'helpers/renderWithRouter';
 import { nav } from '../../util';

--- a/src/components/AddServicePointModal/AddServicePointModal.test.js
+++ b/src/components/AddServicePointModal/AddServicePointModal.test.js
@@ -1,6 +1,6 @@
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
-import { screen, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, cleanup } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import AddServicePointModal from './AddServicePointModal';

--- a/src/components/AffiliationsManager/AffiliationsManager.test.js
+++ b/src/components/AffiliationsManager/AffiliationsManager.test.js
@@ -1,5 +1,5 @@
-import userEvent from '@testing-library/user-event';
-import { render, screen } from '@testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/currencyData.mock';
 

--- a/src/components/AffiliationsManager/useAffiliationsAssignment.test.js
+++ b/src/components/AffiliationsManager/useAffiliationsAssignment.test.js
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@folio/jest-config-stripes/testing-library/react-hooks';
 
 import affiliations from '../../../test/jest/fixtures/affiliations';
 import useAffiliationsAssignment from './useAffiliationsAssignment';

--- a/src/components/AffiliationsSelect/AffiliationsSelect.test.js
+++ b/src/components/AffiliationsSelect/AffiliationsSelect.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/matchMedia.mock';
 

--- a/src/components/BulkOverrideDialog/BulkOverrideDialog.test.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideDialog.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '__mock__/currencyData.mock';
 

--- a/src/components/BulkOverrideDialog/BulkOverrideInfo.test.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideInfo.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '__mock__/currencyData.mock';
 

--- a/src/components/BulkOverrideDialog/BulkOverrideLoansList.test.js
+++ b/src/components/BulkOverrideDialog/BulkOverrideLoansList.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '__mock__/currencyData.mock';
 

--- a/src/components/BulkRenewalDialog/BulkRenewInfo.test.js
+++ b/src/components/BulkRenewalDialog/BulkRenewInfo.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '__mock__/currencyData.mock';
 

--- a/src/components/BulkRenewalDialog/BulkRenewalDialog.test.js
+++ b/src/components/BulkRenewalDialog/BulkRenewalDialog.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '__mock__/currencyData.mock';
 

--- a/src/components/BulkRenewalDialog/BulkRenewedLoansList.test.js
+++ b/src/components/BulkRenewalDialog/BulkRenewedLoansList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/currencyData.mock';
 

--- a/src/components/CustomFieldsFilters/CustomFieldsFilter.test.js
+++ b/src/components/CustomFieldsFilters/CustomFieldsFilter.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import multiSelectCustomField from 'fixtures/multiSelectCustomField';
 import radioButtonSetCustomField from 'fixtures/radioButtonSetCustomField';
 

--- a/src/components/CustomFieldsFilters/CustomFieldsFilters.test.js
+++ b/src/components/CustomFieldsFilters/CustomFieldsFilters.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/matchMedia.mock';
 

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.test.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.test.js
@@ -1,5 +1,5 @@
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { Form } from 'react-final-form';
 
 import '__mock__/stripesComponents.mock';

--- a/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.test.js
+++ b/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.test.js
@@ -1,6 +1,6 @@
 
-import { screen, waitFor, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor, cleanup } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '__mock__/stripesCore.mock';
 

--- a/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/Modals/CreatePasswordModal.test.js
+++ b/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/Modals/CreatePasswordModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import CreatePasswordModalBody from './CreatePasswordModal';

--- a/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/Modals/ResetPasswordModal.test.js
+++ b/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/Modals/ResetPasswordModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import ResetPasswordModalBody from './ResetPasswordModal';

--- a/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/Modals/WithCopyModal/WithCopyModal.test.js
+++ b/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/Modals/WithCopyModal/WithCopyModal.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import WithCopyModal from './WithCopyModal';

--- a/src/components/EditSections/EditExtendedInfo/DepartmentsNameEdit/DepartmentsNameEdit.test.js
+++ b/src/components/EditSections/EditExtendedInfo/DepartmentsNameEdit/DepartmentsNameEdit.test.js
@@ -4,8 +4,8 @@ import { Form } from 'react-final-form';
 import {
   screen,
   cleanup,
-} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+} from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import renderWithRouter from 'helpers/renderWithRouter';
 import DepartmentsNameEdit from './DepartmentsNameEdit';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.test.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import { Form } from 'react-final-form';
 import PropTypes from 'prop-types';
 

--- a/src/components/EditSections/EditExtendedInfo/PasswordControl/PasswordControl.test.js
+++ b/src/components/EditSections/EditExtendedInfo/PasswordControl/PasswordControl.test.js
@@ -3,8 +3,8 @@ import okapiCurrentUser from 'fixtures/okapiCurrentUser';
 import {
   screen,
   cleanup,
-} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+} from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { Form } from 'react-final-form';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/RequestPreferencesEdit.test.js
+++ b/src/components/EditSections/EditExtendedInfo/RequestPreferencesEdit/RequestPreferencesEdit.test.js
@@ -1,6 +1,6 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import { Form } from 'react-final-form';
-import userEvent from '@testing-library/user-event';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import renderWithRouter from 'helpers/renderWithRouter';
 
 import '__mock__/stripesComponents.mock';

--- a/src/components/EditSections/EditProxy/EditProxy.test.js
+++ b/src/components/EditSections/EditProxy/EditProxy.test.js
@@ -1,6 +1,6 @@
 
 import user from 'fixtures/okapiCurrentUser';
-import { screen, cleanup } from '@testing-library/react';
+import { screen, cleanup } from '@folio/jest-config-stripes/testing-library/react';
 import { Form } from 'react-final-form';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/EditSections/EditServicePoints/EditServicePoints.test.js
+++ b/src/components/EditSections/EditServicePoints/EditServicePoints.test.js
@@ -1,8 +1,8 @@
 
 import React from 'react';
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
-import { screen, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, cleanup } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { Form } from 'react-final-form';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
@@ -1,6 +1,6 @@
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { Form } from 'react-final-form';
 
 import '__mock__/stripesComponents.mock';

--- a/src/components/ErrorModal/ErrorModal.test.js
+++ b/src/components/ErrorModal/ErrorModal.test.js
@@ -2,7 +2,7 @@ import {
   screen,
   render,
   fireEvent,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import ErrorModal from './ErrorModal';
 

--- a/src/components/ErrorPane/ErrorPane.test.js
+++ b/src/components/ErrorPane/ErrorPane.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import ErrorPane from './ErrorPane';

--- a/src/components/HelperApp/HelperApp.test.js
+++ b/src/components/HelperApp/HelperApp.test.js
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 

--- a/src/components/Label/Label.test.js
+++ b/src/components/Label/Label.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import Label from './Label';

--- a/src/components/LoanActionDialog/LoanActionDialog.test.js
+++ b/src/components/LoanActionDialog/LoanActionDialog.test.js
@@ -1,8 +1,8 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import PropTypes from 'prop-types';
 import '__mock__/stripesComponents.mock';
 import loan from 'fixtures/openLoan';
-import userEvent from '@testing-library/user-event';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import LoanActionDialog from './LoanActionDialog';

--- a/src/components/Loans/ClosedLoans/ClosedLoans.test.js
+++ b/src/components/Loans/ClosedLoans/ClosedLoans.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, fireEvent, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { createMemoryHistory } from 'history';
 
 import { effectiveCallNumber } from '@folio/stripes/util';

--- a/src/components/Loans/OpenLoans/OpenLoans.test.js
+++ b/src/components/Loans/OpenLoans/OpenLoans.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { createMemoryHistory } from 'history';
 
 import '__mock__/currencyData.mock';

--- a/src/components/Loans/OpenLoans/OpenLoansControl.test.js
+++ b/src/components/Loans/OpenLoans/OpenLoansControl.test.js
@@ -1,8 +1,8 @@
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.test.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.test.js
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 

--- a/src/components/Loans/OpenLoans/components/BulkClaimReturnedModal/BulkClaimReturnedModal.test.js
+++ b/src/components/Loans/OpenLoans/components/BulkClaimReturnedModal/BulkClaimReturnedModal.test.js
@@ -1,7 +1,7 @@
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
 
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import BulkClaimReturnedModal from './BulkClaimReturnedModal';

--- a/src/components/Loans/OpenLoans/components/ContributorsView/ContributorsView.test.js
+++ b/src/components/Loans/OpenLoans/components/ContributorsView/ContributorsView.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import ContributorsView from './ContributorsView';

--- a/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.test.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.test.js
@@ -2,7 +2,7 @@ import okapiCurrentUser from 'fixtures/okapiCurrentUser';
 import {
   screen,
   fireEvent,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import loans from 'fixtures/openLoans';

--- a/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.test.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.test.js
@@ -1,6 +1,6 @@
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import loans from 'fixtures/openLoans';

--- a/src/components/Loans/components/ActionsBar.test.js
+++ b/src/components/Loans/components/ActionsBar.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import ActionsBar from './ActionsBar';
 

--- a/src/components/LostItemsLink/LostItemsLink.test.js
+++ b/src/components/LostItemsLink/LostItemsLink.test.js
@@ -1,7 +1,7 @@
 import {
   screen,
   render,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 

--- a/src/components/ModalContent/ModalContent.test.js
+++ b/src/components/ModalContent/ModalContent.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/stripesCore.mock';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/components/PatronBlock/OverrideModal.test.js
+++ b/src/components/PatronBlock/OverrideModal.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import OverrideModal from './OverrideModal';

--- a/src/components/PatronBlock/PatronBlockForm.test.js
+++ b/src/components/PatronBlock/PatronBlockForm.test.js
@@ -3,9 +3,9 @@ import React from 'react';
 import {
   screen,
   cleanup,
-} from '@testing-library/react';
-import { within } from '@testing-library/dom';
-import userEvent from '@testing-library/user-event';
+} from '@folio/jest-config-stripes/testing-library/react';
+import { within } from '@folio/jest-config-stripes/testing-library/dom';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import PatronBlockForm from './PatronBlockForm';

--- a/src/components/PatronBlock/PatronBlockLayer.test.js
+++ b/src/components/PatronBlock/PatronBlockLayer.test.js
@@ -3,8 +3,8 @@ import React from 'react';
 import {
   screen,
   cleanup,
-} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+} from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import PropTypes from 'prop-types';
 import renderWithRouter from 'helpers/renderWithRouter';
 import PatronBlockLayer from './PatronBlockLayer';

--- a/src/components/PatronBlock/PatronBlockMessage.test.js
+++ b/src/components/PatronBlock/PatronBlockMessage.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import '__mock__/stripesCore.mock';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/PatronBlock/PatronBlockModal.test.js
+++ b/src/components/PatronBlock/PatronBlockModal.test.js
@@ -1,5 +1,5 @@
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import PatronBlockModal from './PatronBlockModal';

--- a/src/components/PatronBlock/PatronBlockModalWithOverrideModal.test.js
+++ b/src/components/PatronBlock/PatronBlockModalWithOverrideModal.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import PatronBlockModalWithOverrideModal from './PatronBlockModalWithOverrideModal';

--- a/src/components/PatronGroupNumberOfUsers/PatronGroupNumberOfUsers.test.js
+++ b/src/components/PatronGroupNumberOfUsers/PatronGroupNumberOfUsers.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import RenderPatronGroupNumberOfUsers from './PatronGroupNumberOfUsers';

--- a/src/components/PermissionLabel/PermissionLabel.test.js
+++ b/src/components/PermissionLabel/PermissionLabel.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import '__mock__/stripesCore.mock';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/PermissionsAccordion/EnableUnassignAll.test.js
+++ b/src/components/PermissionsAccordion/EnableUnassignAll.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 import { Form, Field } from 'react-final-form';
 
 import '__mock__/reactFinalFormListeners.mock';

--- a/src/components/PermissionsAccordion/PermissionsAccordion.test.js
+++ b/src/components/PermissionsAccordion/PermissionsAccordion.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, waitForElementToBeRemoved } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import { IfPermission } from '@folio/stripes/core';
 

--- a/src/components/PermissionsAccordion/PermissionsAccordionList.test.js
+++ b/src/components/PermissionsAccordion/PermissionsAccordionList.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { within } from '@testing-library/dom';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import { within } from '@folio/jest-config-stripes/testing-library/dom';
 
 import '__mock__/reactFinalFormArrays.mock';
 import '__mock__/intl.mock';

--- a/src/components/PermissionsAccordion/PermissionsAccordionListItem.test.js
+++ b/src/components/PermissionsAccordion/PermissionsAccordionListItem.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '__mock__/reactFinalFormArrays.mock';
 import '__mock__/intl.mock';

--- a/src/components/PermissionsAccordion/components/CheckboxColumn/CheckboxColumn.test.js
+++ b/src/components/PermissionsAccordion/components/CheckboxColumn/CheckboxColumn.test.js
@@ -1,6 +1,6 @@
 
-import { cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { cleanup } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '__mock__/matchMedia.mock';
 

--- a/src/components/PermissionsAccordion/components/PermissionsList/PermissionsList.test.js
+++ b/src/components/PermissionsAccordion/components/PermissionsList/PermissionsList.test.js
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 import '__mock__/stripesCore.mock';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.test.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/stripesCore.mock';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/components/PermissionsAccordion/components/SearchForm/SearchForm.test.js
+++ b/src/components/PermissionsAccordion/components/SearchForm/SearchForm.test.js
@@ -1,5 +1,5 @@
-import { screen, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, cleanup } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { Form } from 'react-final-form';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/PermissionsAccordion/helpers/filtersConfig.test.js
+++ b/src/components/PermissionsAccordion/helpers/filtersConfig.test.js
@@ -1,5 +1,3 @@
-import { describe, expect, test } from '@jest/globals';
-
 import { permissionTypeFilterConfig, statusFilterConfig } from './filtersConfig';
 
 const permissions = [

--- a/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.test.js
+++ b/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { Form } from 'react-final-form';
 import renderWithRouter from '../../../../test/jest/helpers/renderWithRouter';
 import ProxyEditItem from './ProxyEditItem';

--- a/src/components/ProxyGroup/ProxyItem/ProxyItem.test.js
+++ b/src/components/ProxyGroup/ProxyItem/ProxyItem.test.js
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/react';
+import { screen, within } from '@folio/jest-config-stripes/testing-library/react';
 import user from 'fixtures/okapiCurrentUser';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/ProxyGroup/ProxyViewList/ProxyViewList.test.js
+++ b/src/components/ProxyGroup/ProxyViewList/ProxyViewList.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import renderWithRouter from 'helpers/renderWithRouter';
 import ProxyViewList from './ProxyViewList';
 

--- a/src/components/ReportModals/CashDrawerReportModal.test.js
+++ b/src/components/ReportModals/CashDrawerReportModal.test.js
@@ -4,7 +4,7 @@ import {
   cleanup,
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import { createMemoryHistory } from 'history';
 import { forEach } from 'lodash';
 

--- a/src/components/ReportModals/FinancialTransactionsReportModal.test.js
+++ b/src/components/ReportModals/FinancialTransactionsReportModal.test.js
@@ -4,7 +4,7 @@ import {
   cleanup,
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import { createMemoryHistory } from 'history';
 import { forEach } from 'lodash';
 

--- a/src/components/ReportModals/RefundsReportModal.test.js
+++ b/src/components/ReportModals/RefundsReportModal.test.js
@@ -1,5 +1,5 @@
-import { screen, cleanup } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, cleanup } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import '__mock__/matchMedia.mock';
 

--- a/src/components/RequestFeeFineBlockButtons/RequestFeeFineBlockButtons.test.js
+++ b/src/components/RequestFeeFineBlockButtons/RequestFeeFineBlockButtons.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import {
   BrowserRouter as Router,
 } from 'react-router-dom';

--- a/src/components/UserAddresses/UserAddresses.test.js
+++ b/src/components/UserAddresses/UserAddresses.test.js
@@ -1,5 +1,5 @@
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import UserAddresses from './UserAddresses';

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.test.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.test.js
@@ -1,5 +1,5 @@
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import PatronBlock from './PatronBlock';

--- a/src/components/UserDetailSections/ProxyPermissions/ProxyPermissions.test.js
+++ b/src/components/UserDetailSections/ProxyPermissions/ProxyPermissions.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import user from 'fixtures/okapiCurrentUser';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.test.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import accounts from 'fixtures/account';
 import loans from 'fixtures/openLoans';
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/UserDetailSections/UserAffiliations/UserAffiliations.test.js
+++ b/src/components/UserDetailSections/UserAffiliations/UserAffiliations.test.js
@@ -1,8 +1,8 @@
 import {
   screen,
   waitForElementToBeRemoved,
-} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+} from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import {
   QueryClient,
   QueryClientProvider,

--- a/src/components/UserDetailSections/UserInfo/UserInfo.test.js
+++ b/src/components/UserDetailSections/UserInfo/UserInfo.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import '__mock__/stripesComponents.mock';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/UserDetailSections/UserLoans/UserLoans.test.js
+++ b/src/components/UserDetailSections/UserLoans/UserLoans.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import '__mock__/stripesComponents.mock';
 import renderWithRouter from 'helpers/renderWithRouter';
 

--- a/src/components/UserDetailSections/UserPermissions/UserPermissions.test.js
+++ b/src/components/UserDetailSections/UserPermissions/UserPermissions.test.js
@@ -1,5 +1,5 @@
-import userEvent from '@testing-library/user-event'
-import { screen } from '@testing-library/react'
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event'
+import { screen } from '@folio/jest-config-stripes/testing-library/react'
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import affiliations from 'fixtures/affiliations';

--- a/src/components/UserDetailSections/UserRequests/UserRequests.test.js
+++ b/src/components/UserDetailSections/UserRequests/UserRequests.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import '__mock__/stripesComponents.mock';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/UserDetailSections/UserServicePoints/UserServicePoints.test.js
+++ b/src/components/UserDetailSections/UserServicePoints/UserServicePoints.test.js
@@ -1,6 +1,6 @@
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
-import userEvent from '@testing-library/user-event';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import '__mock__/stripesComponents.mock';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/components/Wrappers/withClaimReturned.test.js
+++ b/src/components/Wrappers/withClaimReturned.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import PropTypes from 'prop-types';
 
 import '__mock__/currencyData.mock';

--- a/src/components/Wrappers/withDeclareLost.test.js
+++ b/src/components/Wrappers/withDeclareLost.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import PropTypes from 'prop-types';
 
 import '__mock__/currencyData.mock';

--- a/src/components/Wrappers/withFormValues.test.js
+++ b/src/components/Wrappers/withFormValues.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import { Form } from 'react-final-form';
 import PropTypes from 'prop-types';
 

--- a/src/components/Wrappers/withMarkAsMissing.test.js
+++ b/src/components/Wrappers/withMarkAsMissing.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import PropTypes from 'prop-types';
 
 import '__mock__/currencyData.mock';

--- a/src/components/Wrappers/withProxy.test.js
+++ b/src/components/Wrappers/withProxy.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import PropTypes from 'prop-types';
 
 import '__mock__/currencyData.mock';

--- a/src/components/Wrappers/withServicePoints.test.js
+++ b/src/components/Wrappers/withServicePoints.test.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
 import PropTypes from 'prop-types';
 import '__mock__/currencyData.mock';
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';

--- a/src/components/data/converters/address.test.js
+++ b/src/components/data/converters/address.test.js
@@ -1,4 +1,3 @@
-import { describe, expect, test } from '@jest/globals';
 import { getFormAddressList, toUserAddresses } from './address';
 
 describe('getFormAddressList', () => {

--- a/src/components/data/converters/address_type.test.js
+++ b/src/components/data/converters/address_type.test.js
@@ -1,5 +1,3 @@
-import { describe, expect, test } from '@jest/globals';
-
 import { toAddressTypeOptions } from './address_type';
 
 describe('toAddressTypeOptions', () => {

--- a/src/components/data/converters/permission.test.js
+++ b/src/components/data/converters/permission.test.js
@@ -1,5 +1,3 @@
-import { describe, expect, test } from '@jest/globals';
-
 import { getPermissionLabelString } from './permission';
 
 describe('getPermissionLabelString', () => {

--- a/src/components/data/reports/CsvReport.test.js
+++ b/src/components/data/reports/CsvReport.test.js
@@ -1,5 +1,5 @@
 import options from '__mock__/csvReportData.mock';
-import { waitFor } from '@testing-library/react';
+import { waitFor } from '@folio/jest-config-stripes/testing-library/react';
 // eslint-disable-next-line no-unused-vars
 import moment from 'moment-timezone';
 import CsvReport from './CsvReport';

--- a/src/components/validators/asyncValidateField.test.js
+++ b/src/components/validators/asyncValidateField.test.js
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { waitFor } from '@folio/jest-config-stripes/testing-library/react';
 
 import asyncValidateField from './asyncValidateField';
 import memoize from '../util/memoize';

--- a/src/hooks/useConsortium/useConsortium.test.js
+++ b/src/hooks/useConsortium/useConsortium.test.js
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react-hooks';
 import {
   QueryClient,
   QueryClientProvider,

--- a/src/hooks/useConsortiumTenants/useConsortiumTenants.test.js
+++ b/src/hooks/useConsortiumTenants/useConsortiumTenants.test.js
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react-hooks';
 import {
   QueryClient,
   QueryClientProvider,

--- a/src/hooks/useSortingMCL/useSortingMCL.test.js
+++ b/src/hooks/useSortingMCL/useSortingMCL.test.js
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@folio/jest-config-stripes/testing-library/react-hooks';
 
 import { SORT_DIRECTIONS } from '../../constants';
 import useSortingMCL from './useSortingMCL';

--- a/src/hooks/useToggle/useToggle.test.js
+++ b/src/hooks/useToggle/useToggle.test.js
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@folio/jest-config-stripes/testing-library/react-hooks';
 
 import useToggle from './useToggle';
 

--- a/src/hooks/useUserAffiliations/useUserAffiliations.test.js
+++ b/src/hooks/useUserAffiliations/useUserAffiliations.test.js
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react-hooks';
 import {
   QueryClient,
   QueryClientProvider,

--- a/src/hooks/useUserAffiliationsMutation/useUserAffiliationsMutation.test.js
+++ b/src/hooks/useUserAffiliationsMutation/useUserAffiliationsMutation.test.js
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react-hooks';
 import {
   QueryClient,
   QueryClientProvider,

--- a/src/hooks/useUserTenantPermissions/useUserTenantPermissions.test.js
+++ b/src/hooks/useUserTenantPermissions/useUserTenantPermissions.test.js
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react-hooks';
 import {
   QueryClient,
   QueryClientProvider,

--- a/src/settings/AddressTypesSettings.test.js
+++ b/src/settings/AddressTypesSettings.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/stripesCore.mock';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/settings/CommentRequiredForm.test.js
+++ b/src/settings/CommentRequiredForm.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import userEvent from '@testing-library/user-event';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import { Form } from 'react-final-form';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/settings/CommentRequiredSettings.test.js
+++ b/src/settings/CommentRequiredSettings.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import renderWithRouter from 'helpers/renderWithRouter';
 import CommentRequiredSettings from './CommentRequiredSettings';
 

--- a/src/settings/ConditionsSettings.test.js
+++ b/src/settings/ConditionsSettings.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act } from '@testing-library/react';
+import { act } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/stripesCore.mock';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/settings/CustomFieldsSettings.test.js
+++ b/src/settings/CustomFieldsSettings.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import '../../test/jest/__mock__';
 
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import renderWithRouter from '../../test/jest/helpers/renderWithRouter';
 

--- a/src/settings/DepartmentsSettings.test.js
+++ b/src/settings/DepartmentsSettings.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/stripesCore.mock';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/settings/FeeFineSettings.test.js
+++ b/src/settings/FeeFineSettings.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import { buildResources } from 'helpers/buildResources';

--- a/src/settings/FeeFinesTable/ChargeNotice.test.js
+++ b/src/settings/FeeFinesTable/ChargeNotice.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import userEvent from '@testing-library/user-event';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import ChargeNotice from './ChargeNotice';

--- a/src/settings/FeeFinesTable/CopyModal.test.js
+++ b/src/settings/FeeFinesTable/CopyModal.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import CopyModal from './CopyModal';

--- a/src/settings/LimitsSettings.test.js
+++ b/src/settings/LimitsSettings.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { createMemoryHistory } from 'history';
 
 import { Router } from 'react-router-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/stripesCore.mock';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/settings/OwnerSettings.test.js
+++ b/src/settings/OwnerSettings.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { act, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { act, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import { buildResources } from 'helpers/buildResources';

--- a/src/settings/PatronGroupsSettings.test.js
+++ b/src/settings/PatronGroupsSettings.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/stripesCore.mock';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/settings/PaymentSettings.test.js
+++ b/src/settings/PaymentSettings.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import { buildResources } from 'helpers/buildResources';

--- a/src/settings/RefundReasonsSettings.test.js
+++ b/src/settings/RefundReasonsSettings.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/stripesCore.mock';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/settings/TransferAccountsSettings.test.js
+++ b/src/settings/TransferAccountsSettings.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 
 import '__mock__/stripesCore.mock';

--- a/src/settings/TransferCriteriaSettings/TransferCriteriaSettings.test.js
+++ b/src/settings/TransferCriteriaSettings/TransferCriteriaSettings.test.js
@@ -3,7 +3,7 @@ import { Router } from 'react-router-dom';
 import {
   cleanup,
   render,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import { createMemoryHistory } from 'history';
 
 import '__mock__';

--- a/src/settings/WaiveSettings.test.js
+++ b/src/settings/WaiveSettings.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import '__mock__/stripesCore.mock';
 import '__mock__/stripesSmartComponent.mock';

--- a/src/settings/components/SectionPageItem.test.js
+++ b/src/settings/components/SectionPageItem.test.js
@@ -3,7 +3,7 @@ import { Router } from 'react-router-dom';
 import {
   render,
   cleanup,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import { createMemoryHistory } from 'history';
 import { FormattedMessage } from 'react-intl';
 

--- a/src/settings/components/SettingsPage.test.js
+++ b/src/settings/components/SettingsPage.test.js
@@ -3,7 +3,7 @@ import { Router } from 'react-router-dom';
 import {
   render,
   cleanup,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import { createMemoryHistory } from 'history';
 import { FormattedMessage } from 'react-intl';
 

--- a/src/settings/patronBlocks/BlockTemplates/BlockTemplateDetails.test.js
+++ b/src/settings/patronBlocks/BlockTemplates/BlockTemplateDetails.test.js
@@ -1,7 +1,7 @@
-import { screen } from '@testing-library/dom';
+import { screen } from '@folio/jest-config-stripes/testing-library/dom';
 import renderWithRouter from 'helpers/renderWithRouter';
 
-import userEvent from '@testing-library/user-event';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import BlockTemplateDetails from './BlockTemplateDetails';
 
 jest.unmock('@folio/stripes/components');

--- a/src/settings/patronBlocks/Conditions/Conditions.test.js
+++ b/src/settings/patronBlocks/Conditions/Conditions.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { act, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { act, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import Conditions from './Conditions';

--- a/src/settings/patronBlocks/Conditions/ConditionsForm.test.js
+++ b/src/settings/patronBlocks/Conditions/ConditionsForm.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import ConditionsForm from './ConditionsForm';

--- a/src/settings/patronBlocks/Limits/Limits.test.js
+++ b/src/settings/patronBlocks/Limits/Limits.test.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 
-import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import PropTypes from 'prop-types';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/settings/patronBlocks/Limits/LimitsForm.test.js
+++ b/src/settings/patronBlocks/Limits/LimitsForm.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import LimitsForm from './LimitsForm';

--- a/src/settings/permissions/PermissionSetDetails.test.js
+++ b/src/settings/permissions/PermissionSetDetails.test.js
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/react';
+import { fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import PermissionSetDetails from './PermissionSetDetails';

--- a/src/settings/permissions/PermissionSetForm.test.js
+++ b/src/settings/permissions/PermissionSetForm.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import buildStripes from '__mock__/stripes.mock';

--- a/src/settings/permissions/PermissionSets.test.js
+++ b/src/settings/permissions/PermissionSets.test.js
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@folio/jest-config-stripes/testing-library/react';
 import '__mock__/stripesCore.mock';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/settings/sections.test.js
+++ b/src/settings/sections.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render } from '@folio/jest-config-stripes/testing-library/react';
 import { sortBy } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 

--- a/src/views/AccountDetails/AccountDetails.test.js
+++ b/src/views/AccountDetails/AccountDetails.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import '__mock__/stripesCore.mock';
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/views/LoanDetails/LoanProxyDetails.test.js
+++ b/src/views/LoanDetails/LoanProxyDetails.test.js
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import user from 'fixtures/okapiCurrentUser';
 
 import renderWithRouter from 'helpers/renderWithRouter';

--- a/src/views/LoansListing/LoansListing.test.js
+++ b/src/views/LoansListing/LoansListing.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 import user from 'fixtures/okapiCurrentUser';
 import loan from 'fixtures/openLoan';
 import '__mock__/stripesCore.mock';

--- a/src/views/LostItems/LostItemsListContainer/components/Filters/Filters.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/Filters/Filters.test.js
@@ -1,7 +1,7 @@
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../../../test/jest/__mock__';
 

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/LostItemsList.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/LostItemsList.test.js
@@ -3,7 +3,7 @@ import {
   render,
   screen,
   cleanup,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import { noop } from 'lodash';
 import { MultiColumnList } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/ActualCostConfirmModal/ActualCostConfirmModal.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/ActualCostConfirmModal/ActualCostConfirmModal.test.js
@@ -3,7 +3,7 @@ import {
   render,
   screen,
   fireEvent,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../../../../../test/jest/__mock__';
 import ActualCostConfirmModal from './ActualCostConfirmModal';

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/ActualCostDetailsModal/ActualCostDetailsModal.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/ActualCostDetailsModal/ActualCostDetailsModal.test.js
@@ -3,7 +3,7 @@ import {
   render,
   screen,
   fireEvent,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../../../../../test/jest/__mock__';
 import {

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/ActualCostModal/ActualCostModal.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/ActualCostModal/ActualCostModal.test.js
@@ -3,7 +3,7 @@ import {
   render,
   screen,
   fireEvent,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import {
   TextField,
   TextArea,

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/DateTimeFormatter/DateTimeFormatter.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/DateTimeFormatter/DateTimeFormatter.test.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@folio/jest-config-stripes/testing-library/react';
 import {
   FormattedDate,
   FormattedTime,

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/InstanceDetails/InstanceDetails.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/InstanceDetails/InstanceDetails.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import { effectiveCallNumber } from '@folio/stripes/util';
 
 import InstanceDetails, {

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/InstanceDetails/components/ShowLongContentInPopover/ShowLongContentInPopover.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/InstanceDetails/components/ShowLongContentInPopover/ShowLongContentInPopover.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import ShowLongContentInPopover, {
   getComponentText,

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RecordStatus/RecordStatus.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RecordStatus/RecordStatus.test.js
@@ -1,7 +1,7 @@
 import {
   cleanup,
   render,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import {
   FormattedMessage,
   FormattedDate,

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/RenderActions.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/RenderActions.test.js
@@ -3,7 +3,7 @@ import {
   cleanup,
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../../../../../test/jest/__mock__';
 

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/ActualCostDetails/ActualCostDetails.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/ActualCostDetails/ActualCostDetails.test.js
@@ -3,7 +3,7 @@ import {
   fireEvent,
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../../../../../../../test/jest/__mock__';
 

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/BillActualCost/BillActualCost.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/BillActualCost/BillActualCost.test.js
@@ -3,7 +3,7 @@ import {
   fireEvent,
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../../../../../../../test/jest/__mock__';
 

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/DoNotBillActualCost/DoNotBillActualCost.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/DoNotBillActualCost/DoNotBillActualCost.test.js
@@ -3,7 +3,7 @@ import {
   fireEvent,
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../../../../../../../test/jest/__mock__';
 

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/FeeFineDetailsLink/FeeFineDetailsLink.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/FeeFineDetailsLink/FeeFineDetailsLink.test.js
@@ -1,7 +1,7 @@
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import { Button } from '@folio/stripes/components';
 

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/ItemDetailsLink/ItemDetailsLink.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/ItemDetailsLink/ItemDetailsLink.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../../../../../../../test/jest/__mock__';
 

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/LoanDetailsLink/LoanDetailsLink.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/LoanDetailsLink/LoanDetailsLink.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../../../../../../../test/jest/__mock__';
 

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/PatronDetailsLink/PatronDetailsLink.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RenderActions/components/PatronDetailsLink/PatronDetailsLink.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import '../../../../../../../../../../test/jest/__mock__';
 

--- a/src/views/LostItems/LostItemsListContainer/components/Search/Search.test.js
+++ b/src/views/LostItems/LostItemsListContainer/components/Search/Search.test.js
@@ -3,7 +3,7 @@ import {
   render,
   screen,
   fireEvent,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import {
   SearchField,
 } from '@folio/stripes/components';

--- a/src/views/LostItems/NoPermissionMessage/NoPermissionMessage.test.js
+++ b/src/views/LostItems/NoPermissionMessage/NoPermissionMessage.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 
 import NoPermissionMessage from './NoPermissionMessage';
 

--- a/src/views/Notes/NoteCreatePage.test.js
+++ b/src/views/Notes/NoteCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@folio/jest-config-stripes/testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { NoteCreatePage } from '@folio/stripes/smart-components';
 import NoteCreateRoute from './NoteCreatePage';

--- a/src/views/Notes/NoteEditPage.test.js
+++ b/src/views/Notes/NoteEditPage.test.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render } from '@folio/jest-config-stripes/testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { NoteEditPage } from '@folio/stripes/smart-components';
 import NoteEditRoute from './NoteEditPage';

--- a/src/views/Notes/NoteViewPage.test.js
+++ b/src/views/Notes/NoteViewPage.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@folio/jest-config-stripes/testing-library/react';
 import { createMemoryHistory } from 'history';
 
 import NoteViewPage from './NoteViewPage';

--- a/src/views/UserDetail/UserDetail.test.js
+++ b/src/views/UserDetail/UserDetail.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import userEvent from '@testing-library/user-event';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import {
   render,
   screen,
   waitFor,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import {
   useStripes,
   IfInterface,

--- a/src/views/UserDetail/UserDetailFullscreen.test.js
+++ b/src/views/UserDetail/UserDetailFullscreen.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   render,
   screen,
-} from '@testing-library/react';
+} from '@folio/jest-config-stripes/testing-library/react';
 import '../../../test/jest/__mock__';
 import UserDetailFullscreen from './UserDetailFullscreen';
 

--- a/src/views/UserDetail/components/ActionMenuDeleteButton/ActionMenuDeleteButton.test.js
+++ b/src/views/UserDetail/components/ActionMenuDeleteButton/ActionMenuDeleteButton.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import { IfPermission } from '@folio/stripes/core';
 

--- a/src/views/UserDetail/components/ActionMenuEditButton/ActionMenuEditButton.test.js
+++ b/src/views/UserDetail/components/ActionMenuEditButton/ActionMenuEditButton.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import { IfPermission } from '@folio/stripes/core';
 

--- a/src/views/UserDetail/components/DeleteUserModal/DeleteUserModal.test.js
+++ b/src/views/UserDetail/components/DeleteUserModal/DeleteUserModal.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { act, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { act, render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { StripesContext } from '@folio/stripes/core';
 
 import '__mock__';

--- a/src/views/UserDetail/components/OpenTransactionModal/OpenTransactionModal.test.js
+++ b/src/views/UserDetail/components/OpenTransactionModal/OpenTransactionModal.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { act, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { act, render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { StripesContext } from '@folio/stripes/core';
 
 import '__mock__';

--- a/src/views/UserSearch/Filters.test.js
+++ b/src/views/UserSearch/Filters.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@folio/jest-config-stripes/testing-library/react';
 import '../../../test/jest/__mock__/matchMedia.mock';
 
 import Filters from './Filters';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,115 +1222,115 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@esbuild/android-arm64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz#4aa8d8afcffb4458736ca9b32baa97d7cb5861ea"
-  integrity sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==
+"@esbuild/android-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz#bafb75234a5d3d1b690e7c2956a599345e84a2fd"
+  integrity sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==
 
-"@esbuild/android-arm@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.18.tgz#74a7e95af4ee212ebc9db9baa87c06a594f2a427"
-  integrity sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==
+"@esbuild/android-arm@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.19.tgz#5898f7832c2298bc7d0ab53701c57beb74d78b4d"
+  integrity sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==
 
-"@esbuild/android-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.18.tgz#1dcd13f201997c9fe0b204189d3a0da4eb4eb9b6"
-  integrity sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==
+"@esbuild/android-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.19.tgz#658368ef92067866d95fb268719f98f363d13ae1"
+  integrity sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==
 
-"@esbuild/darwin-arm64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz#444f3b961d4da7a89eb9bd35cfa4415141537c2a"
-  integrity sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==
+"@esbuild/darwin-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz#584c34c5991b95d4d48d333300b1a4e2ff7be276"
+  integrity sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==
 
-"@esbuild/darwin-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz#a6da308d0ac8a498c54d62e0b2bfb7119b22d315"
-  integrity sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==
+"@esbuild/darwin-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz#7751d236dfe6ce136cce343dce69f52d76b7f6cb"
+  integrity sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==
 
-"@esbuild/freebsd-arm64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz#b83122bb468889399d0d63475d5aea8d6829c2c2"
-  integrity sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==
+"@esbuild/freebsd-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz#cacd171665dd1d500f45c167d50c6b7e539d5fd2"
+  integrity sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==
 
-"@esbuild/freebsd-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz#af59e0e03fcf7f221b34d4c5ab14094862c9c864"
-  integrity sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==
+"@esbuild/freebsd-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz#0769456eee2a08b8d925d7c00b79e861cb3162e4"
+  integrity sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==
 
-"@esbuild/linux-arm64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz#8551d72ba540c5bce4bab274a81c14ed01eafdcf"
-  integrity sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==
+"@esbuild/linux-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz#38e162ecb723862c6be1c27d6389f48960b68edb"
+  integrity sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==
 
-"@esbuild/linux-arm@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz#e09e76e526df4f665d4d2720d28ff87d15cdf639"
-  integrity sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==
+"@esbuild/linux-arm@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz#1a2cd399c50040184a805174a6d89097d9d1559a"
+  integrity sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==
 
-"@esbuild/linux-ia32@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz#47878860ce4fe73a36fd8627f5647bcbbef38ba4"
-  integrity sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==
+"@esbuild/linux-ia32@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz#e28c25266b036ce1cabca3c30155222841dc035a"
+  integrity sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==
 
-"@esbuild/linux-loong64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz#3f8fbf5267556fc387d20b2e708ce115de5c967a"
-  integrity sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==
+"@esbuild/linux-loong64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz#0f887b8bb3f90658d1a0117283e55dbd4c9dcf72"
+  integrity sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==
 
-"@esbuild/linux-mips64el@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz#9d896d8f3c75f6c226cbeb840127462e37738226"
-  integrity sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==
+"@esbuild/linux-mips64el@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz#f5d2a0b8047ea9a5d9f592a178ea054053a70289"
+  integrity sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==
 
-"@esbuild/linux-ppc64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz#3d9deb60b2d32c9985bdc3e3be090d30b7472783"
-  integrity sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==
+"@esbuild/linux-ppc64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz#876590e3acbd9fa7f57a2c7d86f83717dbbac8c7"
+  integrity sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==
 
-"@esbuild/linux-riscv64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz#8a943cf13fd24ff7ed58aefb940ef178f93386bc"
-  integrity sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==
+"@esbuild/linux-riscv64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz#7f49373df463cd9f41dc34f9b2262d771688bf09"
+  integrity sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==
 
-"@esbuild/linux-s390x@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz#66cb01f4a06423e5496facabdce4f7cae7cb80e5"
-  integrity sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==
+"@esbuild/linux-s390x@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz#e2afd1afcaf63afe2c7d9ceacd28ec57c77f8829"
+  integrity sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==
 
-"@esbuild/linux-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz#23c26050c6c5d1359c7b774823adc32b3883b6c9"
-  integrity sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==
+"@esbuild/linux-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz#8a0e9738b1635f0c53389e515ae83826dec22aa4"
+  integrity sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==
 
-"@esbuild/netbsd-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz#789a203d3115a52633ff6504f8cbf757f15e703b"
-  integrity sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==
+"@esbuild/netbsd-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz#c29fb2453c6b7ddef9a35e2c18b37bda1ae5c462"
+  integrity sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==
 
-"@esbuild/openbsd-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz#d7b998a30878f8da40617a10af423f56f12a5e90"
-  integrity sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==
+"@esbuild/openbsd-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz#95e75a391403cb10297280d524d66ce04c920691"
+  integrity sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==
 
-"@esbuild/sunos-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz#ecad0736aa7dae07901ba273db9ef3d3e93df31f"
-  integrity sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==
+"@esbuild/sunos-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz#722eaf057b83c2575937d3ffe5aeb16540da7273"
+  integrity sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==
 
-"@esbuild/win32-arm64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz#58dfc177da30acf956252d7c8ae9e54e424887c4"
-  integrity sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==
+"@esbuild/win32-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz#9aa9dc074399288bdcdd283443e9aeb6b9552b6f"
+  integrity sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==
 
-"@esbuild/win32-ia32@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz#340f6163172b5272b5ae60ec12c312485f69232b"
-  integrity sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==
+"@esbuild/win32-ia32@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz#95ad43c62ad62485e210f6299c7b2571e48d2b03"
+  integrity sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==
 
-"@esbuild/win32-x64@0.17.18":
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz#3a8e57153905308db357fd02f57c180ee3a0a1fa"
-  integrity sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==
+"@esbuild/win32-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz#8cfaf2ff603e9aabb910e9c0558c26cf32744061"
+  integrity sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
@@ -1385,9 +1385,9 @@
     webpack "^5.80.0"
 
 "@folio/jest-config-stripes@^1.0.0":
-  version "1.0.10000010"
-  resolved "https://repository.folio.org/repository/npm-folioci/@folio/jest-config-stripes/-/jest-config-stripes-1.0.10000010.tgz#94a34d4ad38346f618cbbad353a4163f436e9795"
-  integrity sha512-LhIIRUyIXclL/IBdR03wpjpVWnBvkKSHj+Npdf3Ghm/5a20dUI+KRbP4UGmaZKrra/c4kCzi5tPq065tTjviIQ==
+  version "1.0.10000016"
+  resolved "https://repository.folio.org/repository/npm-folioci/@folio/jest-config-stripes/-/jest-config-stripes-1.0.10000016.tgz#aced94a1795f42b9fb06f831dcd1dc69d3af4ad2"
+  integrity sha512-1uSxOoKvffeLKhg3yI74zXlkWZQVg005XW7sFP0z5cwnYTBhubiS7WfF0sB4tA/X8k1ziG/dRus3o7vO/dtzrA==
   dependencies:
     "@jest/globals" "^29.5.0"
     "@testing-library/dom" "^8.20.0"
@@ -1467,9 +1467,9 @@
     yargs "^17.3.1"
 
 "@folio/stripes-components@~11.1.0":
-  version "11.1.1000002913"
-  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-components/-/stripes-components-11.1.1000002913.tgz#775af04ecec11de333705ddf706fccf98347323a"
-  integrity sha512-L2leHB1TgZ2OSlQSk6p1OQCUioOZ42qK73Cp2NwAW3GVpdpBXhHS18mujMu2IwwF9USO8Z2PNHJA/XtB+Jc1gw==
+  version "11.1.1000002951"
+  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-components/-/stripes-components-11.1.1000002951.tgz#dcc76d025104ecdb623c88fa0974c49e92e54c08"
+  integrity sha512-PfonU+Xw/yoAdlQ0hfqkWSJVEkr2mUcb/FWizSBcLZrbCGVcPlXQE6xOjOp/KY1c9ftFHbBjBjREVLROvWO5Og==
   dependencies:
     "@folio/stripes-react-hotkeys" "^3.0.5"
     classnames "^2.2.5"
@@ -1508,9 +1508,9 @@
     uuid "^9.0.0"
 
 "@folio/stripes-core@~9.1.0":
-  version "9.1.1000001100"
-  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-core/-/stripes-core-9.1.1000001100.tgz#f64b126357efc714377b42e11192f5729e521925"
-  integrity sha512-0H3rO8oeHIhX2lDrw90PiWUBVeurZYQZnHqeiGzCPSwG8P47rTifwL9KTPn+oTfCpwPRPWzS8yE8sv049cs1bA==
+  version "9.1.1000001103"
+  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-core/-/stripes-core-9.1.1000001103.tgz#3bc6d8a251b14b705aa75c752d6184b8cf0fb726"
+  integrity sha512-cZR6Peo6rFQH9EpsmpuoLyrmt/RK+z3QhEgedTqgOOvtqhGMXxY1lajCWeKvVr21rjgREsJIqB6ekyTkqA+yEQ==
   dependencies:
     "@apollo/client" "^3.2.1"
     classnames "^2.2.5"
@@ -1580,9 +1580,9 @@
     prop-types "^15.7.2"
 
 "@folio/stripes-smart-components@~8.1.0":
-  version "8.1.1000001450"
-  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-smart-components/-/stripes-smart-components-8.1.1000001450.tgz#b68fc0b558ed4e552b064eeab4f6b935e8aef466"
-  integrity sha512-OZDc5CiPM6H/oN+LI3GE0N7H9nMio08BsNwZX1xrn0lIDNV3q6hBmNlH9srMcT0Dbq83/O8+pB2XsYfctqi96g==
+  version "8.1.1000001458"
+  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-smart-components/-/stripes-smart-components-8.1.1000001458.tgz#eb688b8fa43d455fe6c0d2e691e5855bde165a40"
+  integrity sha512-Xkfga/NNZgRRbCUAg6gUEY7JTeBms/q7IBuYHx5HOhZvow2jZ6HZKCip5FQRpp/RY+7MAOtCz/t7AmGd8kQf0w==
   dependencies:
     "@rehooks/local-storage" "^2.4.4"
     classnames "^2.2.6"
@@ -1622,9 +1622,9 @@
   integrity sha512-iLx5LfJ5lWCUQ/KYLjNcwa5kQofYitJocd8ABIif+KYky09t/D6NGJ5FrU7xT7QZmYMUkRy1aM4Ac4XrJjeKNA==
 
 "@folio/stripes-util@~5.2.1":
-  version "5.2.10000040"
-  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-util/-/stripes-util-5.2.10000040.tgz#2e5772a41cbf75e56ffb9a47ed6378a74ab96b81"
-  integrity sha512-7A4AGT0XJZOOf1asHcIScaU0Ve04khnTIoeh7GZu2+WcXbMqe6+DtHQtEmwp6O+caEzdJUS0PCWGgPG9S3RO5A==
+  version "5.2.10000048"
+  resolved "https://repository.folio.org/repository/npm-folioci/@folio/stripes-util/-/stripes-util-5.2.10000048.tgz#bf72c685d598ddd6013b3fd7c16625e02cdd79e5"
+  integrity sha512-VR3Fsj8pEVJKzx9uAqYRoZcACz46e1h8afGSIUd7hqXzX2YjN2bUx5CdBP1YWD2nrhjnmx/fDBq4I7tGFxMeGw==
   dependencies:
     json2csv "^4.2.1"
     lodash "^4.17.4"
@@ -2155,19 +2155,19 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-17.1.2.tgz#b7bc1cc5d3581adac9dce197a21f0e5f2ceaabf1"
   integrity sha512-OaS7Ol4Y+U50PbejfzQflGWRMxO04nYWO5ZBv6JerqMKE2WS/tI9VoVDDPXHBlRMGG2fOdKwtVGlFfc7AVIstw==
 
-"@octokit/plugin-paginate-rest@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.0.0.tgz#f34b5a7d9416019126042cd7d7b811e006c0d561"
-  integrity sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==
+"@octokit/plugin-paginate-rest@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.0.tgz#3522ef5c2712436332655085b197eafe4ac7afc4"
+  integrity sha512-5T4iXjJdYCVA1rdWS1C+uZV9AvtZY9QgTG74kFiSFVj94dZXowyi/YK8f4SGjZaL69jZthGlBaDKRdCMCF9log==
   dependencies:
-    "@octokit/types" "^9.0.0"
+    "@octokit/types" "^9.2.2"
 
 "@octokit/plugin-request-log@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
   integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
 
-"@octokit/plugin-rest-endpoint-methods@^7.0.0":
+"@octokit/plugin-rest-endpoint-methods@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.1.0.tgz#7f3f4fac10bf72f8c5cd0c343252cd5f73dbf2d8"
   integrity sha512-SWwz/hc47GaKJR6BlJI4WIVRodbAFRvrR0QRPSoPMs7krb7anYPML3psg+ThEz/kcwOdSNh/oA8qThi/Wvs4Fw==
@@ -2197,14 +2197,14 @@
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^19.0.7":
-  version "19.0.7"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-19.0.7.tgz#d2e21b4995ab96ae5bfae50b4969da7e04e0bb70"
-  integrity sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==
+  version "19.0.8"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-19.0.8.tgz#db1e67cb66018859fde2c6c3a49eb5c55dc04d92"
+  integrity sha512-/PKrzqn+zDzXKwBMwLI2IKrvk8yv8cedJOdcmxrjR3gmu6UIzURhP5oQj+4qkn7+uQi1gg7QqV4SqlaQ1HYW1Q==
   dependencies:
     "@octokit/core" "^4.1.0"
-    "@octokit/plugin-paginate-rest" "^6.0.0"
+    "@octokit/plugin-paginate-rest" "^6.1.0"
     "@octokit/plugin-request-log" "^1.0.4"
-    "@octokit/plugin-rest-endpoint-methods" "^7.0.0"
+    "@octokit/plugin-rest-endpoint-methods" "^7.1.0"
 
 "@octokit/types@^9.0.0", "@octokit/types@^9.2.2":
   version "9.2.2"
@@ -2281,19 +2281,19 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.3.0.tgz#0ec9264cf54a527671d990eb874e030b55b70dcc"
   integrity sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==
 
-"@sinonjs/commons@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
-  integrity sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==
+"@sinonjs/commons@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.0.tgz#beb434fe875d965265e04722ccfc21df7f755d72"
+  integrity sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==
   dependencies:
     type-detect "4.0.8"
 
 "@sinonjs/fake-timers@^10.0.2":
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz#d10549ed1f423d80639c528b6c7f5a1017747d0c"
-  integrity sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.1.0.tgz#3595e42b3f0a7df80a9681cf58d8cb418eac1e99"
+  integrity sha512-w1qd368vtrwttm1PRJWPW1QHlbmHrVDGs1eBH/jZvRPUFS4MNXV9Q33EQdjOdeAxZ7O8+3wM7zxztm2nfUSyKw==
   dependencies:
-    "@sinonjs/commons" "^2.0.0"
+    "@sinonjs/commons" "^3.0.0"
 
 "@socket.io/component-emitter@~3.1.0":
   version "3.1.0"
@@ -2513,9 +2513,9 @@
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
 "@types/node@*", "@types/node@>=10.0.0":
-  version "20.1.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.2.tgz#8fd63447e3f99aba6c3168fd2ec4580d5b97886f"
-  integrity sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g==
+  version "20.1.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.4.tgz#83f148d2d1f5fe6add4c53358ba00d97fc4cdb71"
+  integrity sha512-At4pvmIOki8yuwLtd7BNHl3CiWNbtclUbNtScGx4OHfBd4/oWoJC8KRCIxXwkdndzhxOsPXihrsOoydxBjlE9Q==
 
 "@types/prettier@^2.1.5":
   version "2.7.2"
@@ -2629,14 +2629,14 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^5.28.0":
-  version "5.59.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.5.tgz#f156827610a3f8cefc56baeaa93cd4a5f32966b4"
-  integrity sha512-feA9xbVRWJZor+AnLNAr7A8JRWeZqHUf4T9tlP+TN04b05pFVhO5eN7/O93Y/1OUlLMHKbnJisgDURs/qvtqdg==
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.6.tgz#a350faef1baa1e961698240f922d8de1761a9e2b"
+  integrity sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==
   dependencies:
     "@eslint-community/regexpp" "^4.4.0"
-    "@typescript-eslint/scope-manager" "5.59.5"
-    "@typescript-eslint/type-utils" "5.59.5"
-    "@typescript-eslint/utils" "5.59.5"
+    "@typescript-eslint/scope-manager" "5.59.6"
+    "@typescript-eslint/type-utils" "5.59.6"
+    "@typescript-eslint/utils" "5.59.6"
     debug "^4.3.4"
     grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
@@ -2645,71 +2645,71 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.28.0":
-  version "5.59.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.5.tgz#63064f5eafbdbfb5f9dfbf5c4503cdf949852981"
-  integrity sha512-NJXQC4MRnF9N9yWqQE2/KLRSOLvrrlZb48NGVfBa+RuPMN6B7ZcK5jZOvhuygv4D64fRKnZI4L4p8+M+rfeQuw==
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.6.tgz#bd36f71f5a529f828e20b627078d3ed6738dbb40"
+  integrity sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.59.5"
-    "@typescript-eslint/types" "5.59.5"
-    "@typescript-eslint/typescript-estree" "5.59.5"
+    "@typescript-eslint/scope-manager" "5.59.6"
+    "@typescript-eslint/types" "5.59.6"
+    "@typescript-eslint/typescript-estree" "5.59.6"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.59.5":
-  version "5.59.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.5.tgz#33ffc7e8663f42cfaac873de65ebf65d2bce674d"
-  integrity sha512-jVecWwnkX6ZgutF+DovbBJirZcAxgxC0EOHYt/niMROf8p4PwxxG32Qdhj/iIQQIuOflLjNkxoXyArkcIP7C3A==
+"@typescript-eslint/scope-manager@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.6.tgz#d43a3687aa4433868527cfe797eb267c6be35f19"
+  integrity sha512-gLbY3Le9Dxcb8KdpF0+SJr6EQ+hFGYFl6tVY8VxLPFDfUZC7BHFw+Vq7bM5lE9DwWPfx4vMWWTLGXgpc0mAYyQ==
   dependencies:
-    "@typescript-eslint/types" "5.59.5"
-    "@typescript-eslint/visitor-keys" "5.59.5"
+    "@typescript-eslint/types" "5.59.6"
+    "@typescript-eslint/visitor-keys" "5.59.6"
 
-"@typescript-eslint/type-utils@5.59.5":
-  version "5.59.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.5.tgz#485b0e2c5b923460bc2ea6b338c595343f06fc9b"
-  integrity sha512-4eyhS7oGym67/pSxA2mmNq7X164oqDYNnZCUayBwJZIRVvKpBCMBzFnFxjeoDeShjtO6RQBHBuwybuX3POnDqg==
+"@typescript-eslint/type-utils@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.6.tgz#37c51d2ae36127d8b81f32a0a4d2efae19277c48"
+  integrity sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.59.5"
-    "@typescript-eslint/utils" "5.59.5"
+    "@typescript-eslint/typescript-estree" "5.59.6"
+    "@typescript-eslint/utils" "5.59.6"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.59.5":
-  version "5.59.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.5.tgz#e63c5952532306d97c6ea432cee0981f6d2258c7"
-  integrity sha512-xkfRPHbqSH4Ggx4eHRIO/eGL8XL4Ysb4woL8c87YuAo8Md7AUjyWKa9YMwTL519SyDPrfEgKdewjkxNCVeJW7w==
+"@typescript-eslint/types@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.6.tgz#5a6557a772af044afe890d77c6a07e8c23c2460b"
+  integrity sha512-tH5lBXZI7T2MOUgOWFdVNUILsI02shyQvfzG9EJkoONWugCG77NDDa1EeDGw7oJ5IvsTAAGVV8I3Tk2PNu9QfA==
 
-"@typescript-eslint/typescript-estree@5.59.5":
-  version "5.59.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.5.tgz#9b252ce55dd765e972a7a2f99233c439c5101e42"
-  integrity sha512-+XXdLN2CZLZcD/mO7mQtJMvCkzRfmODbeSKuMY/yXbGkzvA9rJyDY5qDYNoiz2kP/dmyAxXquL2BvLQLJFPQIg==
+"@typescript-eslint/typescript-estree@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.6.tgz#2fb80522687bd3825504925ea7e1b8de7bb6251b"
+  integrity sha512-vW6JP3lMAs/Tq4KjdI/RiHaaJSO7IUsbkz17it/Rl9Q+WkQ77EOuOnlbaU8kKfVIOJxMhnRiBG+olE7f3M16DA==
   dependencies:
-    "@typescript-eslint/types" "5.59.5"
-    "@typescript-eslint/visitor-keys" "5.59.5"
+    "@typescript-eslint/types" "5.59.6"
+    "@typescript-eslint/visitor-keys" "5.59.6"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.59.5", "@typescript-eslint/utils@^5.58.0":
-  version "5.59.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.5.tgz#15b3eb619bb223302e60413adb0accd29c32bcae"
-  integrity sha512-sCEHOiw+RbyTii9c3/qN74hYDPNORb8yWCoPLmB7BIflhplJ65u2PBpdRla12e3SSTJ2erRkPjz7ngLHhUegxA==
+"@typescript-eslint/utils@5.59.6", "@typescript-eslint/utils@^5.58.0":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.6.tgz#82960fe23788113fc3b1f9d4663d6773b7907839"
+  integrity sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.59.5"
-    "@typescript-eslint/types" "5.59.5"
-    "@typescript-eslint/typescript-estree" "5.59.5"
+    "@typescript-eslint/scope-manager" "5.59.6"
+    "@typescript-eslint/types" "5.59.6"
+    "@typescript-eslint/typescript-estree" "5.59.6"
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@5.59.5":
-  version "5.59.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.5.tgz#ba5b8d6791a13cf9fea6716af1e7626434b29b9b"
-  integrity sha512-qL+Oz+dbeBRTeyJTIy0eniD3uvqU7x+y1QceBismZ41hd4aBSRh8UAw4pZP0+XzLuPZmx4raNMq/I+59W2lXKA==
+"@typescript-eslint/visitor-keys@5.59.6":
+  version "5.59.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.6.tgz#673fccabf28943847d0c8e9e8d008e3ada7be6bb"
+  integrity sha512-zEfbFLzB9ETcEJ4HZEEsCR9HHeNku5/Qw1jSS5McYJv5BR+ftYXwFFAH5Al+xkGaZEqowMwl7uoJjQb1YSPF8Q==
   dependencies:
-    "@typescript-eslint/types" "5.59.5"
+    "@typescript-eslint/types" "5.59.6"
     eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
@@ -2886,9 +2886,9 @@ acorn-globals@^7.0.0:
     acorn-walk "^8.0.2"
 
 acorn-import-assertions@^1.7.6:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
-  integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
+  integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
 
 acorn-jsx@^5.3.1:
   version "5.3.2"
@@ -3222,9 +3222,9 @@ available-typed-arrays@^1.0.5:
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 axe-core@^4.4.3:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.0.tgz#34ba5a48a8b564f67e103f0aa5768d76e15bbbbf"
-  integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.1.tgz#04392c9ccb3d7d7c5d2f8684f148d56d3442f33d"
+  integrity sha512-sCXXUhA+cljomZ3ZAwb8i1p3oOlkABzPy08ZDAoGcYuvtBPlQ1Ytde129ArXyHWDhfeewq7rlx9F+cUx2SSlkg==
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -3708,9 +3708,9 @@ camelcase@^7.0.1:
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
 
 caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001464:
-  version "1.0.30001486"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz#56a08885228edf62cbe1ac8980f2b5dae159997e"
-  integrity sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==
+  version "1.0.30001487"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz#d882d1a34d89c11aea53b8cdc791931bdab5fe1b"
+  integrity sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==
 
 canvg@^3.0.6:
   version "3.0.10"
@@ -4869,9 +4869,9 @@ effection@^1.0.0:
   integrity sha512-ITAAnuI7sJqKhjvYlnm66NHaW7zrXzqgsGsjVaaqFHYDWPN8WylVj46xASfkrtwq5wmklbzy6tvRYaj2C4rDHw==
 
 electron-to-chromium@^1.4.284:
-  version "1.4.392"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.392.tgz#57ec91fa02393ab32e46df6925ef309642a44680"
-  integrity sha512-TXQOMW9tnhIms3jGy/lJctLjICOgyueZFJ1KUtm6DTQ+QpxX3p7ZBwB6syuZ9KBuT5S4XX7bgY1ECPgfxKUdOg==
+  version "1.4.395"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.395.tgz#0d1abcd410a28737145bd4c117f26ea8195bf671"
+  integrity sha512-r8IgVPlJsCs7yezgmuBTaOMuu8lgU0mzg+wcLLo0xVy5s+rpuFTI9tEKhHVaMIPgeJPjxwTDHUZqoBEsNMDbCQ==
 
 element-is-visible@^1.0.0:
   version "1.0.0"
@@ -5148,32 +5148,32 @@ esbuild-loader@^3.0.1:
     webpack-sources "^1.4.3"
 
 esbuild@^0.17.6:
-  version "0.17.18"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.18.tgz#f4f8eb6d77384d68cd71c53eb6601c7efe05e746"
-  integrity sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.19.tgz#087a727e98299f0462a3d0bcdd9cd7ff100bd955"
+  integrity sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==
   optionalDependencies:
-    "@esbuild/android-arm" "0.17.18"
-    "@esbuild/android-arm64" "0.17.18"
-    "@esbuild/android-x64" "0.17.18"
-    "@esbuild/darwin-arm64" "0.17.18"
-    "@esbuild/darwin-x64" "0.17.18"
-    "@esbuild/freebsd-arm64" "0.17.18"
-    "@esbuild/freebsd-x64" "0.17.18"
-    "@esbuild/linux-arm" "0.17.18"
-    "@esbuild/linux-arm64" "0.17.18"
-    "@esbuild/linux-ia32" "0.17.18"
-    "@esbuild/linux-loong64" "0.17.18"
-    "@esbuild/linux-mips64el" "0.17.18"
-    "@esbuild/linux-ppc64" "0.17.18"
-    "@esbuild/linux-riscv64" "0.17.18"
-    "@esbuild/linux-s390x" "0.17.18"
-    "@esbuild/linux-x64" "0.17.18"
-    "@esbuild/netbsd-x64" "0.17.18"
-    "@esbuild/openbsd-x64" "0.17.18"
-    "@esbuild/sunos-x64" "0.17.18"
-    "@esbuild/win32-arm64" "0.17.18"
-    "@esbuild/win32-ia32" "0.17.18"
-    "@esbuild/win32-x64" "0.17.18"
+    "@esbuild/android-arm" "0.17.19"
+    "@esbuild/android-arm64" "0.17.19"
+    "@esbuild/android-x64" "0.17.19"
+    "@esbuild/darwin-arm64" "0.17.19"
+    "@esbuild/darwin-x64" "0.17.19"
+    "@esbuild/freebsd-arm64" "0.17.19"
+    "@esbuild/freebsd-x64" "0.17.19"
+    "@esbuild/linux-arm" "0.17.19"
+    "@esbuild/linux-arm64" "0.17.19"
+    "@esbuild/linux-ia32" "0.17.19"
+    "@esbuild/linux-loong64" "0.17.19"
+    "@esbuild/linux-mips64el" "0.17.19"
+    "@esbuild/linux-ppc64" "0.17.19"
+    "@esbuild/linux-riscv64" "0.17.19"
+    "@esbuild/linux-s390x" "0.17.19"
+    "@esbuild/linux-x64" "0.17.19"
+    "@esbuild/netbsd-x64" "0.17.19"
+    "@esbuild/openbsd-x64" "0.17.19"
+    "@esbuild/sunos-x64" "0.17.19"
+    "@esbuild/win32-arm64" "0.17.19"
+    "@esbuild/win32-ia32" "0.17.19"
+    "@esbuild/win32-x64" "0.17.19"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -6023,12 +6023,13 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
-  integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
+  integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
+    has-proto "^1.0.1"
     has-symbols "^1.0.3"
 
 get-package-type@^0.1.0:
@@ -9204,9 +9205,9 @@ postcss-nesting@^10.2.0:
     postcss-selector-parser "^6.0.10"
 
 postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.9:
-  version "6.0.12"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz#2efae5ffab3c8bfb2b7fbf0c426e3bca616c4abb"
-  integrity sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz#d05d8d76b1e8e173257ef9d60b706a8e5e99bf1b"
+  integrity sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
@@ -9806,9 +9807,9 @@ react-transition-group@^2.2.1, react-transition-group@^2.4.0:
     react-lifecycles-compat "^3.0.4"
 
 react-virtualized-auto-sizer@^1.0.2:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.15.tgz#84558bcab61a625d13ec37876639bb09c5a3ec0b"
-  integrity sha512-01yhkssgHShMiu5W8k+86kgl8lutpl+Uef9KP4wrozXnzZjxWIgj+cH8Qi064oQpKD8myn/JNMzp4tcZNQ3Avg==
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.17.tgz#4a172762e1edc2bb3e545bdf24663f1007d1daba"
+  integrity sha512-XtojyZHGo/iYmGkOEL8psTQsr5XI4fd+QxCD16ru00mnJhuvXFXcPLHXj5cKJh/xUttxPCglnpUI8d2u6gUgzw==
 
 react@^17.0.2:
   version "17.0.2"
@@ -10283,9 +10284,9 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.1.3, semver@^7.2.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.0.tgz#ed8c5dc8efb6c629c88b23d41dc9bf40c1d96cd0"
-  integrity sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
+  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
* Consume `@testing-library` deps via `jest-config-stripes`. This simplifies dependency management (we only depend on one package instead of several; we only have to keep the versions of those packages aligned in one place).

* Don't directly import `@jest/globals`; that's handled already by our config.

Refs [UIU-2866](https://issues.folio.org/browse/UIU-2866)