### PR TITLE
UIU-2987-poppy-dcb - Hide all actionalble buttons on user details pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [10.0.5] IN PROGRESS
 
 * Disable open loan actions for virtual patron. Refs UIU-2964.
+* Hide all actionalble buttons on user details pane for DCB Virtual user. Refs UIU-2987.
 
 ## [10.0.4](https://github.com/folio-org/ui-users/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.3...v10.0.4)

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.js
@@ -168,6 +168,9 @@ class PatronBlock extends React.Component {
       location,
       resources,
     } = this.props;
+
+    const user = resources?.selUser?.records[0];
+    
     const {
       sortOrder,
       sortDirection,

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.js
@@ -16,6 +16,7 @@ import {
 } from '@folio/stripes/components';
 import { stripesConnect } from '@folio/stripes/core';
 
+import { isDcbUser } from '../../util';
 import css from './PatronBlock.css';
 
 const PATRON_BLOCKS_COLUMNS = {
@@ -37,6 +38,11 @@ class PatronBlock extends React.Component {
     expanded: PropTypes.bool,
     accordionId: PropTypes.string,
     patronBlocks: PropTypes.arrayOf(PropTypes.object),
+    resources: PropTypes.shape({
+      selUser: PropTypes.shape({
+        records: PropTypes.arrayOf(PropTypes.object),
+      }),
+    }),
     mutator: PropTypes.shape({
       activeRecord: PropTypes.shape({
         update: PropTypes.func,
@@ -160,6 +166,7 @@ class PatronBlock extends React.Component {
       patronBlocks,
       match: { params },
       location,
+      resources,
     } = this.props;
     const {
       sortOrder,
@@ -203,7 +210,7 @@ class PatronBlock extends React.Component {
         id={accordionId}
         onToggle={onToggle}
         label={title}
-        displayWhenOpen={displayWhenOpen}
+        displayWhenOpen={!isDcbUser(user) ? displayWhenOpen : null}
       >
         <Row><Col xs>{items}</Col></Row>
       </Accordion>

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.js
@@ -170,7 +170,7 @@ class PatronBlock extends React.Component {
     } = this.props;
 
     const user = resources?.selUser?.records[0];
-    
+
     const {
       sortOrder,
       sortDirection,

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.test.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import { act, screen } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
@@ -52,20 +52,36 @@ const props = {
 };
 
 describe('render ProxyPermissions component', () => {
-  beforeEach(() => {
-    renderPatronBlock(props);
-  });
   it('Component must be rendered', () => {
+    renderPatronBlock(props);
     expect(screen.getByText('ui-users.settings.patronBlocks')).toBeInTheDocument();
   });
   it('Clicking the patron row should redirect via history.push', async () => {
-    await userEvent.click(document.querySelector('[data-row-inner="0"]'));
+    renderPatronBlock(props);
+    await act(async () => userEvent.click(document.querySelector('[data-row-inner="0"]')));
     expect(mockRedirect).toHaveBeenCalled();
   });
-  /* Need to fix the bug UIU-2538 for the sorting to work so that this test case can be uncommented */
-
-  // it('checking for sort order', () => {
-  //   userEvent.click(document.querySelector('[id="clickable-list-column-blockedactions"]'));
-  //   expect(screen.getByText('Sample')).toBeInTheDocument();
-  // });
+  it('checking for sort order', () => {
+    userEvent.click(document.querySelector('[id="clickable-list-column-blockedactions"]'));
+    expect(screen.getByText('Sample')).toBeInTheDocument();
+  });
+  describe('when user is of type "dcb"', () => {
+    it('should not display "Create block" button', () => {
+      const alteredProps = {
+        ...props,
+        resources: {
+          selUser: {
+            records: [
+              {
+                personal: { lastName: 'DcbSystem' },
+                type: 'dcb'
+              }
+            ]
+          }
+        }
+      };
+      renderPatronBlock(alteredProps);
+      expect(screen.queryByText('Create block')).toBeNull();
+    });
+  });
 });

--- a/src/components/UserDetailSections/PatronBlock/PatronBlock.test.js
+++ b/src/components/UserDetailSections/PatronBlock/PatronBlock.test.js
@@ -62,6 +62,7 @@ describe('render ProxyPermissions component', () => {
     expect(mockRedirect).toHaveBeenCalled();
   });
   it('checking for sort order', () => {
+    renderPatronBlock(props);
     userEvent.click(document.querySelector('[id="clickable-list-column-blockedactions"]'));
     expect(screen.getByText('Sample')).toBeInTheDocument();
   });

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
+import { get } from 'lodash';
 
 import {
   Row,
@@ -20,6 +21,7 @@ import {
   refundStatuses,
   refundClaimReturned,
 } from '../../../constants';
+import { isDcbUser } from '../../util';
 
 
 /**
@@ -39,6 +41,7 @@ const UserAccounts = ({
   },
   resources,
 }) => {
+  const user = get(resources, ['selUser', 'records', '0']);
   const [totals, setTotals] = useState({
     openAccountsCount: 0,
     closedAccountsCount: 0,
@@ -98,7 +101,7 @@ const UserAccounts = ({
       onToggle={onToggle}
       label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.accounts.title.feeFine" /></Headline>}
       displayWhenClosed={displayWhenClosed}
-      displayWhenOpen={displayWhenOpen}
+      displayWhenOpen={!isDcbUser(user) ? displayWhenOpen : null}
     >
       {accountsLoaded ?
         <Row>

--- a/src/components/UserDetailSections/UserAccounts/UserAccounts.test.js
+++ b/src/components/UserDetailSections/UserAccounts/UserAccounts.test.js
@@ -60,4 +60,39 @@ describe('Render UserAccounts component', () => {
     renderUserAccounts(props(false));
     expect(document.querySelector('[id="numOpenAccounts"]')).toBeNull();
   });
+  describe('when user is of type dcb', () => {
+    it('should not display "Create fee/fine" button', () => {
+      const alteredProps = {
+        accounts : {
+          records: [accounts],
+          isPending: false,
+        },
+        accordionId: 'UserAccounts',
+        expanded: true,
+        onToggle: onToggleMock,
+        location: {
+          search: '',
+          path: '/userAccounts'
+        },
+        match: {
+          params: {
+            id: ''
+          }
+        },
+        resources: {
+          ...resources,
+          selUser: {
+            records: [
+              {
+                personal: { lastName: 'DcbSystem' },
+                type: 'dcb'
+              }
+            ]
+          },
+        },
+      };
+      renderUserAccounts(alteredProps);
+      expect(screen.queryByText('Create fee/fine')).toBeNull();
+    });
+  });
 });

--- a/src/components/UserDetailSections/UserRequests/UserRequests.js
+++ b/src/components/UserDetailSections/UserRequests/UserRequests.js
@@ -21,6 +21,7 @@ import {
   getOpenRequestStatusesFilterString,
   getClosedRequestStatusesFilterString,
   getRequestUrl,
+  isDcbUser,
 } from '../../util';
 
 /**
@@ -107,12 +108,10 @@ class UserRequests extends React.Component {
       expanded,
       onToggle,
       accordionId,
-      user: {
-        barcode,
-        id,
-      },
+      user,
       resources
     } = this.props;
+    const { barcode, id } = user;
     const openRequestsTotal = _.get(resources.openRequestsCount, ['records', '0', 'totalRecords'], 0);
     const closedRequestsTotal = _.get(resources.closedRequestsCount, ['records', '0', 'totalRecords'], 0);
     const openRequestsCount = (_.get(resources.openRequestsCount, ['isPending'], true)) ? -1 : openRequestsTotal;
@@ -142,7 +141,7 @@ class UserRequests extends React.Component {
         onToggle={onToggle}
         label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.requests.title" /></Headline>}
         displayWhenClosed={displayWhenClosed}
-        displayWhenOpen={displayWhenOpen}
+        displayWhenOpen={!isDcbUser(user) ? displayWhenOpen : null}
       >
         {requestsLoaded ?
           <List

--- a/src/components/UserDetailSections/UserRequests/UserRequests.test.js
+++ b/src/components/UserDetailSections/UserRequests/UserRequests.test.js
@@ -126,4 +126,20 @@ describe('Render User Requests component', () => {
     renderUserRequests(props(false));
     expect(screen.getByText('List Component')).toBeInTheDocument();
   });
+
+  describe('when user is of type dcb', () => {
+    it('should not display "Create Request" button', () => {
+      const alteredProps = (perm) => {
+        return {
+          ...props(perm),
+          user: {
+            personal: { lastName: 'DcbSystem' },
+            type: 'dcb'
+          },
+        };
+      };
+      renderUserRequests(alteredProps(true));
+      expect(screen.queryByText('Create Request')).toBeNull();
+    });
+  });
 });

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -57,6 +57,7 @@ import { getFormAddressList } from '../../components/data/converters/address';
 import {
   getFullName,
   isAffiliationsEnabled,
+  isDcbUser,
 } from '../../components/util';
 import RequestFeeFineBlockButtons from '../../components/RequestFeeFineBlockButtons';
 import { departmentsShape } from '../../shapes';
@@ -430,6 +431,7 @@ class UserDetail extends React.Component {
     const accounts = get(resources, ['accounts', 'records'], []);
     const loans = get(resources, ['loanRecords', 'records'], []);
     const isShadowUser = user?.type === USER_TYPES.SHADOW;
+    const isVirtualPatron = isDcbUser(user);
 
     const feesFinesReportData = {
       user,
@@ -446,7 +448,7 @@ class UserDetail extends React.Component {
       || this.props.stripes.hasPerm('ui-requests.all')
       || this.props.stripes.hasPerm('ui-users.delete,ui-users.opentransactions');
 
-    if (showActionMenu) {
+    if (showActionMenu && !isVirtualPatron) {
       return (
         <>
           {!isShadowUser && (
@@ -624,6 +626,7 @@ class UserDetail extends React.Component {
     const isAffiliationsVisible = isAffiliationsEnabled(user);
 
     const isShadowUser = user?.type === USER_TYPES.SHADOW;
+    const isVirtualPatron = isDcbUser(user);
     const showPatronBlocksSection = hasPatronBlocksPermissions && !isShadowUser;
 
     if (this.userNotFound()) {
@@ -862,6 +865,7 @@ class UserDetail extends React.Component {
                       pathToNoteCreate="/users/notes/new"
                       pathToNoteDetails="/users/notes"
                       hideAssignButton
+                      hideNewButton={isVirtualPatron}
                     />
                   </IfPermission>
                 </IfInterface>

--- a/src/views/UserDetail/UserDetail.test.js
+++ b/src/views/UserDetail/UserDetail.test.js
@@ -332,4 +332,11 @@ describe('UserDetail', () => {
       expect(screen.queryByText('ui-users.patronBlocks')).toBeNull();
     });
   });
+
+  describe('when user type is dcb', () => {
+    it('should not render action menu', () => {
+      renderUserDetail(stripes, { resources: { ...resources, selUser: { records: [{ ...resources.selUser.records[0], type: 'dcb', personal: { lastName: 'DcbSystem' } }] } } });
+      expect(screen.queryByText('Actions')).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
Link to PR with master branch as target - https://github.com/folio-org/ui-users/pull/2592