### PR TITLE
UIU-2970 Make the `username` field required for users with the `staff` type in "ECS" mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [10.1.0] IN PROGRESS
 
 * Don't display affiliations of users with types `patron` or `dcb`. Refs UIU-2967.
+* Make the `username` field required for users with the `staff` type in ECS mode. Refs UIU-2970.
 
 ## [10.0.0](https://github.com/folio-org/ui-users/tree/v10.0.0) (2023-10-13)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v9.0.3...v10.0.0)

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -12,7 +12,10 @@ import {
   Datepicker,
   Headline,
 } from '@folio/stripes/components';
-import { IfPermission } from '@folio/stripes/core';
+import {
+  IfPermission,
+  stripesShape,
+} from '@folio/stripes/core';
 
 import { withFormValues } from '../../Wrappers';
 import asyncValidateField from '../../validators/asyncValidateField';
@@ -21,6 +24,10 @@ import {
   addressTypesShape,
   departmentsShape,
 } from '../../../shapes';
+import {
+  isConsortiumEnabled,
+  isStaffUser,
+} from '../../util';
 
 import CreateResetPasswordControl from './CreateResetPasswordControl';
 import RequestPreferencesEdit from './RequestPreferencesEdit';
@@ -41,6 +48,7 @@ class EditExtendedInfo extends Component {
     values: PropTypes.object,
     uniquenessValidator: PropTypes.object,
     disabled: PropTypes.bool,
+    stripes: stripesShape,
   };
 
   buildAccordionHeader = () => {
@@ -85,6 +93,8 @@ class EditExtendedInfo extends Component {
       change,
       uniquenessValidator,
       disabled,
+      values,
+      stripes,
     } = this.props;
 
     const accordionHeader = this.buildAccordionHeader();
@@ -92,6 +102,7 @@ class EditExtendedInfo extends Component {
     const addresses = this.getAddresses();
     const defaultDeliveryAddressTypeId = this.getDefaultDeliveryAddressTypeId();
     const deliveryAvailable = this.isDeliveryAvailable();
+    const isUsernameFieldRequired = isConsortiumEnabled(stripes) && isStaffUser(values);
 
     return (
       <Accordion
@@ -195,6 +206,7 @@ class EditExtendedInfo extends Component {
               fullWidth
               validStylesEnabled
               disabled={disabled}
+              required={isUsernameFieldRequired}
               validate={asyncValidateField('username', username, uniquenessValidator)}
             />
           </Col>

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -203,6 +203,7 @@ export const getRequestUrl = (barcode, userId) => {
 
 export const isPatronUser = (user) => user?.type === USER_TYPES.PATRON;
 export const isDcbUser = (user) => user?.type === USER_TYPES.DCB;
+export const isStaffUser = (user) => user?.type === USER_TYPES.STAFF;
 
 export const isAffiliationsEnabled = (user) => {
   return !isPatronUser(user) && !isDcbUser(user);

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -369,6 +369,7 @@ class UserForm extends React.Component {
                     departments={formData.departments}
                     uniquenessValidator={uniquenessValidator}
                     disabled={isShadowUser}
+                    stripes={stripes}
                   />
                   <EditContactInfo
                     accordionId="contactInfo"


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->
https://issues.folio.org/browse/UIU-2970

Currently, it is possible to save staff users without a username populated. Basically, staff users should be able to login to ECS so a username is required. Also, the username field is necessary to create affiliations.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Make the `username` field required only for users with the `staff` type and only in the ESC mode (with enabled `consortia` interface).

## Screenshots

https://github.com/folio-org/ui-users/assets/88109087/5b4332e9-5a9a-448a-a245-aa84075d1027


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
