### PR TITLE
UIU-2805 Register form field on tenant permissions initialization

### DIFF
--- a/src/views/UserEdit/TenantsPermissionsAccordion.js
+++ b/src/views/UserEdit/TenantsPermissionsAccordion.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
+import { get, noop } from 'lodash';
 import { useCallback, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
@@ -33,7 +33,7 @@ const TenantsPermissionsAccordion = ({
   const [tenantId, setTenantId] = useState(stripes.okapi.tenant);
   const [isActionsDisabled, setActionsDisabled] = useState(false);
 
-  const { change, getState } = form;
+  const { getState, registerField } = form;
   const { id: userId, username } = initialValues;
   const permissionsField = `permissions.${tenantId}`;
   const isPermissionsPresent = Boolean(get(getState().values, permissionsField));
@@ -42,9 +42,9 @@ const TenantsPermissionsAccordion = ({
     setActionsDisabled(false);
 
     if (!isPermissionsPresent) {
-      change(permissionsField, permissionNames);
+      registerField(permissionsField, noop, { value: true }, { initialValue: permissionNames });
     }
-  }, [change, isPermissionsPresent, permissionsField]);
+  }, [isPermissionsPresent, permissionsField, registerField]);
 
   const handleError = useCallback(({ code }) => {
     setActionsDisabled(true);

--- a/src/views/UserEdit/TenantsPermissionsAccordion.test.js
+++ b/src/views/UserEdit/TenantsPermissionsAccordion.test.js
@@ -36,6 +36,7 @@ const defaultProps = {
       values: {},
     })),
     change: jest.fn(),
+    registerField: jest.fn(),
   },
   initialValues: {
     id: 'userId',
@@ -90,7 +91,7 @@ describe('TenantsPermissionsAccordion', () => {
 
     mockUserTenantPermsHookOpts.onSuccess({ permissionNames: ['user.item.get'] });
 
-    expect(defaultProps.form.change).toHaveBeenCalled();
+    expect(defaultProps.form.registerField).toHaveBeenCalled();
   });
 
   it('should handle errors when affiliations or permissions loading is failed', async () => {


### PR DESCRIPTION
## Purpose
Improvement of https://issues.folio.org/browse/UIU-2805

When tenant permissions are initialized related form field is just changed (via form.change()), but it's not registered and doesn't have an initial value, so it causes form state issues (pristine, dirty, etc.).

![chrome_84yFSSWFp4](https://github.com/folio-org/ui-users/assets/88109087/6608dda7-514a-4f09-b9b9-bdb1ff8a03ef)


## Approach
Register a field in the final form (if it was not registered yet) when tenant permissions were initialized.

![chrome_J8n7lfFuLr](https://github.com/folio-org/ui-users/assets/88109087/1a067dc2-2ac3-4b6c-bfd7-f49ad7849b48)


