### PR TITLE
UIU-2895 correct subpermission for adding patron/loan notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * In loan history, older staff notes should NOT be marked as "SUPERSEDED". Fixes UIU-2891.
 * Users with view-only access to user permissions and access to edit user records get error message when saving a user record. Refs UIU-2885.
 * Use new WSAPI for adding patron/staff notes to loans. Fixes UIU-2893. **Note.** The new requirement of the `add-info` interface is a breaking change.
+* Modify add-patron/staff-info permission to use new subpermission. Fixes UIU-2895.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -748,7 +748,7 @@
         "permissionName": "ui-users.loans.add-patron-info",
         "displayName": "Users: User loans: add patron information",
         "subPermissions": [
-          "circulation.loans.item.put"
+          "circulation.loans.add-info.post"
         ],
         "visible": true
       },
@@ -756,7 +756,7 @@
         "permissionName": "ui-users.loans.add-staff-info",
         "displayName": "Users: User loans: add staff information",
         "subPermissions": [
-          "circulation.loans.item.put"
+          "circulation.loans.add-info.post"
         ],
         "visible": true
       },


### PR DESCRIPTION
Since the addition of the `/circulation/loans/{id}/add-info` WSAPI to mod-circulation, we use that to add patron and staff notes instead of doing a PUT to the loan object. As a result, the user-level permissions for adding patron and staff notes no longer require the high-powered `circulation.loans.item.put` subpermission, but do require the permission that guards the new API, `circulation.loans.add-info.post`.

Fixes UIU-2895.
