### PR TITLE
UIU-2920: Requests accordion is not shown on the User's details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * Add permissions check to edit Limits in user settings. Refs. UIU-2912.
 * User settings > Comment required: Disable editing for users with "Setting (Users): View all settings" permission. Refs UIU-2905.
 * Display assigned users accordion on Permission set. Refs UIU-2872.
+* Add support for `request-storage` version `6.0` for `<UserRequests>`. Refs UIU-2920.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -798,7 +798,7 @@ class UserDetail extends React.Component {
                 </IfPermission>
 
                 <IfPermission perm="ui-users.requests.all">
-                  <IfInterface name="request-storage" version="2.5 3.0 4.0 5.0">
+                  <IfInterface name="request-storage" version="2.5 3.0 4.0 5.0 6.0">
                     <IfInterface name="circulation">
                       <UserRequests
                         expanded={sections.requestsSection}


### PR DESCRIPTION
## Purpose
Add support for `request-storage` version `6.0` to be able to see the "Requests" accordion on a user details page.

## Refs
[UIU-2920](https://issues.folio.org/browse/UIU-2920)