### PR TITLE
UIU-3061, UIU-3063 omit permissions accordions/queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Hide all actionable buttons on user details pane for DCB Virtual user. Refs UIU-2987.
 * Leverage `users-keycloak` interface endpoints for user data when available.
 * Fix problem with `Reset password email sent` , application points to  bl-users endpoint, even if `users-keycloak` interface provided. Refs UIU-3031.
+* Omit permissions accordions and queries when `roles` interface is present. Refs UIU-3061, UIU-3062.
 
 ## [10.0.4](https://github.com/folio-org/ui-users/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.3...v10.0.4)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0 7.0",
       "notes": "2.0 3.0",
-      "request-storage": "2.5 3.0 4.0 5.0 6.0"
+      "request-storage": "2.5 3.0 4.0 5.0 6.0",
+      "roles": "1.0"
     },
     "permissionSets": [
       {

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -142,9 +142,19 @@ class UserRecordContainer extends React.Component {
       type: 'okapi',
       throwErrors: false,
       POST: {
-        path: 'perms/users',
+        path: (queryParams, pathComponents, resourceData, config, props) => {
+          if (props.stripes.hasInterface('roles')) {
+            return undefined;
+          }
+          return 'perms/users';
+        }
       },
-      path: 'perms/users/:{id}',
+      path: (queryParams, pathComponents, resourceData, config, props) => {
+        if (props.stripes.hasInterface('roles')) {
+          return undefined;
+        }
+        return 'perms/users/:{id}';
+      },
       params: { full: 'true', indexField: 'userId' },
     },
     // NOTE: 'indexField', used as a parameter in the userPermissions paths,
@@ -158,17 +168,37 @@ class UserRecordContainer extends React.Component {
       resourceShouldRefresh: true,
       DELETE: {
         pk: 'permissionName',
-        path: 'perms/users/:{id}/permissions',
+        path: (queryParams, pathComponents, resourceData, config, props) => {
+          if (props.stripes.hasInterface('roles')) {
+            return undefined;
+          }
+          return 'perms/users/:{id}/permissions';
+        },
         params: { indexField: 'userId' },
       },
       GET: {
-        path: 'perms/users/:{id}/permissions',
+        path: (queryParams, pathComponents, resourceData, config, props) => {
+          if (props.stripes.hasInterface('roles')) {
+            return undefined;
+          }
+          return 'perms/users/:{id}/permissions';
+        },
         params: { full: 'true', indexField: 'userId' },
       },
       PUT: {
-        path: 'perms/users/%{permUserId}',
+        path: (queryParams, pathComponents, resourceData, config, props) => {
+          if (props.stripes.hasInterface('roles')) {
+            return undefined;
+          }
+          return 'perms/users/%{permUserId}';
+        },
       },
-      path: 'perms/users/:{id}/permissions',
+      path: (queryParams, pathComponents, resourceData, config, props) => {
+        if (props.stripes.hasInterface('roles')) {
+          return undefined;
+        }
+        return 'perms/users/:{id}/permissions';
+      },
       params: { indexField: 'userId' },
     },
     settings: {

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -211,6 +211,19 @@ class UserDetail extends React.Component {
     this._isMounted = false;
   }
 
+  /**
+   * showPermissionsAccordion
+   * Return true unless the `roles` interface is present; then return false.
+   * When `roles` is present, this indicates access management is handled
+   * by keycloak; thus, roles, policies, and capabilites are used to manage
+   * access, not the legacy permissions system.
+   *
+   * @returns boolean true unless the `roles` interface is present
+   */
+  showPermissionsAccordion = () => {
+    return !this.props.stripes.hasInterface('roles');
+  };
+
   getUser = () => {
     const { resources, match: { params: { id } } } = this.props;
     const selUser = (resources.selUser || {}).records || [];
@@ -829,16 +842,18 @@ class UserDetail extends React.Component {
                   )
                 }
 
-                <IfPermission perm="perms.users.get">
-                  <IfInterface name="permissions" version="5.0">
-                    <UserPermissions
-                      expanded={sections.permissionsSection}
-                      onToggle={this.handleSectionToggle}
-                      accordionId="permissionsSection"
-                      {...this.props}
-                    />
-                  </IfInterface>
-                </IfPermission>
+                { this.showPermissionsAccordion() &&
+                  <IfPermission perm="perms.users.get">
+                    <IfInterface name="permissions" version="5.0">
+                      <UserPermissions
+                        expanded={sections.permissionsSection}
+                        onToggle={this.handleSectionToggle}
+                        accordionId="permissionsSection"
+                        {...this.props}
+                      />
+                    </IfInterface>
+                  </IfPermission>
+                }
 
                 <IfPermission perm="inventory-storage.service-points.collection.get,inventory-storage.service-points-users.collection.get">
                   <IfInterface name="service-points-users" version="1.0">

--- a/src/views/UserDetail/UserDetail.test.js
+++ b/src/views/UserDetail/UserDetail.test.js
@@ -119,10 +119,11 @@ jest.mock(
     ContactInfo: jest.fn(() => null),
     ProxyPermissions: jest.fn(() => null),
     PatronBlock: jest.fn(() => null),
-    UserPermissions: jest.fn(() => null),
+    UserPermissions: jest.fn(() => <div>Permissions accordion</div>),
     UserLoans: jest.fn(() => null),
     UserRequests: jest.fn(() => null),
     UserAccounts: jest.fn(() => null),
+    UserAffiliations: jest.fn(() => null),
     UserServicePoints: jest.fn(() => null),
   })
 );
@@ -280,6 +281,23 @@ describe('UserDetail', () => {
     test('should render checkDelete button in action menu ', async () => {
       renderUserDetail(stripes);
       expect(screen.getByRole('button', { name: 'ui-users.details.checkDelete' })).toBeVisible();
+    });
+
+    describe('permissions', () => {
+      it('shows permissions accordion in legacy mode', async () => {
+        stripes.hasInterface = () => false;
+        renderUserDetail(stripes);
+        expect(screen.getByText('Permissions accordion')).toBeTruthy();
+      });
+
+      it('omits permissions pane when "roles" interface is present', async () => {
+        stripes.hasInterface = (i) => {
+          return (i === 'roles');
+        };
+
+        renderUserDetail(stripes);
+        expect(screen.queryByText('Permissions accordion')).toBeFalsy();
+      });
     });
 
     describe('click checkDelete button', () => {

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -285,6 +285,19 @@ class UserForm extends React.Component {
     }
   }
 
+  /**
+   * showPermissionsAccordion
+   * Return true unless the `roles` interface is present; then return false.
+   * When `roles` is present, this indicates access management is handled
+   * by keycloak; thus, roles, policies, and capabilites are used to manage
+   * access, not the legacy permissions system.
+   *
+   * @returns boolean true unless the `roles` interface is present
+   */
+  showPermissionsAccordion = () => {
+    return !this.props.stripes.hasInterface('roles');
+  };
+
   render() {
     const {
       initialValues,
@@ -404,12 +417,15 @@ class UserForm extends React.Component {
                           fullName={fullName}
                         />
                       )
-                     }
-                      <TenantsPermissionsAccordion
-                        form={form}
-                        initialValues={initialValues}
-                        setButtonRef={this.setButtonRef}
-                      />
+                      }
+                      {
+                      this.showPermissionsAccordion() &&
+                        <TenantsPermissionsAccordion
+                          form={form}
+                          initialValues={initialValues}
+                          setButtonRef={this.setButtonRef}
+                        />
+                      }
                       <EditServicePoints
                         accordionId="servicePoints"
                         setButtonRef={this.setButtonRef}

--- a/test/jest/__mock__/stripesSmartComponent.mock.js
+++ b/test/jest/__mock__/stripesSmartComponent.mock.js
@@ -48,6 +48,7 @@ jest.mock('@folio/stripes/smart-components', () => {
     AddressEditList: () => <div data-testid="address-edit-list">AddressEditList</div>,
     ChangeDueDateDialog: (props) => <div data-testid="change-duedate-dialog">ChangeDueDateDialog</div>,
     ControlledVocab: jest.fn(({ validate }) => <div data-testid="controlled-vocab">ControlledVocab</div>),
+    EditCustomFieldsRecord: () => <div>EditCustomFieldsRecord accordion</div>,
     DueDatePicker: () => <div data-testid="due-date-picker">DueDatePicker</div>,
     LocationLookup: () => <div>LocationLookup</div>,
     NotePopupModal: () => <div>NotePopupModal</div>,
@@ -75,7 +76,7 @@ jest.mock('@folio/stripes/smart-components', () => {
         if(props.onBeforeSave){
         props.onBeforeSave(data);
       }
-        const values = { 
+        const values = {
           name: 'test1'
         };
         props.validate(values);


### PR DESCRIPTION
When the `roles` interface is present, indicating the legacy permissions system has been replaced, do not show the permissions accordions on the user-details or user-edit panes, and do not query any permissions-related endpoints.

Refs [UIU-3061](https://folio-org.atlassian.net/browse/UIU-3061), [UIU-3063](https://folio-org.atlassian.net/browse/UIU-3063)
