### PR TITLE
UIU-2913 - Restrict edit of Patron Block Templates in settings based on permissions check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * Add info about reminder fees to loan details screen. Refs UIU-2591.
 * Add info about reminder fees to loan history. Refs UIU-2590.
 * Replace `word-wrap` (unmaintained) with `@aashutoshrathi/word-wrap`, a fork, to mitigate CVE-2023-26115.
+* Restrict edit of Patron Block Templates in settings based on permissions check. UIU-2913.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/settings/patronBlocks/BlockTemplates/BlockTemplates.js
+++ b/src/settings/patronBlocks/BlockTemplates/BlockTemplates.js
@@ -24,7 +24,10 @@ function BlockTemplates(props) {
     intl: { formatMessage },
     mutator,
     resources: { manualBlockTemplates },
+    stripes,
   } = props;
+
+  const editable = stripes.hasPerm('ui-users.settings.patron-block-templates.all');
 
   return (
     <EntryManager
@@ -47,6 +50,7 @@ function BlockTemplates(props) {
         post: 'manual-block-templates.item.post',
         delete: 'manual-block-templates.item.delete',
       }}
+      editable={editable}
     />
   );
 }
@@ -78,6 +82,9 @@ BlockTemplates.propTypes = {
       DELETE: PropTypes.func,
     }).isRequired,
   }).isRequired,
+  stripes: PropTypes.shape({
+    hasPerm: PropTypes.func,
+  }),
 };
 
 export default injectIntl(stripesConnect(BlockTemplates));

--- a/src/settings/patronBlocks/BlockTemplates/BlockTemplates.test.js
+++ b/src/settings/patronBlocks/BlockTemplates/BlockTemplates.test.js
@@ -51,6 +51,9 @@ describe('BlockTemplates component', () => {
       resources,
       mutator,
       intl: {},
+      stripes: {
+        hasPerm: jest.fn(() => true),
+      }
     };
     renderBlockTemplates(props);
     expect(screen.getByText('circ-admin')).toBeTruthy();


### PR DESCRIPTION
## Purpose
User settings > Templates: Disable editing for users with "Setting (Users): View all settings" permission

## Refs
https://issues.folio.org/browse/UIU-2913