### PR TITLE
UIU-2919 - Clean up setting.transfertypes permissions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * User settings > Comment required: Disable editing for users with "Setting (Users): View all settings" permission. Refs UIU-2905.
 * Display assigned users accordion on Permission set. Refs UIU-2872.
 * Add support for `request-storage` version `6.0` for `<UserRequests>`. Refs UIU-2920.
+* Clean up setting.transfertypes permissions. Refs UIU-2919.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -299,8 +299,7 @@
           "ui-users.settings.payments.view",
           "ui-users.settings.refunds.view",
           "ui-users.settings.comments.view",
-          "ui-users.settings.transfers.view",
-          "ui-users.settings.transfertypes.view"
+          "ui-users.settings.transfers.view"
         ],
         "visible": true
       },
@@ -316,7 +315,6 @@
           "ui-users.settings.refunds.all",
           "ui-users.settings.comments.all",
           "ui-users.settings.transfers.all",
-          "ui-users.settings.transfertypes.all",
           "ui-users.settings.manual-charges.all",
           "ui-plugin-bursar-export.bursar-exports.all"
         ],
@@ -518,27 +516,6 @@
           "transfers.item.delete",
           "transfers.item.post",
           "transfers.item.put"
-        ],
-        "visible": true
-      },
-      {
-        "permissionName": "ui-users.settings.transfertypes.view",
-        "displayName": "Settings (Users): Can view transfer criteria",
-        "subPermissions": [
-          "transfer-criterias.collection.get",
-          "transfer-criterias.item.get",
-          "settings.users.enabled"
-        ],
-        "visible": false
-      },
-      {
-        "permissionName": "ui-users.settings.transfertypes.all",
-        "displayName": "Settings (Users): Can create, edit and remove transfer criteria",
-        "subPermissions": [
-          "ui-users.settings.transfertypes.view",
-          "transfer-criterias.item.delete",
-          "transfer-criterias.item.post",
-          "transfer-criterias.item.put"
         ],
         "visible": true
       },

--- a/translations/ui-users/en_US.json
+++ b/translations/ui-users/en_US.json
@@ -1110,8 +1110,6 @@
     "permission.settings.refunds.all": "Settings (Users): Can create, edit and remove refund reasons",
     "permission.settings.transfers.view": "Settings (Users): Can view transfer accounts ",
     "permission.settings.transfers.all": "Settings (Users): Can create, edit and remove transfer accounts ",
-    "permission.settings.transfertypes.view": "Settings (Users): Can view transfer criteria",
-    "permission.settings.transfertypes.all": "Settings (Users): Can create, edit and remove transfer criteria",
     "permission.settings.usergroups.view": "Settings (Users): Can view patron groups",
     "permission.settings.usergroups.all": "Settings (Users): Can create, edit and remove patron groups",
     "permission.settings.waives.view": "Settings (Users): Can view waive reasons",


### PR DESCRIPTION
## Purpose
Clean up setting.transfertypes permissions

## Approach
Removed unused permissions

## Ref
https://issues.folio.org/browse/UIU-2919