### PR TITLE
UIU-3068: add users-keycloak perms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Hide all actionable buttons on user details pane for DCB Virtual user. Refs UIU-2987.
 * Leverage `users-keycloak` interface endpoints for user data when available.
 * Fix problem with `Reset password email sent` , application points to  bl-users endpoint, even if `users-keycloak` interface provided. Refs UIU-3031.
-* Add `users-keycloak` permissions. Refs MODROLSKC-152
+* Add `users-keycloak` permissions. Refs UIU-3068
 
 ## [10.0.4](https://github.com/folio-org/ui-users/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.3...v10.0.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Hide all actionable buttons on user details pane for DCB Virtual user. Refs UIU-2987.
 * Leverage `users-keycloak` interface endpoints for user data when available.
 * Fix problem with `Reset password email sent` , application points to  bl-users endpoint, even if `users-keycloak` interface provided. Refs UIU-3031.
+* Add `users-keycloak` permissions. Refs MODROLSKC-152
 
 ## [10.0.4](https://github.com/folio-org/ui-users/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.3...v10.0.4)

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
           "addresstypes.collection.get",
           "users.collection.get",
           "users.item.get",
+          "users-keycloak.collection.get",
+          "users-keycloak.item.get",
           "usergroups.collection.get",
           "configuration.entries.collection.get",
           "user-settings.custom-fields.collection.get",
@@ -89,6 +91,7 @@
           "ui-users.view",
           "users-bl.item.put",
           "users.item.put",
+          "users-keycloak.item.put",
           "tags.collection.get",
           "tags.item.post",
           "circulation-storage.request-preferences.item.post",
@@ -122,6 +125,7 @@
           "ui-users.edit",
           "users-bl.item.post",
           "users.item.post",
+          "users-keycloak.item.post",
           "perms.users.item.post",
           "login.item.post"
         ],
@@ -417,7 +421,8 @@
           "payments.item.delete",
           "payments.item.post",
           "payments.item.put",
-          "users.collection.get"
+          "users.collection.get",
+          "users-keycloak.collection.get"
         ],
         "visible": true
       },
@@ -860,7 +865,8 @@
           "login.credentials-existence.get",
           "ui-users.view",
           "ui-users.edit",
-          "users-bl.password-reset-link.generate"
+          "users-bl.password-reset-link.generate",
+          "users-keycloak.password-reset-link.generate"
         ],
         "visible": true
       },


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
https://folio-org.atlassian.net/browse/UIU-3068
Add newly added users-keycloak permissions to the package.json 

## Approach
- add users-keycloak related permissions

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
