### PR TITLE
UIU-2948: Fix user can not renew the loan through the override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * Relabel "Users: Can create new user" to "Users: Can create and edit users". Refs UIU-2955.
 * Assign/unassign a users affiliations adjustments. Refs UIU-2942.
 * ECS - Prevent editing of specific shadow user data. Refs UIU-2951.
+* Fix user can not renew the loan through the override. Refs UIU-2948.
 
 ## [9.0.0](https://github.com/folio-org/ui-users/tree/v9.0.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v8.1.0...v9.0.0)

--- a/src/components/Wrappers/withRenew.js
+++ b/src/components/Wrappers/withRenew.js
@@ -51,8 +51,6 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
       additionalInfo: '',
       loans: [],
       // eslint-disable-next-line react/no-unused-state
-      errors: [],
-      // eslint-disable-next-line react/no-unused-state
       bulkRenewal: false,
       bulkRenewalDialogOpen: false,
       renewSuccess: [],
@@ -126,9 +124,8 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
 
           if (contentType && contentType.startsWith('application/json')) {
             resp.json()
-              .then((error) => {
-                const errors = this.handleErrors(error);
-                reject(this.getMessage(errors));
+              .then(({ errors }) => {
+                reject(errors);
               });
           } else {
             resp.text()
@@ -153,11 +150,13 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
         renewSuccess.push(
           await this.renewItem(loan, patron, bulkRenewal, index !== loansSize - 1, additionalInfo)
         );
-      } catch (error) {
+      } catch (errors) {
+        const errorMessage = this.getMessage(errors);
+
         renewFailure.push(loan);
         errorMsg[loan.id] = {
-          ...error,
-          ...isOverridePossible(this.state.errors),
+          ...errorMessage,
+          ...isOverridePossible(errors),
         };
       }
     }
@@ -190,13 +189,6 @@ const withRenew = WrappedComponent => class WithRenewComponent extends React.Com
     );
 
     this.callout.sendCallout({ message });
-  };
-
-  handleErrors = (error) => {
-    const { errors } = error;
-    // eslint-disable-next-line react/no-unused-state
-    this.setState({ errors });
-    return errors;
   };
 
   getPolicyName = (errors) => {


### PR DESCRIPTION
## Purpose
Fix user can not renew the loan through the override

## Approach
We don't need use state in current case

## Refs
https://issues.folio.org/browse/UIU-2948