### PR TITLE
UIU-2896 Expose `<RenderPermissions>`, `<PermissionSetDetails>` and `<PermissionSetForm>` components for reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * In loan history, older staff notes should NOT be marked as "SUPERSEDED". Fixes UIU-2891.
 * Users with view-only access to user permissions and access to edit user records get error message when saving a user record. Refs UIU-2885.
 * Use new WSAPI for adding patron/staff notes to loans. Fixes UIU-2893. **Note.** The new requirement of the `add-info` interface is a breaking change.
+* Expose `<RenderPermissions>`, `<PermissionSetDetails>` and `<PermissionSetForm>` components for reuse. Refs UIU-2896.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+// app root
+export { default } from './src';
+
+// components
+export { default as RenderPermissions } from './src/components/RenderPermissions';
+export { default as PermissionSetDetails } from './src/settings/permissions/PermissionSetDetails';
+export { default as PermissionSetForm } from './src/settings/permissions/PermissionSetForm';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "main": "src/index.js",
+  "main": "index.js",
   "stripes": {
     "actsAs": [
       "app",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2896

In order to implement consortium-related components, it would be useful not to write all from scratch, but use existing ones.