### PR TITLE
Add permisison checks to restrict edit on Manual charges settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * Add permissions check to edit Limits in user settings. Refs. UIU-2912.
 * User settings > Comment required: Disable editing for users with "Setting (Users): View all settings" permission. Refs UIU-2905.
 * Display assigned users accordion on Permission set. Refs UIU-2872.
+* Add permisison checks to restrict edit on Manual charges settings page. Ref. UIU-2903.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -72,6 +72,7 @@ class FeeFineSettings extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
+      hasPerm: PropTypes.func.isRequired,
     }).isRequired,
     resources: PropTypes.object,
     mutator: PropTypes.shape({
@@ -253,10 +254,14 @@ class FeeFineSettings extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage } } = this.props;
+    const { intl: { formatMessage }, stripes } = this.props;
     const { owners, templates, ownerId } = this.state;
     const filterOwners = this.getOwners();
     const label = formatMessage({ id: 'ui-users.feefines.singular' });
+    const hasEditPerm = stripes.hasPerm('feefines.item.put');
+    const hasDeletePerm = stripes.hasPerm('feefines.item.delete');
+    const hasCreatePerm = stripes.hasPerm('feefines.item.post');
+    const hasEditOwnerPerm = stripes.hasPerm('owners.item.put');
 
     let templateCharge = templates.filter(t => t.category === 'FeeFineCharge') || [];
     templateCharge = [{}, ...templateCharge.map((t) => ({ value: t.id, label: t.name }))];
@@ -310,6 +315,7 @@ class FeeFineSettings extends React.Component {
           templateCharge={templateCharge}
           templateAction={templateAction}
           onSubmit={this.onUpdateOwner}
+          hasEditOwnerPerm={hasEditOwnerPerm}
         />
         <CopyModal
           {...this.props}
@@ -343,6 +349,11 @@ class FeeFineSettings extends React.Component {
         visibleFields={['feeFineType', 'defaultAmount', 'chargeNoticeId', 'actionNoticeId']}
         formType="final-form"
         shouldReinitialize
+        canCreate={hasCreatePerm}
+        actionSuppressor={{
+          delete: item => !hasDeletePerm,
+          edit: (item) => !hasEditPerm,
+        }}
       />
     );
   }

--- a/src/settings/FeeFineSettings.js
+++ b/src/settings/FeeFineSettings.js
@@ -351,8 +351,8 @@ class FeeFineSettings extends React.Component {
         shouldReinitialize
         canCreate={hasCreatePerm}
         actionSuppressor={{
-          delete: item => !hasDeletePerm,
-          edit: (item) => !hasEditPerm,
+          delete: () => !hasDeletePerm,
+          edit: () => !hasEditPerm,
         }}
       />
     );

