### PR TITLE
UIU-2805 Fix form state after tenant selection in the permissions form

### DIFF
--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -185,12 +185,6 @@ class PermissionsModal extends React.Component {
     }
   }
 
-  setAssignedPermissionIds = (assignedPermissionIds) => {
-    if (this._isMounted) {
-      this.setState({ assignedPermissionIds });
-    }
-  }
-
   // Search for permissions
   onSubmitSearch = (searchText) => {
     const permissions = this.state.allPermissions || [];

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -144,6 +144,10 @@ class PermissionsModal extends React.Component {
     if (this.props.tenantId !== prevProps.tenantId) {
       await this.initPermissionsModal();
     }
+
+    if (this.props.assignedPermissions !== prevProps.assignedPermissions) {
+      this.setAssignedPermissionIds(this.props.assignedPermissions.map(({ id }) => id));
+    }
   }
 
   componentWillUnmount() {
@@ -178,6 +182,12 @@ class PermissionsModal extends React.Component {
         permissions,
         assignedPermissionIds: this.props.assignedPermissions.map(({ id }) => id)
       });
+    }
+  }
+
+  setAssignedPermissionIds = (assignedPermissionIds) => {
+    if (this._isMounted) {
+      this.setState({ assignedPermissionIds });
     }
   }
 

--- a/src/components/RenderPermissions/RenderPermissions.js
+++ b/src/components/RenderPermissions/RenderPermissions.js
@@ -103,7 +103,7 @@ class RenderPermissions extends React.Component {
       >
         <IfConsortium>
           <IfConsortiumPermission perm="consortia.user-tenants.collection.get">
-            {affiliations && (
+            {Boolean(affiliations) && (
               <AffiliationsSelect
                 affiliations={affiliations}
                 onChange={onChangeAffiliation}

--- a/src/views/UserEdit/TenantsPermissionsAccordion.js
+++ b/src/views/UserEdit/TenantsPermissionsAccordion.js
@@ -1,6 +1,11 @@
 import PropTypes from 'prop-types';
 import { get, noop } from 'lodash';
-import { useCallback, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import {
@@ -30,6 +35,7 @@ const TenantsPermissionsAccordion = ({
 }) => {
   const stripes = useStripes();
   const callout = useCallout();
+  const unregisterHandlersRef = useRef([]);
   const [tenantId, setTenantId] = useState(stripes.okapi.tenant);
   const [isActionsDisabled, setActionsDisabled] = useState(false);
 
@@ -38,11 +44,18 @@ const TenantsPermissionsAccordion = ({
   const permissionsField = `permissions.${tenantId}`;
   const isPermissionsPresent = Boolean(get(getState().values, permissionsField));
 
+  useEffect(() => {
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      unregisterHandlersRef.current.forEach((unregister) => unregister());
+    };
+  }, []);
+
   const initPermissionsValue = useCallback(({ permissionNames }) => {
     setActionsDisabled(false);
 
     if (!isPermissionsPresent) {
-      registerField(permissionsField, noop, { value: true }, { initialValue: permissionNames });
+      unregisterHandlersRef.current.push(registerField(permissionsField, noop, { value: true }, { initialValue: permissionNames }));
     }
   }, [isPermissionsPresent, permissionsField, registerField]);
 

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -100,9 +100,6 @@ class UserEdit extends React.Component {
 
     return {
       ...userFormValues,
-      permissions: {
-        [stripes.okapi.tenant]: resources.permissions?.records,
-      },
       preferredServicePoint: getPreferredServicePoint(),
       proxies: getProxies(),
       sponsors: getSponsors(),

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -66,8 +66,6 @@ class UserEdit extends React.Component {
       getSponsors,
       getPreferredServicePoint,
       getUserServicePoints,
-      resources,
-      stripes,
       match,
     } = this.props;
 


### PR DESCRIPTION
## Purpose
Improvement of https://issues.folio.org/browse/UIU-2805

When tenant permissions are initialized related form field is just changed (via form.change()), but it's not registered and doesn't have an initial value, so it causes form state issues (pristine, dirty, etc.).

![chrome_84yFSSWFp4](https://github.com/folio-org/ui-users/assets/88109087/6608dda7-514a-4f09-b9b9-bdb1ff8a03ef)


## Approach
Register a field in the final form (if it was not registered yet) when tenant permissions were initialized.

![chrome_J8n7lfFuLr](https://github.com/folio-org/ui-users/assets/88109087/1a067dc2-2ac3-4b6c-bfd7-f49ad7849b48)


