### PR TITLE
UIU-2967 Don't display affiliations of users with types `patron` or `dcb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-users
 
-## [11.0.0] IN PROGRESS
+## [10.0.1] IN PROGRESS
 
 * Don't display affiliations of users with types `patron` or `dbc`. Refs UIU-2967.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [10.1.0] IN PROGRESS
 
-* Don't display affiliations of users with types `patron` or `dbc`. Refs UIU-2967.
+* Don't display affiliations of users with types `patron` or `dcb`. Refs UIU-2967.
 
 ## [10.0.0](https://github.com/folio-org/ui-users/tree/v10.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v9.0.3...v10.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-users
 
-## [10.0.1] IN PROGRESS
+## [10.1.0] IN PROGRESS
 
 * Don't display affiliations of users with types `patron` or `dbc`. Refs UIU-2967.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [11.0.0] IN PROGRESS
 
+* Don't display affiliations of users with types `patron` or `dbc`. Refs UIU-2967.
+
 ## [10.0.0](https://github.com/folio-org/ui-users/tree/v10.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v9.0.3...v10.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/users",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "User management",
   "repository": "folio-org/ui-users",
   "publishConfig": {

--- a/src/components/PermissionsAccordion/PermissionsAccordion.js
+++ b/src/components/PermissionsAccordion/PermissionsAccordion.js
@@ -27,6 +27,7 @@ import EnableUnassignAll from './EnableUnassignAll';
 import AffiliationsSelect from '../AffiliationsSelect';
 import IfConsortium from '../IfConsortium';
 import IfConsortiumPermission from '../IfConsortiumPermission';
+import { isAffiliationsEnabled } from '../util';
 
 const PermissionsAccordion = (props) => {
   const {
@@ -57,6 +58,7 @@ const PermissionsAccordion = (props) => {
 
   const isAllowedPermissions = !!getAssignedPermissions().length;
   const isActionsDisabled = disabled || isLoading;
+  const isAffiliationsVisible = isAffiliationsEnabled(props.initialValues) && affiliations?.length > 1;
 
   const [permissionModalOpen, setPermissionModalOpen] = useState(false);
   const [unassignModalOpen, setUnassignModalOpen] = useState(false);
@@ -186,7 +188,7 @@ const PermissionsAccordion = (props) => {
       >
         <IfConsortium>
           <IfConsortiumPermission perm="consortia.user-tenants.collection.get">
-            {affiliations?.length > 1 && (
+            {isAffiliationsVisible && (
               <AffiliationsSelect
                 affiliations={affiliations}
                 onChange={onChangeAffiliation}

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -6,6 +6,7 @@ import queryString from 'query-string';
 import { NoValue } from '@folio/stripes/components';
 
 import {
+  USER_TYPES,
   requestStatuses,
   sortTypes,
 } from '../../constants';
@@ -198,4 +199,11 @@ export const getRequestUrl = (barcode, userId) => {
       layer: 'create',
       userId,
     })}`;
+};
+
+export const isPatronUser = (user) => user?.type === USER_TYPES.PATRON;
+export const isDcbUser = (user) => user?.type === USER_TYPES.DCB;
+
+export const isAffiliationsEnabled = (user) => {
+  return !isPatronUser(user) && !isDcbUser(user);
 };

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -425,11 +425,11 @@ describe('isAffiliationsEnabled', () => {
     expect(isAffiliationsEnabled({ type: USER_TYPES.PATRON })).toBeFalsy();
   });
 
-  it('should return \'false\' if a user type is \'dbc\'', () => {
+  it('should return \'false\' if a user type is \'dcb\'', () => {
     expect(isAffiliationsEnabled({ type: USER_TYPES.DCB })).toBeFalsy();
   });
 
-  it('should return \'true\' if a user type is other than \'patron\' and \'dbc\'', () => {
+  it('should return \'true\' if a user type is other than \'patron\' and \'dcb\'', () => {
     expect(isAffiliationsEnabled({ type: USER_TYPES.SHADOW })).toBeTruthy();
     expect(isAffiliationsEnabled({ type: USER_TYPES.STAFF })).toBeTruthy();
     expect(isAffiliationsEnabled({ type: USER_TYPES.SYSTEM })).toBeTruthy();

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -1,5 +1,6 @@
 import '__mock__';
 import okapiUser from 'fixtures/okapiCurrentUser';
+import { USER_TYPES } from '../../constants';
 import {
   accountsMatchStatus,
   checkUserActive,
@@ -23,7 +24,6 @@ import {
   getRequestUrl,
   isAffiliationsEnabled,
 } from './util';
-import { USER_TYPES } from '../../constants';
 
 const STRIPES = {
   hasPerm: jest.fn().mockReturnValue(true),

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -21,7 +21,9 @@ import {
   getCentralTenantId,
   isConsortiumEnabled,
   getRequestUrl,
+  isAffiliationsEnabled,
 } from './util';
+import { USER_TYPES } from '../../constants';
 
 const STRIPES = {
   hasPerm: jest.fn().mockReturnValue(true),
@@ -415,5 +417,21 @@ describe('getRequestUrl', () => {
     const userId = 'userId';
 
     expect(getRequestUrl(undefined, userId)).toBe(`/requests/?layer=create&userId=${userId}`);
+  });
+});
+
+describe('isAffiliationsEnabled', () => {
+  it('should return \'false\' if a user type is \'patron\'', () => {
+    expect(isAffiliationsEnabled({ type: USER_TYPES.PATRON })).toBeFalsy();
+  });
+
+  it('should return \'false\' if a user type is \'dbc\'', () => {
+    expect(isAffiliationsEnabled({ type: USER_TYPES.DCB })).toBeFalsy();
+  });
+
+  it('should return \'true\' if a user type is other than \'patron\' and \'dbc\'', () => {
+    expect(isAffiliationsEnabled({ type: USER_TYPES.SHADOW })).toBeTruthy();
+    expect(isAffiliationsEnabled({ type: USER_TYPES.STAFF })).toBeTruthy();
+    expect(isAffiliationsEnabled({ type: USER_TYPES.SYSTEM })).toBeTruthy();
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -346,4 +346,5 @@ export const USER_TYPES = {
   SHADOW: 'shadow',
   STAFF: 'staff',
   SYSTEM: 'system',
+  DCB: 'dcb',
 };

--- a/src/hooks/useUserAffiliations/useUserAffiliations.js
+++ b/src/hooks/useUserAffiliations/useUserAffiliations.js
@@ -32,7 +32,11 @@ const useUserAffiliations = ({ userId } = {}, options = {}) => {
 
   const consortium = stripes?.user?.user?.consortium;
   const currentUserTenants = stripes?.user?.user?.tenants;
-  const { assignedToCurrentUser, ...queryOptions } = options;
+  const {
+    assignedToCurrentUser,
+    enabled: enabledOption = true,
+    ...queryOptions
+  } = options;
 
   const searchParams = {
     userId,
@@ -42,7 +46,8 @@ const useUserAffiliations = ({ userId } = {}, options = {}) => {
   const enabled = Boolean(
     consortium?.centralTenantId
     && consortium?.id
-    && userId,
+    && userId
+    && enabledOption,
   );
 
   const {

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -54,7 +54,10 @@ import HelperApp from '../../components/HelperApp';
 import IfConsortium from '../../components/IfConsortium';
 import { PatronBlockMessage } from '../../components/PatronBlock';
 import { getFormAddressList } from '../../components/data/converters/address';
-import { getFullName } from '../../components/util';
+import {
+  getFullName,
+  isAffiliationsEnabled,
+} from '../../components/util';
 import RequestFeeFineBlockButtons from '../../components/RequestFeeFineBlockButtons';
 import { departmentsShape } from '../../shapes';
 import ErrorPane from '../../components/ErrorPane';
@@ -618,7 +621,7 @@ class UserDetail extends React.Component {
     const userDepartments = (user?.departments || [])
       .map(departmentId => departments.find(({ id }) => id === departmentId)?.name);
     const accounts = resources?.accounts;
-    const isAffiliationEnabled = user?.type !== USER_TYPES.PATRON;
+    const isAffiliationsVisible = isAffiliationsEnabled(user);
 
     const isShadowUser = user?.type === USER_TYPES.SHADOW;
     const showPatronBlocksSection = hasPatronBlocksPermissions && !isShadowUser;
@@ -704,7 +707,7 @@ class UserDetail extends React.Component {
                 <IfConsortium>
                   <IfConsortiumPermission perm="consortia.user-tenants.collection.get">
                     {
-                      isAffiliationEnabled && (
+                      isAffiliationsVisible && (
                         <UserAffiliations
                           accordionId="affiliationsSection"
                           expanded={sections.affiliationsSection}

--- a/src/views/UserEdit/TenantsPermissionsAccordion.js
+++ b/src/views/UserEdit/TenantsPermissionsAccordion.js
@@ -18,6 +18,7 @@ import {
   statusFilterConfig,
   permissionTypeFilterConfig,
 } from '../../components/PermissionsAccordion/helpers/filtersConfig';
+import { isAffiliationsEnabled } from '../../components/util';
 import {
   useUserAffiliations,
   useUserTenantPermissions,
@@ -93,6 +94,7 @@ const TenantsPermissionsAccordion = ({
   } = useUserAffiliations(
     { userId },
     {
+      enabled: isAffiliationsEnabled(initialValues),
       onError: handleLoadAffiliationsError
     },
   );


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->
https://issues.folio.org/browse/UIU-2967

When changing a user type from `staff` to `patron` - affiliations are deleted on BE side and it results in an error when querying users' tenants. So for for users with types `patron` or `dbc` (a new user type, that isn't meant to work with affiliations) "Affiliations" selector should be hidden in the permissions accordion and the related query to fetch user affiliations should be disabled.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Prevent fetching affiliations if a user type is a `patron` or `dcb`. Hide the "Affiliations" selection for those types in the user edit form.

## Screenshots

https://github.com/folio-org/ui-users/assets/88109087/14083b4c-c51c-4c71-8704-e4f520264fa1



## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
