### PR TITLE
UIU-2914 Prevent editing of shared settings from outside "Consortium manager"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Update translations text for permission.settings.manual-charges.all. Fixes UIU-2908.
 * Rename user setting permissions disaplay name and update their visibility. Refs UIU-2907.
 * Cleanup User Settings permissions – Part 1. Refs UIU-2906
+* Prevent editing of shared settings from outside "Consortium manager". Refs UIU-2914.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -334,3 +334,7 @@ export const CONFIGURATIONS_ENTRIES_API = `${CONFIGURATIONS_API}/entries`;
 export const CONSORTIA_API = 'consortia';
 export const CONSORTIA_TENANTS_API = 'tenants';
 export const CONSORTIA_USER_TENANTS_API = 'user-tenants';
+
+export const RECORD_SOURCE = {
+  CONSORTIUM: 'consortium',
+};

--- a/src/settings/DepartmentsSettings.js
+++ b/src/settings/DepartmentsSettings.js
@@ -7,6 +7,9 @@ import {
 import { NoValue } from '@folio/stripes/components';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { useStripes } from '@folio/stripes/core';
+import { getSourceSuppressor } from '@folio/stripes/util';
+
+import { RECORD_SOURCE } from '../constants';
 
 
 const validate = (item, index, items) => {
@@ -30,6 +33,8 @@ const validate = (item, index, items) => {
 
   return errors;
 };
+
+const suppress = getSourceSuppressor(RECORD_SOURCE.CONSORTIUM);
 
 const DepartmentsSettings = () => {
   const { formatMessage } = useIntl();
@@ -61,8 +66,8 @@ const DepartmentsSettings = () => {
       }}
       validate={validate}
       actionSuppressor={{
-        delete: item => !hasDeletePerm || item.usageNumber,
-        edit: () => !hasEditPerm,
+        delete: item => !hasDeletePerm || item.usageNumber || suppress(item),
+        edit: (item) => !hasEditPerm || suppress(item),
       }}
     />
   );

--- a/src/settings/PatronGroupsSettings.js
+++ b/src/settings/PatronGroupsSettings.js
@@ -6,6 +6,12 @@ import {
 } from 'react-intl';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { withStripes } from '@folio/stripes/core';
+import { getSourceSuppressor } from '@folio/stripes/util';
+
+import { RECORD_SOURCE } from '../constants';
+
+const suppress = getSourceSuppressor(RECORD_SOURCE.CONSORTIUM);
+const actionSuppressor = { delete: suppress, edit: suppress };
 
 class PatronGroupsSettings extends React.Component {
   static propTypes = {
@@ -55,6 +61,7 @@ class PatronGroupsSettings extends React.Component {
         label={intl.formatMessage({ id: 'ui-users.information.patronGroups' })}
         labelSingular={intl.formatMessage({ id: 'ui-users.information.patronGroup' })}
         objectLabel={<FormattedMessage id="ui-users.information.patronGroup.users" />}
+        actionSuppressor={actionSuppressor}
         visibleFields={['group', 'desc', 'expirationOffsetInDays']}
         hiddenFields={['numberOfObjects']}
         columnMapping={{

--- a/test/jest/__mock__/stripesUtils.mock.js
+++ b/test/jest/__mock__/stripesUtils.mock.js
@@ -2,4 +2,5 @@ import React from 'react';
 
 jest.mock('@folio/stripes/util', () => ({
   exportCsv: jest.fn(),
+  getSourceSuppressor: jest.fn(() => () => false),
 }));


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/UIU-2914

Prevent editing or deleting controlled vocabulary settings with the "consortium" source.

**Note**: applied for the settings from the [list](https://wiki.folio.org/display/FOLIJET/Consortium+manager+settings)