### PR TITLE
UIU-2912 - add permissions check to edit patron block limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * Add info about reminder fees to loan history. Refs UIU-2590.
 * Replace `word-wrap` (unmaintained) with `@aashutoshrathi/word-wrap`, a fork, to mitigate CVE-2023-26115.
 * Convert primary search listing to use prev/next pagination vs load-more pagination. Refs UIU-2870.
+* Add permissions check to edit Limits in user settings. Refs. UIU-2912
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/settings/patronBlocks/Limits/Limits.js
+++ b/src/settings/patronBlocks/Limits/Limits.js
@@ -59,6 +59,9 @@ class Limits extends Component {
     ).isRequired,
     patronGroupId: PropTypes.string.isRequired,
     patronGroup: PropTypes.string.isRequired,
+    stripes: PropTypes.shape({
+      hasPerm: PropTypes.func,
+    }).isRequired,
   }
 
   constructor(props) {
@@ -234,8 +237,10 @@ class Limits extends Component {
       patronGroup,
       patronGroupId,
       patronBlockConditions,
+      stripes,
     } = this.props;
 
+    const canEditConditions = stripes.hasPerm('ui-users.settings.limits.all');
     if (!this._isMounted) return null;
 
     return (
@@ -250,6 +255,7 @@ class Limits extends Component {
             patronBlockConditions={patronBlockConditions}
             initialValues={this.getInitialValues()}
             onSubmit={this.onSubmit}
+            canEditConditions={canEditConditions}
           />
 
           <Callout ref={this.callout} />

--- a/src/settings/patronBlocks/Limits/LimitsForm.js
+++ b/src/settings/patronBlocks/Limits/LimitsForm.js
@@ -78,6 +78,7 @@ class LimitsForm extends Component {
     pristine: PropTypes.bool.isRequired,
     submitting: PropTypes.bool.isRequired,
     handleSubmit: PropTypes.func.isRequired,
+    canEditConditions: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -85,7 +86,7 @@ class LimitsForm extends Component {
   }
 
   renderConditions = () => {
-    const { patronBlockConditions } = this.props;
+    const { patronBlockConditions, canEditConditions } = this.props;
 
     return (
       map(patronBlockConditions, ({ name: condition, id }) => {
@@ -111,6 +112,7 @@ class LimitsForm extends Component {
                   type="number"
                   name={id}
                   validate={id === feeFineBalanceId ? feeFineLimitsValidation : limitsValidation}
+                  disabled={!canEditConditions}
                 />
               </Col>
             </Row>

--- a/src/settings/patronBlocks/Limits/LimitsForm.test.js
+++ b/src/settings/patronBlocks/Limits/LimitsForm.test.js
@@ -60,11 +60,12 @@ const propData = {
     getState: getStateMock,
   },
   handleSubmit: handleSubmitMock,
+  canEditConditions: true,
 };
 
 const renderLimitsForm = async (props) => renderWithRouter(<LimitsForm {...props} />);
 
-describe('Conditions Form Component', () => {
+describe('Limits Form Component', () => {
   beforeEach(async () => {
     await waitFor(() => renderLimitsForm(propData));
   });
@@ -78,5 +79,27 @@ describe('Conditions Form Component', () => {
   it('handle Submit in conditions form', async () => {
     userEvent.click(screen.getByText('stripes-core.button.save'));
     expect(handleSubmitMock).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('When canEditConditions prop is false', () => {
+  beforeEach(async () => {
+    const alteredPropData = {
+      ...propData,
+      canEditConditions: false,
+    };
+    await waitFor(() => renderLimitsForm(alteredPropData));
+  });
+
+  it('component must be rendered', async () => {
+    expect(screen.getByText('Maximum number of items charged out')).toBeInTheDocument();
+  });
+
+  it('should disable conditions on each limit', () => {
+    const fields = screen.getAllByRole('spinbutton');
+
+    fields.forEach(fld => {
+      expect(fld).toBeDisabled();
+    });
   });
 });


### PR DESCRIPTION
## Purpose
User settings > Limits: Disable editing for users with "Setting (Users): View all settings"

## Screenshots
when logged in user has view all user settings permissions.
![image](https://github.com/folio-org/ui-users/assets/104053200/b3bbc256-8393-4953-ab95-29614f1d5f3f)

![image](https://github.com/folio-org/ui-users/assets/104053200/d21ff41c-eb07-43fe-90dc-af05130a13ef)

when logged in with diku

![image](https://github.com/folio-org/ui-users/assets/104053200/5ef08f9b-f419-4483-a115-348b47f9c7bf)

## Refs
https://issues.folio.org/browse/UIU-2912