### PR TITLE
UIU-2897 Move view/assign affiliation from `ui-users` to `ui-consortia-settings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Users with view-only access to user permissions and access to edit user records get error message when saving a user record. Refs UIU-2885.
 * Use new WSAPI for adding patron/staff notes to loans. Fixes UIU-2893. **Note.** The new requirement of the `add-info` interface is a breaking change.
 * Modify add-patron/staff-info permission to use new subpermission. Fixes UIU-2895.
+* Move view/assign affiliation permissions from `ui-users` to `ui-consortia-settings`. Refs UIU-2897.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -109,28 +109,6 @@
         "visible": true
       },
       {
-        "permissionName": "ui-users.consortia.affiliations.view",
-        "displayName": "Users: View affiliations",
-        "description": "View a list of affiliations assigned to an user",
-        "subPermissions": [
-          "consortia.consortium.collection.get",
-          "consortia.user-tenants.collection.get"
-        ],
-        "visible": true
-      },
-      {
-        "permissionName": "ui-users.consortia.affiliations.edit",
-        "displayName": "Users: Assign and unassign affiliations",
-        "description": "Assign and unassign affiliations",
-        "subPermissions": [
-          "ui-users.consortia.affiliations.view",
-          "consortia.tenants.collection.get",
-          "consortia.user-tenants.item.post",
-          "consortia.user-tenants.item.delete"
-        ],
-        "visible": true
-      },
-      {
         "permissionName": "ui-users.opentransactions",
         "displayName": "Users: Can check open transactions",
         "description": "Check if user does have any open transactions",

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -968,8 +968,6 @@
   "filters.status.inactive": "Inactive",
   "permission.accounts": "Fee/Fine History: Can create, edit and remove accounts",
   "permission.create": "Users: Can create new user",
-  "permission.consortia.affiliations.view": "Users: View affiliations",
-  "permission.consortia.affiliations.edit": "Users: Assign and unassign affiliations",
   "permission.edit": "Users: Can edit user profile",
   "permission.editperms": "Users: Can assign and unassign permissions to users",
   "permission.editproxies": "Users: Can create, edit and remove proxies",


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UIU-2897

"View" and "Assign" affiliations permissions should be stored in `ui-consortia-settings` and available to assign only in the central tenant of a consortium.