### PR TITLE
UIU-3010: Fix wrong date in Cash-Drawer-Reconciliation-Report.pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix problem with Date field in User app reports does not populate when a first entry was cleared. Refs UIU-2991.
 * Hide all actionalble buttons on user details pane for DCB Virtual user. Refs UIU-2987.
 * Open loan page modifications for a virtual patron. Refs UIU-2988.
+* Fix wrong date in Cash-Drawer-Reconciliation-Report.pdf. Refs UIU-3010.
 
 ## [10.0.4](https://github.com/folio-org/ui-users/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.3...v10.0.4)

--- a/src/components/data/reports/CashDrawerReconciliationReport.js
+++ b/src/components/data/reports/CashDrawerReconciliationReport.js
@@ -22,13 +22,17 @@ class CashDrawerReconciliationReport {
   }
 
   buildHeader() {
+    const DEFAULT_DATE_OPTIONS = {
+      timeZone: 'UTC',
+    };
+
     return this.formatMessage(
       { id: 'ui-users.reports.cash.header' },
       {
         servicePoint: this.headerData.createdAt,
         sources: this.headerData.sources,
-        startDate: this.formatDate(this.headerData.startDate),
-        endDate: this.formatDate(this.headerData.endDate) || moment().format('YYYY/MM/DD') // if no endDate then show date='today'
+        startDate: this.formatDate(this.headerData.startDate, DEFAULT_DATE_OPTIONS),
+        endDate: this.formatDate(this.headerData.endDate, DEFAULT_DATE_OPTIONS) || moment().format('YYYY/MM/DD') // if no endDate then show date='today'
       }
     );
   }


### PR DESCRIPTION
## Purpose
Fix wrong date in Cash-Drawer-Reconciliation-Report.pdf

## Approach 
We should have the same date that we select in Datepicker

## Refs
https://issues.folio.org/browse/UIU-3010