--- a/src/settings/FeeFineSettings.test.js
+++ b/src/settings/FeeFineSettings.test.js
@@ -203,7 +203,7 @@ const propData = {
 
 const renderFeeFineSettings = async (props) => renderWithRouter(<FeeFineSettings {...props} />);
 
-describe('Payment settings', () => {
+describe('FeeFine settings', () => {
   beforeEach(async () => {
     await waitFor(() => renderFeeFineSettings(propData));
   });

--- a/src/settings/FeeFinesTable/ChargeNotice.js
+++ b/src/settings/FeeFinesTable/ChargeNotice.js
@@ -126,6 +126,7 @@ class ChargeNotice extends React.Component {
           <Col xs={4}>
             <Button
               id="charge-notice-primary"
+              data-testid="chargeNotice"
               onClick={buttonAction}
               disabled={!hasEditOwnerPerm}
             >{buttonLabel}

--- a/src/settings/FeeFinesTable/ChargeNotice.js
+++ b/src/settings/FeeFinesTable/ChargeNotice.js
@@ -44,6 +44,7 @@ class ChargeNotice extends React.Component {
     templateAction: PropTypes.arrayOf(PropTypes.object),
     templates: PropTypes.arrayOf(PropTypes.object),
     form: PropTypes.object,
+    hasEditOwnerPerm: PropTypes.bool,
   };
 
   constructor(props) {
@@ -84,6 +85,7 @@ class ChargeNotice extends React.Component {
       owner,
       templates,
       handleSubmit,
+      hasEditOwnerPerm,
     } = this.props;
 
     const buttonLabel = (edit) ? <FormattedMessage id="ui-users.comment.save" /> : <FormattedMessage id="ui-users.edit" />;
@@ -122,7 +124,12 @@ class ChargeNotice extends React.Component {
             />
           </Col>
           <Col xs={4}>
-            <Button id="charge-notice-primary" onClick={buttonAction}>{buttonLabel}</Button>
+            <Button
+              id="charge-notice-primary"
+              onClick={buttonAction}
+              disabled={!hasEditOwnerPerm}
+            >{buttonLabel}
+            </Button>
             {edit &&
               <Button id="charge-notice-cancel" onClick={this.onCancel}><FormattedMessage id="ui-users.cancel" /></Button>
             }

--- a/src/settings/FeeFinesTable/ChargeNotice.test.js
+++ b/src/settings/FeeFinesTable/ChargeNotice.test.js
@@ -14,6 +14,7 @@ const props = {
   templates: [{ id: '1', name: 'template1' }, { id: '2', name: 'template2' }],
   form: { initialize: jest.fn() },
   onSubmit: jest.fn(),
+  hasEditOwnerPerm: true,
 };
 
 const renderChargeNotice = () => renderWithRouter(<ChargeNotice {...props} />);

--- a/src/settings/FeeFinesTable/ChargeNotice.test.js
+++ b/src/settings/FeeFinesTable/ChargeNotice.test.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import ChargeNotice from './ChargeNotice';
 
 jest.unmock('@folio/stripes/components');
 
-const props = {
+const cNprops = {
   owner: { defaultChargeNoticeId: '1', defaultActionNoticeId: '2' },
   handleSubmit: jest.fn(),
   templateCharge: [{ id: '1', name: 'template1' }],
@@ -17,21 +18,21 @@ const props = {
   hasEditOwnerPerm: true,
 };
 
-const renderChargeNotice = () => renderWithRouter(<ChargeNotice {...props} />);
+const renderChargeNotice = (props) => renderWithRouter(<ChargeNotice {...props} />);
 
 describe('ChargeNotice', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
   it('render Item component with the correct props', () => {
-    const { getByText } = renderChargeNotice();
+    const { getByText } = renderChargeNotice(cNprops);
     expect(getByText('ui-users.feefines.defaultChargeNotice')).toBeInTheDocument();
     expect(getByText('ui-users.feefines.defaultActionNotice')).toBeInTheDocument();
     expect(getByText('template1')).toBeInTheDocument();
     expect(getByText('template2')).toBeInTheDocument();
   });
   it('set edit state when button is clicked and click cancel button', () => {
-    const { getByText } = renderChargeNotice();
+    const { getByText } = renderChargeNotice(cNprops);
     const editButton = getByText('ui-users.edit');
     userEvent.click(editButton);
     const cancelButton = getByText('ui-users.cancel');
@@ -39,11 +40,22 @@ describe('ChargeNotice', () => {
     userEvent.click(cancelButton);
   });
   it('set edit state when button is clicked and click save button', () => {
-    const { getByText } = renderChargeNotice();
+    const { getByText } = renderChargeNotice(cNprops);
     const editButton = getByText('ui-users.edit');
     userEvent.click(editButton);
     const saveButton = getByText('ui-users.comment.save');
     expect(saveButton).toBeInTheDocument();
     userEvent.click(saveButton);
   });
+  describe('when hasEditOwnerPerm prop is false', () => {
+    it('should have edit button disabled', () => {
+      const alteredCNProps = {
+        ...cNprops,
+        hasEditOwnerPerm: false,
+      };
+      renderChargeNotice(alteredCNProps);
+      expect(screen.getByTestId('chargeNotice')).toBeDisabled();
+    });
+  });
 });
+


### PR DESCRIPTION
## Purpose
User settings > Manual Charges: Disable editing for users with "Setting (Users): View all settings" permission

## Screenshots
Behavior on Manual charges settings page when logged in user have view only permission.
![chrome_qmzudoTDBq](https://github.com/folio-org/ui-users/assets/104053200/eb9abf47-4b42-48a2-a260-e71d03fc759a)

Behavior on Manual charges settings page when logged in diku user.
![k0dyITG8Wt](https://github.com/folio-org/ui-users/assets/104053200/e4153bc4-9862-4f02-9ac7-248af6c03fc9)


## Refs
https://issues.folio.org/browse/UIU-2903