### PR TITLE
UIU-2933 ECS - Do not display shadow users in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 * Add PULL_REQUEST_TEMPLATE.md file to the repository. Refs. UIU-2918.
 * Adjust `loans.staffInfoDialogBody` translation. Refs. UIU-2922.
 * *BREAKING* Upgrade React to v18. Refs-UIU-2912.
+* ECS - Do not display shadow users in search results. Refs UIU-2933.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -339,3 +339,9 @@ export const CONSORTIA_USER_TENANTS_API = 'user-tenants';
 export const RECORD_SOURCE = {
   CONSORTIUM: 'consortium',
 };
+
+export const USER_TYPES = {
+  PATRON: 'patron',
+  SHADOW: 'shadow',
+  STAFF: 'staff',
+};

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -23,6 +23,8 @@ import { buildFilterConfig } from './utils';
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
 
+export const NOT_SHADOW_USER_CQL = `((cql.allRecords=1 NOT type ="") or type<>"${USER_TYPES.SHADOW}")`;
+
 const searchFields = [
   'username="%{query}*"',
   'personal.firstName="%{query}*"',
@@ -37,10 +39,8 @@ const searchFields = [
 ];
 const compileQuery = template(`(${searchFields.join(' or ')})`, { interpolate: /%{([\s\S]+?)}/g });
 
-const notShadowUsersCql = `((cql.allRecords=1 NOT type ="") or type<>"${USER_TYPES.SHADOW}")`;
-
-function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
-  const customFilterConfig = buildFilterConfig(queryParams.filters)
+export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
+  const customFilterConfig = buildFilterConfig(queryParams.filters);
 
   const mainQuery = makeQueryFunction(
     'cql.allRecords=1',
@@ -60,7 +60,7 @@ function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
     2,
   )(queryParams, pathComponents, resourceData, logger, props);
 
-  return mainQuery && `${notShadowUsersCql} and ${mainQuery}`;
+  return mainQuery && `${NOT_SHADOW_USER_CQL} and ${mainQuery}`;
 }
 
 class UserSearchContainer extends React.Component {

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -14,7 +14,10 @@ import {
 
 import filterConfig from './filterConfig';
 import { UserSearch } from '../views';
-import { MAX_RECORDS } from '../constants';
+import {
+  MAX_RECORDS,
+  USER_TYPES,
+} from '../constants';
 import { buildFilterConfig } from './utils';
 
 const INITIAL_RESULT_COUNT = 30;
@@ -34,10 +37,12 @@ const searchFields = [
 ];
 const compileQuery = template(`(${searchFields.join(' or ')})`, { interpolate: /%{([\s\S]+?)}/g });
 
-function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
-  const customFilterConfig = buildFilterConfig(queryParams.filters);
+const notShadowUsersCql = `((cql.allRecords=1 NOT type ="") or type<>"${USER_TYPES.SHADOW}")`;
 
-  return makeQueryFunction(
+function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
+  const customFilterConfig = buildFilterConfig(queryParams.filters)
+
+  const mainQuery = makeQueryFunction(
     'cql.allRecords=1',
     // TODO: Refactor/remove this after work on FOLIO-2066 and RMB-385 is done
     (parsedQuery, _, localProps) => localProps.query.query.trim().replace('*', '').split(/\s+/)
@@ -54,6 +59,8 @@ function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
     [...filterConfig, ...customFilterConfig],
     2,
   )(queryParams, pathComponents, resourceData, logger, props);
+
+  return mainQuery && `${notShadowUsersCql} and ${mainQuery}`;
 }
 
 class UserSearchContainer extends React.Component {

--- a/src/routes/UserSearchContainer.test.js
+++ b/src/routes/UserSearchContainer.test.js
@@ -1,0 +1,23 @@
+import {
+  buildQuery,
+  NOT_SHADOW_USER_CQL,
+} from './UserSearchContainer';
+
+const queryParams = {
+  filters: 'active.active',
+  query: 'Joe',
+  sort: 'name',
+};
+const pathComponents = {};
+const resourceData = {
+  query: queryParams,
+};
+const logger = {
+  log: jest.fn(),
+};
+
+describe('buildQuery', () => {
+  it('should exclude shadow users when building CQL query', () => {
+    expect(buildQuery(queryParams, pathComponents, resourceData, logger)).toEqual(expect.stringContaining(NOT_SHADOW_USER_CQL));
+  });
+});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->
https://issues.folio.org/browse/UIU-2933
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Mix a directive in CQL to exclude users with `type` equal to "shadow".

## Screencast

https://github.com/folio-org/ui-users/assets/88109087/99bd9d8b-7d1d-4416-99fc-876a8d9d2f99

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
