### PR TITLE
UIU-2977 x-okapi-token header must always be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change history for ui-users
 
 ## [10.1.0] IN PROGRESS
+
 * Also support `feesfines` interface version `19.0`. Refs UIU-2960.
-* Pass location.search parameter through history search. Refs UIU-2971.
+* Pass `location.search` parameter through history search. Refs UIU-2971.
+* Correctly handle optional `X-Okapi-token` request header. Refs UIU-2977.
 
 ## [10.0.1](https://github.com/folio-org/ui-users/tree/v10.0.1) (2023-10-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.0...v10.0.1)

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -170,7 +170,7 @@ class PermissionsModal extends React.Component {
     const permissions = await GET({
       headers: {
         [OKAPI_TENANT_HEADER]: tenantId || okapi.tenant,
-        [OKAPI_TOKEN_HEADER]: okapi.token,
+        ...(okapi.token && { [OKAPI_TOKEN_HEADER]: okapi.token }),
       }
     });
 


### PR DESCRIPTION
The `X-Okapi-Token` header is optional and should only be included when a token value is present on the `stripes.okapi` object.

Refs [UIU-2977](https://issues.folio.org/browse/UIUSERS-2977)