### PR TITLE
revert effective call number sorting change

### DIFF
--- a/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
+++ b/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
@@ -85,7 +85,6 @@ export default function getListDataFormatter(
       key:'callNumber',
       view: formatMessage({ id: 'ui-users.loans.details.effectiveCallNumber' }),
       formatter: loan => (<div data-test-list-call-numbers>{effectiveCallNumber(loan)}</div>),
-      sorter:  loan => effectiveCallNumber(loan),
     },
     'loanPolicy': {
       key:'loanPolicy',


### PR DESCRIPTION
Revert UIU-3002 changes.

## Purpose
Accidently, effective call number sorting bug changes were pushed to master. This PR is to revert those changes from master.
The needful changes will be propagated via a new PR.