### PR TITLE
UIU-2932: Add auto focus to textarea on staff and patron info modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * Add dropdown to specify user type: Patron or Staff. Refs UIU-2936.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIU-2946.
 * Generate "Create request" url for users without barcode. Refs UIU-2869.
+* Add auto focus to textarea on staff and patron info modal. Fixes UIU-2932.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -290,6 +290,7 @@ class ModalContent extends React.Component {
               data-test-additional-info-textarea
               label={<FormattedMessage id="ui-users.additionalInfo.label" />}
               required
+              autoFocus
               onChange={this.handleAdditionalInfoChange}
             />
           </Col>


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-2932

Add auto focus to textarea on staff and patron info modal