### PR TITLE
UIU-3054 use users-keycloak interface for central-tenant permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Hide all actionable buttons on user details pane for DCB Virtual user. Refs UIU-2987.
 * Leverage `users-keycloak` interface endpoints for user data when available.
 * Fix problem with `Reset password email sent` , application points to  bl-users endpoint, even if `users-keycloak` interface provided. Refs UIU-3031.
+* Retrieve user's central-tenant permission from `users-keycloak` endpoints when available. Refs UIU-3054.
 
 ## [10.0.4](https://github.com/folio-org/ui-users/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.3...v10.0.4)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0 7.0",
       "notes": "2.0 3.0",
-      "request-storage": "2.5 3.0 4.0 5.0 6.0"
+      "request-storage": "2.5 3.0 4.0 5.0 6.0",
+      "users-keycloak": "1.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
When the `users-keycloak` interface is present, use its endpoints to retrieve the logged-in user's permissions in the central tenant.

Refs [UIU-3054](https://folio-org.atlassian.net/browse/UIU-3054)
