### PR TITLE
UIU-2870 convert search results to Prev/Next Pagination

### DIFF
--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -62,10 +62,12 @@ class UserSearchContainer extends React.Component {
     query: { initialValue: { sort: 'name' } },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
     resultOffset: { initialValue: 0 },
+    resultDensity : 'sparse',
     records: {
       type: 'okapi',
       records: 'users',
       resultOffset: '%{resultOffset}',
+      resultDensity: 'sparse',
       perRequest: 100,
       path: 'users',
       GET: {

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -62,7 +62,6 @@ class UserSearchContainer extends React.Component {
     query: { initialValue: { sort: 'name' } },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
     resultOffset: { initialValue: 0 },
-    resultDensity : 'sparse',
     records: {
       type: 'okapi',
       records: 'users',

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -25,6 +25,7 @@ import {
   SearchField,
   SRStatus,
   MenuSection,
+  MCLPagingTypes,
 } from '@folio/stripes/components';
 
 import {
@@ -841,10 +842,9 @@ class UserSearch extends React.Component {
                             isEmptyMessage={resultsStatusMessage}
                             isSelected={this.isSelected}
                             autosize
-                            virtualize
                             hasMargin
                             pageAmount={100}
-                            pagingType="click"
+                            pagingType={MCLPagingTypes.PREV_NEXT}
                           />
                         </Pane>
                       )}


### PR DESCRIPTION
Use prev/next pagination when the page's main focus is a search/result list.

![image](https://github.com/folio-org/ui-users/assets/20704067/70f78009-7be9-4c17-986a-e3ef4eaa3756)
