### PR TITLE
UIU-2590: Add info about reminder fees to loan history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Prevent editing of shared settings from outside "Consortium manager". Refs UIU-2914.
 * User settings > Fee/fine section: Disable editing for users with "Setting (Users): View all settings" permission. Refs UIU-2904.
 * Add info about reminder fees to loan details screen. Refs UIU-2591.
+* Add info about reminder fees to loan history. Refs UIU-2590.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.js
@@ -13,6 +13,9 @@ import {
 import { stripesShape } from '@folio/stripes/core';
 import { NoValue } from '@folio/stripes/components';
 
+import {
+  getLoanLastReminderNumber,
+} from '../../../../util';
 import OpenLoans from '../../OpenLoans';
 import Modals from '../Modals/Modals';
 import OpenLoansSubHeader from '../OpenLoansSubHeader/OpenLoansSubHeader';
@@ -184,6 +187,7 @@ class OpenLoansWithStaticData extends React.Component {
     const { resources } = this.props;
     const accounts = get(resources, ['loanAccount', 'records'], []);
     const accountsLoan = accounts.filter(a => a.loanId === loan.id) || [];
+
     const suspendedStatus = accountsLoan.filter(a => a?.paymentStatus?.name === refundClaimReturned.PAYMENT_STATUS) || [];
     let amount = 0;
 
@@ -198,7 +202,10 @@ class OpenLoansWithStaticData extends React.Component {
     return (suspendedStatus.length > 0) ?
       <FormattedMessage id="ui-users.loans.details.accounts.suspended" values={{ amount }} />
       :
-      amount;
+      <>
+        {amount}
+        {getLoanLastReminderNumber(loan)}
+      </>;
   };
 
   getContributorslist = (loan) => {

--- a/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.test.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansWithStaticData/OpenLoansWithStaticData.test.js
@@ -101,8 +101,8 @@ const props = {
   visibleColumns: [{
     status: true,
     title: 'Contributors'
-  }],
-  possibleColumns: [],
+  }, { title: 'feefineIncurred', status: true }],
+  possibleColumns: ['feefineIncurred', 'Contributors'],
   resources: {
     activeRecord: { user: 'ab579dc3-219b-4f5b-8068-ab1c7a55c402' },
     loanAccount: { records: [] },
@@ -169,5 +169,34 @@ describe('OpenLoansWithStatic Data component', () => {
     userEvent.click(document.querySelector('[id="columnsDropdown"]'));
     userEvent.click(document.querySelector('[id="ui-users.loans.columns.contributors"]'));
     expect(mockToggleColumn).toHaveBeenCalled();
+  });
+
+  it('should show fees with reminder for given loan', async () => {
+    const resources = {
+      loanAccount: {
+        records: [{
+          loanId: '40f5e9d9-38ac-458e-ade7-7795bd821652',
+          amount: '50',
+          paymentStatus: { name: 'Payment Name' },
+        }],
+      },
+    };
+
+    const { container } = renderOpenLoansWithStaticData({
+      ...props,
+      resources,
+      loans: [{
+        ...loans[0],
+        id: '40f5e9d9-38ac-458e-ade7-7795bd821652',
+        reminders: {
+          lastFeeBilled: {
+            number: 2
+          }
+        }
+      }],
+    });
+
+    expect(container).toHaveTextContent('50.00');
+    expect(container).toHaveTextContent('ui-users.loans.lastReminderNumber');
   });
 });


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2590

Add info about reminder fees to loan history

![reminder](https://github.com/folio-org/ui-users/assets/63545/59062a47-0767-4351-8fec-f4e0e0be9db8)

This is the continuation of the work from https://github.com/folio-org/ui-users/pull/2510
