### PR TITLE
UIU-2591: Add info about reminder fees to loan details screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Cleanup User Settings permissions – Part 1. Refs UIU-2906
 * Prevent editing of shared settings from outside "Consortium manager". Refs UIU-2914.
 * User settings > Fee/fine section: Disable editing for users with "Setting (Users): View all settings" permission. Refs UIU-2904.
+* Add info about reminder fees to loan details screen. Refs UIU-2591.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/util/getLoanLastReminderNumber.js
+++ b/src/components/util/getLoanLastReminderNumber.js
@@ -1,0 +1,26 @@
+import { FormattedMessage } from 'react-intl';
+
+/**
+ * getLoanLastReminderNumber
+ * Return a JSX containing info about the last reminder fee based on:
+ * https://github.com/folio-org/mod-circulation-storage/blob/cef90bb4e12739276ad5b7f36bd05932b05375ec/ramls/loan.json#L141
+ *
+ * @param object loan object
+ *
+ * @return JSX containing info about the last reminder fee if reminders are present
+ * or null otherwise;
+ */
+export default function getLoanLastReminderNumber(loan) {
+  const lastReminderNumber = loan?.reminders?.lastFeeBilled?.number;
+
+  if (!lastReminderNumber) {
+    return null;
+  }
+
+  return (
+    <>
+      <br />
+      (<FormattedMessage id="ui-users.loans.lastReminderNumber" values={{ count: lastReminderNumber }} />)
+    </>
+  );
+}

--- a/src/components/util/getLoanLastReminderNumber.test.js
+++ b/src/components/util/getLoanLastReminderNumber.test.js
@@ -1,0 +1,28 @@
+import { FormattedMessage } from 'react-intl';
+import getLoanLastReminderNumber from './getLoanLastReminderNumber';
+
+describe('getLoanLastReminderNumber', () => {
+  it('should return null if lastReminderNumber is not present', () => {
+    const loan = {};
+    const result = getLoanLastReminderNumber(loan);
+    expect(result).toBeNull();
+  });
+
+  it('should return JSX containing info about the last reminder fee if lastReminderNumber is present', () => {
+    const loan = {
+      reminders: {
+        lastFeeBilled: {
+          number: 2,
+        },
+      },
+    };
+    const result = getLoanLastReminderNumber(loan);
+    const expected = (
+      <>
+        <br />
+        (<FormattedMessage id="ui-users.loans.lastReminderNumber" values={{ count: 2 }} />)
+      </>
+    );
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/components/util/getLoanLastReminderNumber.test.js
+++ b/src/components/util/getLoanLastReminderNumber.test.js
@@ -3,8 +3,7 @@ import getLoanLastReminderNumber from './getLoanLastReminderNumber';
 
 describe('getLoanLastReminderNumber', () => {
   it('should return null if lastReminderNumber is not present', () => {
-    const loan = {};
-    const result = getLoanLastReminderNumber(loan);
+    const result = getLoanLastReminderNumber({});
     expect(result).toBeNull();
   });
 

--- a/src/components/util/index.js
+++ b/src/components/util/index.js
@@ -4,3 +4,4 @@ export * from './util';
 export { default as getRenewalPatronBlocksFromPatronBlocks } from './patronBlocks';
 export { nav };
 export { default as isRefundAllowed } from './isRefundAllowed';
+export { default as getLoanLastReminderNumber } from './getLoanLastReminderNumber';

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -37,6 +37,7 @@ import PatronBlockModalWithOverrideModal from '../../components/PatronBlock/Patr
 import {
   getFullName,
   nav,
+  getLoanLastReminderNumber,
   getOpenRequestsPath,
   getRenewalPatronBlocksFromPatronBlocks,
   accountsMatchStatus,
@@ -202,7 +203,7 @@ class LoanDetails extends React.Component {
   }
 
   viewFeeFine() {
-    const { stripes, loanAccountActions } = this.props;
+    const { stripes, loanAccountActions, loan } = this.props;
     const total = loanAccountActions.reduce((acc, { amount }) => (acc + parseFloat(amount)), 0);
     const suspendedAction = loanAccountActions.filter(a => a?.paymentStatus?.name === refundClaimReturned.PAYMENT_STATUS) || [];
     const suspendedMessage = (suspendedAction.length > 0) ? <FormattedMessage id="ui-users.accounts.suspended" /> : '';
@@ -223,7 +224,14 @@ class LoanDetails extends React.Component {
       :
       value;
 
-    return <>{ valueDisplay }<br />{ suspendedMessage }</>;
+    return (
+      <>
+        {valueDisplay}
+        {getLoanLastReminderNumber(loan)}
+        <br />
+        {suspendedMessage}
+      </>
+    );
   }
 
   feefinedetails = (e) => {

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -123,6 +123,7 @@
   "loans.action.source.system": "System",
   "loans.rows.select": "Select loan",
   "loans.selectAllLoans": "Select all loans",
+  "loans.lastReminderNumber": "{count, number} {count, plural, one {reminder fee} other {reminder fees}} billed",
   "settings.label": "Users",
   "settings.general": "General",
   "settings.feefine": "Fee/fine",


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2591

Display the number of reminder fees the patron has already been billed for.

![reminders](https://github.com/folio-org/ui-users/assets/63545/196c63bc-8505-4f7b-b7a8-0a32098f8939)
