### PR TITLE
UIU-3013 - Refactor feefines css away from color() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Display item title and barcode as text when the item is dcb virtual item. Refs UIU-2966.
 * Fix wrong date in Cash-Drawer-Reconciliation-Report.pdf. Refs UIU-3010.
 * Conditionally hide actions on closed loan records for DCB Circulation. Refs UIU-2989.
+* Refactor CSS away from `color()` function. Refs UIU-3013.
 
 ## [10.0.4](https://github.com/folio-org/ui-users/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.3...v10.0.4)

--- a/src/components/Accounts/ChargeFeeFine/index.css
+++ b/src/components/Accounts/ChargeFeeFine/index.css
@@ -1,7 +1,7 @@
 @import "@folio/stripes-components/lib/variables.css";
 
-.root {  
-  background-color: color(#fcfcfc contrast(100%) blend(#fcfcfc 90%));
+.root {
+  background-color: color-mix(in oklch, oklch(from #fcfcfc calc(l - 0.7) c h) 10%, #fcfcfc);
   border-radius: 6px;
   padding: 10px 30px;
   font-weight: var(--text-weight-bold);


### PR DESCRIPTION
https://issues.folio.org/browse/UIU-3013

Minor CSS refactor as we strive to eliminate a non-spec postcss- dependency. This doesn't change appearance, just implementation. The spec for `color()` has changed - and native `color()` does not function in the same way that we use it in a number of places - in this case, to obtain a contrasted version and then blend it with the original...

`oklch` colorspace is a new color space that assures better, more accessible outcomes to color adjustment.
CSS color-adjustment syntax `(from ...)` is a new feature that allows for adjustment of pre-existing colors.
`color-mix()` is a native function that can be used to blend colors.