### PR TITLE
UIU-2881: User does not have access to all feefines-related entries in settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Add/Edit a users permissions for associated affiliation(s). Refs UIU-2805.
 * New permission(s) to view all Users settings in UI. Refs UIU-2784.
 * Unassigning banner should not be displayed at top of "Assign / Unassign affiliation" modal. Refs UIU-2876.
+* Add user access to all feefines-related entries in settings if user has "...all feefines-related entries" perm. Refs UIU-2881.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -339,7 +339,9 @@
           "ui-users.settings.refunds.all",
           "ui-users.settings.comments.all",
           "ui-users.settings.transfers.all",
-          "ui-users.settings.transfertypes.all"
+          "ui-users.settings.transfertypes.all",
+          "ui-users.settings.manual-charges.all",
+          "ui-plugin-bursar-export.bursar-exports.all"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
User that has "Settings (Users): Can create, edit and remove all feefines-related entries" permission does not have access to the following fee/fine settings:
- Manual charges
- Transfer criteria

## Approach
In the scope of [this PR](https://github.com/folio-org/ui-users/pull/2459) "ui-users.settings.manual-charges.all" and "ui-plugin-bursar-export.bursar-exports.all" permissions were not added to "ui-users.settings.feefines.all" permission. As a result "Manual charges" and "Transfer criteria" are not visible.

## Refs
[UIU-2881](https://issues.folio.org/browse/UIU-2881)