### PR TITLE
UIU-2880: User doesn't have an access to Limits menu option in Settings->Users menu option with the permission that allows to make changes to patron block limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Add/Edit a users permissions for associated affiliation(s). Refs UIU-2805.
 * New permission(s) to view all Users settings in UI. Refs UIU-2784.
 * Unassigning banner should not be displayed at top of "Assign / Unassign affiliation" modal. Refs UIU-2876.
+* Make Limit menu visible if user has "ui-users.settings.limits.all" permission. Refs UIU-2880.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -667,7 +667,7 @@
         "displayName": "Settings (Users): Can create, edit and remove patron blocks limits",
         "subPermissions": [
           "ui-users.settings.conditions.edit",
-          "ui-users.settings.conditions.view",
+          "ui-users.settings.limits.view",
           "patron-block-limits.item.post",
           "patron-block-limits.item.put",
           "patron-block-limits.item.delete"


### PR DESCRIPTION
## Purpose
User that has "Settings (Users): Can create, edit and remove patron blocks limits" permission does not have access to Limits menu option.

## Approach
I added "ui-users.settings.limits.view" permission to "ui-users.settings.limits.all" permission and as a result Limits menu will be visible because it depends on "ui-users.settings.limits.view" permission.

## Refs
[UIU-2880](https://issues.folio.org/browse/UIU-2880)