### PR TITLE
UIU-2995 - Update resourceData and queryParams in UserSearchContainer.js to escape special characters in tags filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Also support `feesfines` interface version `19.0`. Refs UIU-2960.
 * Correctly handle optional `X-Okapi-token` request header. Refs UIU-2977.
 * Fix bug with Edit form Expand/collapse all shortcuts not working. Refs UIU-2959.
-* Update resourceData to escape special characters in filter tags before passing to makeQuery function. Refs. UIU-2731.
+* Update resourceData and queryParams in `UserSearchContainer.js` to escape special characters in tags filter. Refs. UIU-2731.
 
 ## [10.0.3](https://github.com/folio-org/ui-users/tree/v10.0.3) (2023-10-23)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.1...v10.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Also support `feesfines` interface version `19.0`. Refs UIU-2960.
 * Correctly handle optional `X-Okapi-token` request header. Refs UIU-2977.
 * Fix bug with Edit form Expand/collapse all shortcuts not working. Refs UIU-2959.
+* Update resourceData to escape special characters in filter tags before passing to makeQuery function. Refs. UIU-2731.
 
 ## [10.0.3](https://github.com/folio-org/ui-users/tree/v10.0.3) (2023-10-23)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.1...v10.0.3)

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -35,6 +35,15 @@ const searchFields = [
 ];
 const compileQuery = template(`(${searchFields.join(' or ')})`, { interpolate: /%{([\s\S]+?)}/g });
 
+/*
+  Some of the special characters that are allowed while creating a tag are  "", \, *, ?
+  These special characters cause CQL exceptions while searching the user records, which are
+  assigned with such tags.
+  This function "escapeSpecialCharactersInTagFilters" intends to escape the special characters
+  in filters of type "Tags"
+  Ref: https://issues.folio.org/browse/UIU-2995
+*/
+
 const escapeSpecialCharactersInTagFilters = (queryParams, resourceData) => {
   const newResourceData = cloneDeep(resourceData);
   let escapedFilters;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
[UIU-2995](https://issues.folio.org/browse/UIU-2995) - Mask/escape backslash and double quote in tag search
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Approach
Special characters like ",*,?,\ are allowed in creation of tags.
When such a tag is searched in users app via the "Tags" filter, an error like "QueryValidationException: ? wildcard not allowed in full text query string" and "QueryValidationException: * right truncation wildcard must be followed by space or end of string, but found .." are observed.

Hence, the tags filters are escaped before passing them to makeQueryFunction.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screencast
![chrome_KnP3FezMPz](https://github.com/folio-org/ui-users/assets/104053200/24389ad4-cf6d-402f-8b88-7cb115a81efc)


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
