### PR TITLE
UIU-2910 - Add permission check to restrict edit of transfer account page on user settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * User settings > Comment required: Disable editing for users with "Setting (Users): View all settings" permission. Refs UIU-2905.
 * Display assigned users accordion on Permission set. Refs UIU-2872.
 * Add support for `request-storage` version `6.0` for `<UserRequests>`. Refs UIU-2920.
+* Add permission check to restrict edit of transfer account page on user settings. Refs UIU-2910.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/settings/CommentRequiredSettings.test.js
+++ b/src/settings/CommentRequiredSettings.test.js
@@ -7,7 +7,7 @@ import CommentRequiredSettings from './CommentRequiredSettings';
 jest.unmock('@folio/stripes/components');
 const mockPUT = jest.fn();
 const mockPOST = jest.fn();
-const props = {
+const defaultProps = {
   mutator: {
     record: {
       update: jest.fn()
@@ -39,11 +39,11 @@ const props = {
 const renderCommentRequiredSettings = (props) => renderWithRouter(<CommentRequiredSettings {...props} />);
 describe('CommentRequiredSettings', () => {
   it('Component should render correctly', () => {
-    renderCommentRequiredSettings(props);
+    renderCommentRequiredSettings(defaultProps);
     expect(screen.getByText('ui-users.comment.title')).toBeInTheDocument();
   });
   it('PUT function to called on clicking save button', async () => {
-    renderCommentRequiredSettings(props);
+    renderCommentRequiredSettings(defaultProps);
     userEvent.selectOptions(screen.getByRole('combobox', { name: 'ui-users.comment.transferred' }), 'ui-users.no');
     userEvent.click(screen.getByRole('button', { name: 'ui-users.comment.save' }));
     await waitFor(() => {
@@ -52,43 +52,43 @@ describe('CommentRequiredSettings', () => {
   });
   it('should render component properly when GET call do not respond with any records', () => {
     const alteredProps = {
-      ...props,
+      ...defaultProps,
       mutator: {
-        ...props.mutator,
+        ...defaultProps.mutator,
         commentRequired: {
-          ...props.mutator.commentRequired,
+          ...defaultProps.mutator.commentRequired,
           GET: jest.fn().mockResolvedValue([])
         }
       },
       resources: {
-        ...props.resources,
+        ...defaultProps.resources,
         commentRequired: {
-          ...props.resources.commentRequired,
+          ...defaultProps.resources.commentRequired,
           records: []
         }
       }
-    }
+    };
     renderCommentRequiredSettings(alteredProps);
     expect(screen.getByText('ui-users.comment.title')).toBeInTheDocument();
   });
   it('should make POST call when length of records is 0', async () => {
     const alteredProps = {
-      ...props,
+      ...defaultProps,
       mutator: {
-        ...props.mutator,
+        ...defaultProps.mutator,
         commentRequired: {
-          ...props.mutator.commentRequired,
+          ...defaultProps.mutator.commentRequired,
           GET: jest.fn().mockResolvedValue([])
         }
       },
       resources: {
-        ...props.resources,
+        ...defaultProps.resources,
         commentRequired: {
-          ...props.resources.commentRequired,
+          ...defaultProps.resources.commentRequired,
           records: []
         }
       }
-    }
+    };
     renderCommentRequiredSettings(alteredProps);
     await waitFor(() => {
       expect(mockPOST).toHaveBeenCalled();

--- a/src/settings/TransferAccountsSettings.js
+++ b/src/settings/TransferAccountsSettings.js
@@ -37,6 +37,7 @@ class TransferAccountsSettings extends React.Component {
   static propTypes = {
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
+      hasPerm: PropTypes.func.isRequired,
     }).isRequired,
     intl: PropTypes.object.isRequired,
     mutator: PropTypes.shape({
@@ -73,7 +74,7 @@ class TransferAccountsSettings extends React.Component {
   }
 
   render() {
-    const { intl: { formatMessage } } = this.props;
+    const { intl: { formatMessage }, stripes } = this.props;
     const {
       ownerId,
       owners
@@ -84,6 +85,10 @@ class TransferAccountsSettings extends React.Component {
       item.ownerId = ownerId;
       return item;
     };
+
+    const hasCreatePerm = stripes.hasPerm('transfers.item.post');
+    const hasEditPerm = stripes.hasPerm('transfers.item.put');
+    const hasDeletePerm = stripes.hasPerm('transfers.item.delete');
 
     return (
       <this.connectedControlledVocab
@@ -103,6 +108,11 @@ class TransferAccountsSettings extends React.Component {
         sortby="accountName"
         validate={(item, index, items) => validate(item, index, items, 'accountName', label)}
         visibleFields={['accountName', 'desc']}
+        canCreate={hasCreatePerm}
+        actionSuppressor={{
+          edit: _=> !hasEditPerm,
+          delete: _=> !hasDeletePerm,
+        }}
       />
     );
   }

--- a/src/settings/TransferAccountsSettings.js
+++ b/src/settings/TransferAccountsSettings.js
@@ -110,8 +110,8 @@ class TransferAccountsSettings extends React.Component {
         visibleFields={['accountName', 'desc']}
         canCreate={hasCreatePerm}
         actionSuppressor={{
-          edit: _=> !hasEditPerm,
-          delete: _=> !hasDeletePerm,
+          edit: _ => !hasEditPerm,
+          delete: _ => !hasDeletePerm,
         }}
       />
     );

--- a/src/settings/TransferAccountsSettings.test.js
+++ b/src/settings/TransferAccountsSettings.test.js
@@ -43,6 +43,10 @@ const defaultProps = {
       GET: jest.fn().mockResolvedValue([]),
     },
   },
+  stripes: {
+    connect: jest.fn(c => c),
+    hasPerm: jest.fn(() => true),
+  }
 };
 
 const renderTransferAccountsSettings = () => renderWithRouter(<TransferAccountsSettings {...defaultProps} />);
@@ -64,5 +68,24 @@ describe('TransferAccountsSettings', () => {
     const preCreateHookButton = screen.getByTestId('preCreateHook-button');
     userEvent.click(preCreateHookButton);
     expect(ControlledVocab).toHaveBeenCalledTimes(2);
+  });
+  describe('Action suppression', () => {
+    it('should have disabled new button when user do not have permission to create new transfer account', () => {
+      const transferAccount = {
+        accountName: 'test',
+        id: '82db1a06-6e4a-40a4-ac94-770e222e09ac',
+        metadata: {
+          createdDate: '2023-07-11T10:50:42.623+00:00',
+          createdByUserId: 'ff96b580-4206-4957-8b5d-7bdbc3d192f9',
+          updatedDate: '2023-07-11T10:50:42.623+00:00',
+          updatedByUserId: 'ff96b580-4206-4957-8b5d-7bdbc3d192f9'
+        },
+        ownerId: '73e450d9-acb5-4443-a36e-9ea3709e58bd',
+      };
+
+      const { actionSuppressor } = ControlledVocab.mock.calls[0][0];
+      expect(actionSuppressor.edit(transferAccount)).toBeFalsy();
+      expect(actionSuppressor.delete(transferAccount)).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
## Purpose
User settings > Transfer Accounts: Disable editing for users with "Setting (Users): View all settings" permission

## Screencast
When logged in user has view all user settings permissions - 
<img width="960" alt="chrome_jUj5hDffmA" src="https://github.com/folio-org/ui-users/assets/104053200/4c3b2a0e-89a1-4865-9adf-8561a312429e">
<img width="960" alt="chrome_VvDT8PA44f" src="https://github.com/folio-org/ui-users/assets/104053200/ee5bd074-527e-439a-8d43-d39651349d72">

when logged in with diku
<img width="960" alt="chrome_m5wqjfavpI" src="https://github.com/folio-org/ui-users/assets/104053200/8607fe30-672e-4231-a952-e5fa6ef14b9b">

## Ref
https://issues.folio.org/browse/UIU-2910