### PR TITLE
UIU-2928 - Add serach filters to path while navigating back to user preview screen, when cancelling user edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * Add permission check to restrict edit of transfer account page on user settings. Refs UIU-2910.
 * Leverage cookie-based authentication in all API requests. Refs UIU-2746.
 * Assign/unassign users from Permission set. Refs UIU-2873.
+* Add serach filters to path while navigating back to user preview screen, when cancelling user edit. Refs. UIU-2928
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -400,7 +400,7 @@ class UserEdit extends React.Component {
         onSubmit={onSubmit}
         onCancel={() => {
           history.push({
-            pathname: params.id ? `/users/preview/${params.id}` : '/users',
+            pathname: params.id ? `/users/preview/${params.id}${location.search}` : '/users',
             state: location.state,
           });
         }}

--- a/src/views/UserEdit/UserEdit.test.js
+++ b/src/views/UserEdit/UserEdit.test.js
@@ -79,7 +79,9 @@ describe('UserEdit', () => {
     history: {
       push: jest.fn(),
     },
-    location: {},
+    location: {
+      search: '?filters=active.active'
+    },
     match: { params: { id: 'userId' } },
     updateProxies: jest.fn(),
     updateSponsors: jest.fn(),

--- a/src/views/UserEdit/UserEdit.test.js
+++ b/src/views/UserEdit/UserEdit.test.js
@@ -48,6 +48,7 @@ jest.mock('../../components/EditSections', () => ({
   EditProxy: jest.fn(() => null),
   EditServicePoints: jest.fn(() => null),
 }));
+
 describe('UserEdit', () => {
   let props = {
     stripes: {
@@ -389,6 +390,107 @@ describe('UserEdit', () => {
 
         expect(props.mutator.perms.PUT).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('Cancel user form', () => {
+    beforeEach(() => {
+      jest.unmock('./UserForm');
+    });
+
+    const defaultProps = {
+      stripes: {
+        hasPerm: jest.fn().mockReturnValue(true),
+        okapi: {
+          tenant: 'tenantId',
+        },
+      },
+      resources: {
+        selUser: {
+          records: [{ id: 'userId' }],
+        },
+        patronGroups: {
+          records: [],
+        },
+        perms: {
+          records: [{ id: 'permUserRecordId' }],
+        },
+        addressTypes: {
+          records: [],
+        },
+        servicePoints: {
+          records: [],
+        },
+        departments: {
+          records: [],
+        },
+      },
+      history: {
+        push: jest.fn(),
+      },
+      location: {
+        pathname: '/users/userId/edit',
+        search: '?filters=active.active',
+        state: undefined,
+      },
+      match: { params: { id: 'userId' } },
+      updateProxies: jest.fn(),
+      updateSponsors: jest.fn(),
+      updateServicePoints: jest.fn(),
+      getUserServicePoints: jest.fn(),
+      getPreferredServicePoint: jest.fn(),
+      mutator: {
+        records: {
+          POST: jest
+            .fn()
+            .mockResolvedValue(jest.fn().mockResolvedValue({ result: [] })),
+        },
+        perms: {
+          POST: jest.fn().mockResolvedValue({ data: {} }),
+          PUT: jest.fn().mockResolvedValue({ data: {} }),
+        },
+        permissions: {
+          POST: jest.fn().mockResolvedValue({ data: {} }),
+          PUT: jest.fn().mockResolvedValue({ data: {} }),
+        },
+        requestPreferences: {
+          POST: jest.fn().mockResolvedValue({ data: {} }),
+          PUT: jest.fn().mockResolvedValue({ data: {} }),
+        },
+        selUser: {
+          PUT: jest.fn().mockResolvedValue({ data: {} }),
+        },
+        permUserId: '2',
+      },
+      getProxies: jest.fn(),
+      getSponsors: jest.fn(),
+      okapiKy: {
+        extend: jest.fn(() => props.okapiKy),
+        get: jest.fn(() => ({ json: () => Promise.resolve() })),
+        post: jest.fn(() => ({ json: () => Promise.resolve({}) })),
+        put: jest.fn(() => ({ json: () => Promise.resolve({}) })),
+      },
+    };
+
+    it('should call history.push on cancelling user edit form', () => {
+      const { container } = renderWithRouter(<UserEdit {...defaultProps} />);
+      const cancelButton = container.querySelector('#clickable-cancel');
+      userEvent.click(cancelButton);
+      expect(defaultProps.history.push).toHaveBeenCalled();
+    });
+
+    it('should call history.push on cancelling new user form', () => {
+      const alteredProps = {
+        ...defaultProps,
+        match: {
+          ...props.match,
+          params:{}
+        }
+      };
+      const { container } = renderWithRouter(<UserEdit {...alteredProps} />);
+      const cancelButton = container.querySelector('#clickable-cancel');
+      userEvent.click(cancelButton);
+      expect(alteredProps.history.push).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Purpose
"User search results" pane is cleared after canceling user's profile editing

## Approach
Add search filters to path while navigating back to user preview screen, when cancelling user edit.

## Screencast
![U6vka5l8jC](https://github.com/folio-org/ui-users/assets/104053200/355df425-251d-4b00-845b-be0581f81235)


## Refs
https://issues.folio.org/browse/UIU-2928