### PR TITLE
use master branch of sonarcloud scanner GitHub Action

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -176,7 +176,7 @@ jobs:
         run: git fetch --no-tags ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} +refs/heads/${{ env.DEFAULT_BRANCH }}:refs/remotes/origin/${{ env.DEFAULT_BRANCH }}
 
       - name: Run SonarCloud scan
-        uses: sonarsource/sonarcloud-github-action@v1.8
+        uses: sonarsource/sonarcloud-github-action@master
         with:
           args: >
             -Dsonar.organization=folio-org

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -116,7 +116,7 @@ jobs:
         run: git fetch --no-tags ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} +refs/heads/${{ env.DEFAULT_BRANCH }}:refs/remotes/origin/${{ env.DEFAULT_BRANCH }}
 
       - name: Run SonarCloud scan
-        uses: sonarsource/sonarcloud-github-action@v1.8
+        uses: sonarsource/sonarcloud-github-action@master
         with:
           args: >
             -Dsonar.organization=folio-org


### PR DESCRIPTION
Use the `master` branch of the SonarCloud GitHub action instead of pinning to an old old version. This has no effect on how things work in production, only on how code is analyzed in CI. This brings ui-users' workflow files into line with those in other UI repositories that were configured after we first configured it here as a POC.