### PR TITLE
UIU-2876 Unassigning banner should not be displayed at top of 'Assign / Unassign affiliation' modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Create tests for adding patron/staff info. Fixes UIU-2868.
 * Add/Edit a users permissions for associated affiliation(s). Refs UIU-2805.
 * New permission(s) to view all Users settings in UI. Refs UIU-2784.
+* Unassigning banner should not be displayed at top of "Assign / Unassign affiliation" modal. Refs UIU-2876.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/AffiliationsManager/AffiliationsManagerModal/AffiliationsManagerModal.js
+++ b/src/components/AffiliationsManager/AffiliationsManagerModal/AffiliationsManagerModal.js
@@ -8,7 +8,6 @@ import {
   useCallback,
   useMemo,
   useReducer,
-  useState,
 } from 'react';
 import { FormattedMessage } from 'react-intl';
 
@@ -42,7 +41,6 @@ import css from '../AffiliationsManager.css';
 const INITIAL_FILTERS = {};
 
 const AffiliationManagerModal = ({ onClose, onSubmit, userId }) => {
-  const [isDisplayWarning, setDisplayWarning] = useState(false);
   const [isFiltersVisible, toggleFilters] = useToggle(true);
   const [filters, dispatch] = useReducer(filtersReducer, INITIAL_FILTERS);
 
@@ -71,7 +69,6 @@ const AffiliationManagerModal = ({ onClose, onSubmit, userId }) => {
   } = useAffiliationsAssignment({
     affiliations,
     tenants,
-    onUnassignedCheck: setDisplayWarning,
   });
 
   const isLoading = isConsortiumTenantsLoading || isUsersAffiliationsLoading;
@@ -149,7 +146,6 @@ const AffiliationManagerModal = ({ onClose, onSubmit, userId }) => {
         <AffiliationsManagerResultsPane
           assignment={assignment}
           contentData={contentData}
-          displayWarning={isDisplayWarning}
           isAllAssigned={isAllAssigned}
           isFiltersVisible={isFiltersVisible}
           isLoading={isLoading}

--- a/src/components/AffiliationsManager/AffiliationsManagerResultsPane/AffiliationsManagerResultsPane.js
+++ b/src/components/AffiliationsManager/AffiliationsManagerResultsPane/AffiliationsManagerResultsPane.js
@@ -4,7 +4,6 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   Checkbox,
-  MessageBanner,
   MultiColumnList,
   Pane,
   PaneMenu,
@@ -56,7 +55,6 @@ const AffiliationsManagerResultsPane = ({
   assignment,
   changeSorting,
   contentData,
-  displayWarning,
   isAllAssigned,
   isFiltersVisible,
   isLoading,
@@ -99,12 +97,6 @@ const AffiliationsManagerResultsPane = ({
       paneSub={paneSub}
       firstMenu={firstMenu}
     >
-      <MessageBanner
-        show={displayWarning}
-        type="warning"
-      >
-        <FormattedMessage id="ui-users.affiliations.manager.modal.warning.unassigned" />
-      </MessageBanner>
       <MultiColumnList
         id="user-affiliations-list"
         columnIdPrefix="affiliations-manager"
@@ -126,7 +118,6 @@ AffiliationsManagerResultsPane.propTypes = {
   assignment: PropTypes.object.isRequired,
   changeSorting: PropTypes.func.isRequired,
   contentData: PropTypes.arrayOf(PropTypes.object).isRequired,
-  displayWarning: PropTypes.bool.isRequired,
   isAllAssigned: PropTypes.bool.isRequired,
   isFiltersVisible: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,

--- a/src/components/AffiliationsManager/useAffiliationsAssignment.js
+++ b/src/components/AffiliationsManager/useAffiliationsAssignment.js
@@ -6,7 +6,7 @@ import {
   useState,
 } from 'react';
 
-const useAffiliationsAssignment = ({ affiliations, tenants, onUnassignedCheck }) => {
+const useAffiliationsAssignment = ({ affiliations, tenants }) => {
   const [assignment, setAssignment] = useState({});
 
   useEffect(() => {
@@ -29,19 +29,13 @@ const useAffiliationsAssignment = ({ affiliations, tenants, onUnassignedCheck })
     Object.values(assignment).filter(Boolean).length
   ), [assignment]);
 
-  const checkUnassigned = useCallback((_assignment) => {
-    onUnassignedCheck(affiliations.some(({ tenantId }) => !_assignment[tenantId]));
-  }, [affiliations, onUnassignedCheck]);
-
   const toggle = useCallback(({ id }) => {
     setAssignment(prev => {
       const newAssignment = { ...prev, [id]: !prev[id] };
 
-      checkUnassigned(newAssignment);
-
       return newAssignment;
     });
-  }, [checkUnassigned]);
+  }, []);
 
   const toggleAll = useCallback(() => {
     setAssignment(prev => {
@@ -51,11 +45,9 @@ const useAffiliationsAssignment = ({ affiliations, tenants, onUnassignedCheck })
         return acc;
       }, {});
 
-      checkUnassigned(newAssignment);
-
       return newAssignment;
     });
-  }, [checkUnassigned, isAllAssigned]);
+  }, [isAllAssigned]);
 
   return {
     assignment,

--- a/src/components/AffiliationsManager/useAffiliationsAssignment.test.js
+++ b/src/components/AffiliationsManager/useAffiliationsAssignment.test.js
@@ -1,22 +1,16 @@
 import { act, renderHook } from '@folio/jest-config-stripes/testing-library/react-hooks';
 
-import affiliations from '../../../test/jest/fixtures/affiliations';
+import affiliations from 'fixtures/affiliations';
 import useAffiliationsAssignment from './useAffiliationsAssignment';
 
 const userAffiliations = affiliations.slice(0, 3);
 const tenants = affiliations.map(({ tenantId, tenantName }) => ({ id: tenantId, name: tenantName }));
-const onUnassignedCheck = jest.fn();
 
 describe('useAffiliationsAssignment', () => {
-  beforeEach(() => {
-    onUnassignedCheck.mockClear();
-  });
-
   it('should mark initial user\'s affiliations as assigned', async () => {
     const { result } = renderHook(() => useAffiliationsAssignment({
       affiliations: userAffiliations,
       tenants,
-      onUnassignedCheck,
     }));
 
     expect(result.current.totalAssigned).toEqual(3);
@@ -32,7 +26,6 @@ describe('useAffiliationsAssignment', () => {
     const { result } = renderHook(() => useAffiliationsAssignment({
       affiliations: userAffiliations,
       tenants,
-      onUnassignedCheck,
     }));
 
     act(() => result.current.toggle({ id: affiliations[0].tenantId }));
@@ -52,7 +45,6 @@ describe('useAffiliationsAssignment', () => {
     const { result } = renderHook(() => useAffiliationsAssignment({
       affiliations: userAffiliations,
       tenants,
-      onUnassignedCheck,
     }));
 
     act(() => result.current.toggleAll());
@@ -68,18 +60,5 @@ describe('useAffiliationsAssignment', () => {
     expect(result.current.assignment).toEqual(
       affiliations.reduce((acc, { tenantId }) => ({ ...acc, [tenantId]: false }), {}),
     );
-  });
-
-  it('should check user\'s unassigned affiliations when toggle an affiliation', async () => {
-    const { result } = renderHook(() => useAffiliationsAssignment({
-      affiliations: userAffiliations,
-      tenants,
-      onUnassignedCheck,
-    }));
-
-    act(() => result.current.toggle({ id: affiliations[0].tenantId }));
-    act(() => result.current.toggleAll());
-
-    expect(onUnassignedCheck).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UIU-2876
Remove message banner

## Approach
The initial approach has been changed and user permissions will not be cleared after affiliation unassign. Therefore message banner should be removed from `<AffiliationsManager>`.

<details open><summary>Preview</summary>
<p>

![chrome_hJWO8gQEAK](https://github.com/folio-org/ui-users/assets/88109087/68491cee-082e-45ad-abaa-0094012b7684)

</p>
</details> 