### PR TITLE
UIU-2889: show error messages on create/edit users with existing username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * Add permission check to restrict edit of transfer account page on user settings. Refs UIU-2910.
 * Leverage cookie-based authentication in all API requests. Refs UIU-2746.
 * Assign/unassign users from Permission set. Refs UIU-2873.
+* ECS - Check username uniqueness when editing. Refs UIU-2889.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.js
+++ b/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.js
@@ -35,7 +35,7 @@ const useAssignedUsers = ({ grantedToIds = [], permissionSetId, tenantId }, opti
     refetch,
     isFetching,
   } = useQuery(
-    [namespace, permissionSetId],
+    [namespace, permissionSetId, grantedToIds],
     async ({ signal }) => {
       const permissionUsersResponse = await batchRequest(
         ({ params: searchParams }) => api

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -172,9 +172,7 @@ class UserEdit extends React.Component {
       })
       .then(() => {
         history.push(`/users/preview/${user.id}${search}`);
-      }).catch((e) => {
-        showErrorCallout(e, this.context.sendCallout);
-      });
+      }).catch((e) => showErrorCallout(e, this.context.sendCallout));
   }
 
   formatCustomFieldsPayload(customFields) {

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -172,6 +172,8 @@ class UserEdit extends React.Component {
       })
       .then(() => {
         history.push(`/users/preview/${user.id}${search}`);
+      }).catch((e) => {
+        showErrorCallout(e, this.context.sendCallout);
       });
   }
 

--- a/src/views/UserEdit/UserEditHelpers.js
+++ b/src/views/UserEdit/UserEditHelpers.js
@@ -34,7 +34,7 @@ export async function showErrorCallout(res, sendCallout) {
     const contentType = res.headers.get('content-type');
     let errorMessage = '';
 
-    if (contentType && contentType.includes('application/json')) {
+    if (contentType?.includes('application/json')) {
       const json = await res.json();
       errorMessage = json?.errors?.map(e => e.message)?.join(', ');
     } else {

--- a/src/views/UserEdit/UserEditHelpers.js
+++ b/src/views/UserEdit/UserEditHelpers.js
@@ -29,15 +29,19 @@ export function resourcesLoaded(obj, exceptions = []) {
  * @param {function} sendCallout function reference, likely this.context.sendCallout
  */
 export function showErrorCallout(res, sendCallout) {
+  console.error(res); // eslint-disable-line no-console
   res.text()
     .then(body => {
+      const isUserExists = body?.includes('username already exists');
+      const messageId = isUserExists ? 'ui-users.errors.usernameUnavailable' : 'ui-users.errors.permissionChangeFailed';
+
       sendCallout({
         type: 'error',
         timeout: 0,
         message: (
           <div>
-            <div><strong><FormattedMessage id="ui-users.errors.permissionChangeFailed" /></strong></div>
-            <div>{body}</div>
+            <div><strong><FormattedMessage id={messageId} /></strong></div>
+            <div>{!isUserExists && body}</div>
           </div>
         )
       });

--- a/src/views/UserEdit/UserEditHelpers.test.js
+++ b/src/views/UserEdit/UserEditHelpers.test.js
@@ -1,7 +1,7 @@
 import { resourcesLoaded, showErrorCallout } from './UserEditHelpers';
 
 describe('resourcesLoaded', () => {
-  test('loaded, no exceptions', async () => {
+  it('loaded, no exceptions', async () => {
     const res = {
       foo: { isPending: false },
       bar: { isPending: false },
@@ -10,7 +10,7 @@ describe('resourcesLoaded', () => {
     expect(resourcesLoaded(res)).toBe(true);
   });
 
-  test('loaded, with exceptions', async () => {
+  it('loaded, with exceptions', async () => {
     const res = {
       foo: { isPending: false },
       bar: { isPending: true },
@@ -19,7 +19,7 @@ describe('resourcesLoaded', () => {
     expect(resourcesLoaded(res, ['bar'])).toBe(true);
   });
 
-  test('loaded (not an object)', async () => {
+  it('loaded (not an object)', async () => {
     const res = {
       foo: { isPending: false },
       bar: () => { },
@@ -28,7 +28,7 @@ describe('resourcesLoaded', () => {
     expect(resourcesLoaded(res)).toBe(true);
   });
 
-  test('unloaded (null)', async () => {
+  it('unloaded (null)', async () => {
     const res = {
       foo: { isPending: false },
       bar: null,
@@ -37,7 +37,7 @@ describe('resourcesLoaded', () => {
     expect(resourcesLoaded(res)).toBe(false);
   });
 
-  test('unloaded (pending)', async () => {
+  it('unloaded (pending)', async () => {
     const res = {
       foo: { isPending: false },
       bar: { isPending: true },
@@ -50,12 +50,25 @@ describe('resourcesLoaded', () => {
 describe('showErrorCallout', () => {
   it('calls the callout', async () => {
     const res = {
-      text: jest.fn().mockReturnValue(Promise.resolve()),
+      text: jest.fn().mockReturnValue(Promise.resolve('')),
     };
     const sendCallout = jest.fn();
 
     await showErrorCallout(res, sendCallout);
 
     expect(sendCallout).toHaveBeenCalled();
+  });
+
+  it('calls the error callout with username exist', async () => {
+    const res = {
+      text: jest.fn().mockReturnValue(Promise.resolve('username already exists')),
+    };
+    const sendCallout = jest.fn();
+
+    await showErrorCallout(res, sendCallout);
+
+    expect(sendCallout).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'error',
+    }));
   });
 });

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -349,6 +349,7 @@
   "errors.noMatch.how": "How did you get to {location}?",
   "errors.userExpired": "User has expired",
   "errors.usernameUnavailable": "This username already exists",
+  "errors.generic": "Something went wrong. Please try again later.",
   "errors.barcodeUnavailable": "This barcode has already been taken",
   "errors.proxyrelationship.expired": "Proxy relationship has expired",
   "errors.proxies.expired": "Proxy user record expired",


### PR DESCRIPTION
## [UIU-2889](https://issues.folio.org/browse/UIU-2889) - shows error messages for not unique usernames.

- Given staff user is creating/editing a user with a username
- When staff user inputs a username already in use by any member and clicks save
- Then staff user is alerted: "This username already exists"
- AND the create/edit screen remains open
- AND the user is NOT saved

https://github.com/folio-org/ui-users/assets/116072773/bec90133-c445-46a0-866a-6ca2b0632d86

