### PR TITLE
UIU-2960: Also support feesfines interface version 19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-users
 
 ## [10.1.0] IN PROGRESS
+* Also support `feesfines` interface version `19.0`. Refs UIU-2960.
 
 ## [10.0.1](https://github.com/folio-org/ui-users/tree/v10.0.1) (2023-10-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.0...v10.0.1)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       "automated-patron-blocks": "0.1",
       "circulation": "9.0 10.0 11.0 12.0 13.0 14.0",
       "consortia": "1.0",
-      "feesfines": "16.1 17.0 18.0",
+      "feesfines": "16.1 17.0 18.0 19.0",
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0 7.0",
       "notes": "2.0 3.0",


### PR DESCRIPTION
## Purpose
Also support `feesfines` interface version `19.0`

## Approach
Changes was in endpoint `/accounts` the field `status` has become required, this does not affect the current module.
This is part of `Quesnelia (R1 2024)` release
Should be merged after merging https://issues.folio.org/browse/MODFEE-337

## Refs
https://issues.folio.org/browse/UIU-2960