### PR TITLE
UIU-2875: Also support request-storage 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Align affiliation assignment with stripes-core updates (switch active affiliation). Refs UIU-2855.
 * Also support `circulation` `14.0`. Refs UIU-2858.
 * Import `@testing-library` deps from `jest-config-stripes`. Refs UIU-2866.
+* Also support `request-storage` `6.0`. Refs UIU-2875.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0 7.0",
       "notes": "2.0 3.0",
-      "request-storage": "2.5 3.0 4.0 5.0"
+      "request-storage": "2.5 3.0 4.0 5.0 6.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Purpose
Also support request-storage 6.0

## Approach
Field fulfilmentPreference was renamed to fulfillmentPreference. This changes do not affect current module.

## Refs
https://issues.folio.org/browse/UIU-2875