### PR TITLE
UIU-2873: allow to run query without grantedToIds

### DIFF
--- a/src/components/AssignedUsers/AssignedUsersContainer.js
+++ b/src/components/AssignedUsers/AssignedUsersContainer.js
@@ -109,7 +109,7 @@ const AssignedUsersContainer = ({ permissionSetId, expanded, onToggle, tenantId 
         : (
           <AssignedUsersList
             isFetching={isFetching || isMutationLoading}
-            users={users}
+            users={grantedTo.length ? users : []}
           />
         )}
     </Accordion>

--- a/src/components/AssignedUsers/AssignedUsersContainer.js
+++ b/src/components/AssignedUsers/AssignedUsersContainer.js
@@ -109,7 +109,7 @@ const AssignedUsersContainer = ({ permissionSetId, expanded, onToggle, tenantId 
         : (
           <AssignedUsersList
             isFetching={isFetching || isMutationLoading}
-            users={grantedTo.length ? users : []}
+            users={users}
           />
         )}
     </Accordion>

--- a/src/components/AssignedUsers/AssignedUsersContainer.test.js
+++ b/src/components/AssignedUsers/AssignedUsersContainer.test.js
@@ -109,6 +109,26 @@ describe('AssignedUsersContainer', () => {
     expect(screen.getByText('Loading')).toBeInTheDocument();
   });
 
+  it('should render empty list', async () => {
+    usePermissionSet.mockClear().mockReturnValue({
+      permissionSet: {
+        id: '1',
+        name: 'permissionSetName',
+        displayName: 'permissionSetDisplayName',
+        grantedTo: [],
+      },
+      isLoading: false,
+    });
+    useAssignedUsers.mockClear().mockReturnValue({
+      users: [],
+      isLoading: false,
+    });
+    renderComponent(props);
+
+    await waitFor(() => expect(screen.queryByText('Loading')).toBeNull());
+    expect(screen.getByText('AssignedUsersList')).toBeInTheDocument();
+  });
+
   it('should render AssignedUsersList', async () => {
     useAssignedUsers.mockReturnValue({
       users: mockUsers,

--- a/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.js
+++ b/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.js
@@ -79,7 +79,7 @@ const useAssignedUsers = ({ grantedToIds = [], permissionSetId, tenantId }, opti
       }));
     },
     {
-      enabled: Boolean(grantedToIds.length && permissionSetId),
+      enabled: Boolean(permissionSetId),
       keepPreviousData: true,
       ...options,
     },

--- a/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.js
+++ b/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.js
@@ -79,7 +79,7 @@ const useAssignedUsers = ({ grantedToIds = [], permissionSetId, tenantId }, opti
       }));
     },
     {
-      enabled: Boolean(permissionSetId),
+      enabled: Boolean(grantedToIds.length && permissionSetId),
       keepPreviousData: true,
       ...options,
     },

--- a/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.js
+++ b/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.js
@@ -17,7 +17,9 @@ import {
   buildQueryByIds,
 } from '../utils';
 
-const useAssignedUsers = ({ grantedToIds = [], permissionSetId, tenantId }, options = {}) => {
+const DEFAULT_DATA = [];
+
+const useAssignedUsers = ({ grantedToIds = DEFAULT_DATA, permissionSetId, tenantId }, options = {}) => {
   const stripes = useStripes();
   const defaultTenantId = stripes.okapi?.tenant;
 
@@ -31,7 +33,7 @@ const useAssignedUsers = ({ grantedToIds = [], permissionSetId, tenantId }, opti
   const [namespace] = useNamespace({ key: 'get-assigned-users' });
   const {
     isLoading,
-    data = [],
+    data = DEFAULT_DATA,
     refetch,
     isFetching,
   } = useQuery(
@@ -85,11 +87,13 @@ const useAssignedUsers = ({ grantedToIds = [], permissionSetId, tenantId }, opti
     },
   );
 
+  const users = !grantedToIds.length ? DEFAULT_DATA : data;
+
   return ({
     refetch,
     isLoading,
     isFetching,
-    users: data,
+    users,
   });
 };
 

--- a/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.test.js
+++ b/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.test.js
@@ -72,8 +72,8 @@ describe('useAssignedUsers', () => {
       permissionSetId: mockTenantId,
       tenantId: mockTenantId,
     }), { wrapper });
-    console.log(result.current);
-    await waitFor(() => !result.current.isLoading, { timeout: 5000 });
+
+    await waitFor(() => !result.current.isLoading);
     expect(result.current.users).toHaveLength(0);
   });
 

--- a/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.test.js
+++ b/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.test.js
@@ -1,3 +1,4 @@
+import { waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import { renderHook } from '@folio/jest-config-stripes/testing-library/react-hooks';
 import {
   QueryClient,
@@ -66,13 +67,13 @@ describe('useAssignedUsers', () => {
   });
 
   it('should return empty assigned users', async () => {
-    const { result, waitFor } = renderHook(() => useAssignedUsers({
+    const { result } = renderHook(() => useAssignedUsers({
       grantedToIds: [],
       permissionSetId: mockTenantId,
       tenantId: mockTenantId,
     }), { wrapper });
-
-    await waitFor(() => !result.current.isLoading);
+    console.log(result.current);
+    await waitFor(() => !result.current.isLoading, { timeout: 5000 });
     expect(result.current.users).toHaveLength(0);
   });
 
@@ -81,7 +82,7 @@ describe('useAssignedUsers', () => {
       .mockResolvedValueOnce(kyResponseMap[PERMISSIONS_API].permissionUsers)
       .mockResolvedValueOnce(kyResponseMap[USERS_API].users);
 
-    const { result, waitFor } = renderHook(() => useAssignedUsers({
+    const { result } = renderHook(() => useAssignedUsers({
       grantedToIds: mockGrantedToIds,
       permissionSetId: mockTenantId,
       tenantId: mockTenantId,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->
[UIU-2873](https://issues.folio.org/browse/UIU-2873) - allow to run query with empty grantedToIds
The reason to allow run query when the user removes all assigned users the list isn't updated due to `grantedToIds` length equal to 0.
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
https://github.com/folio-org/ui-users/assets/116072773/abf5cef7-fbb1-42e0-8cad-cc8906578712
#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
