### PR TITLE
UIU-2993: Add the possibility to do "Claim returned" from action menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Correctly handle optional `X-Okapi-token` request header. Refs UIU-2977.
 * Fix bug with Edit form Expand/collapse all shortcuts not working. Refs UIU-2959.
 * Update patron groups retrieval in user search to hold `maxUnpagedResourceCount`. Refs UIU-2973.
+* Lost item fees not suspended when item is claimed returned from the ellipses in action menu. Refs UIU-2993.
 
 ## [10.0.3](https://github.com/folio-org/ui-users/tree/v10.0.3) (2023-10-23)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.1...v10.0.3)

--- a/src/routes/LoansListingContainer.js
+++ b/src/routes/LoansListingContainer.js
@@ -12,6 +12,32 @@ import { LoansListing } from '../views';
 
 class LoansListingContainer extends React.Component {
   static manifest = Object.freeze({
+    accounts: {
+      type: 'okapi',
+      records: 'accounts',
+      PUT: {
+        path: 'accounts/%{activeAccount.id}'
+      },
+      fetch: false,
+      accumulate: true,
+    },
+    feefineactions: {
+      type: 'okapi',
+      records: 'feefineactions',
+      path: 'feefineactions',
+      fetch: false,
+      accumulate: true,
+    },
+    loanstorage: {
+      type: 'okapi',
+      PUT: {
+        path: 'loan-storage/loans/%{activeLoanStorage.id}'
+      },
+      fetch: false,
+      accumulate: true,
+    },
+    activeAccount: {},
+    activeLoanStorage: {},
     query: {},
     selUser: {
       type: 'okapi',


### PR DESCRIPTION
## Purpose
When user clicks on "Claim returned" button from the action menu dropdown item status becomes "Claimed returned" but fee/fine status is not "Suspended claim returned" and Fees/fines incurred is not "Suspended".

## Approach
The issue happened because we did not have access to some data from manifest and as a result a few additional requests were not executed.
I extended already existing manifest to have all necessary "mutators" and "resources".

## Refs
[UIU-2993](https://issues.folio.org/browse/UIU-2993)