### PR TITLE
sync settings pages with master, repairing tests

### DIFF
--- a/src/settings/DepartmentsSettings.js
+++ b/src/settings/DepartmentsSettings.js
@@ -7,6 +7,10 @@ import {
 import { NoValue } from '@folio/stripes/components';
 import { ControlledVocab } from '@folio/stripes/smart-components';
 import { useStripes } from '@folio/stripes/core';
+import { getSourceSuppressor } from '@folio/stripes/util';
+
+import { RECORD_SOURCE } from '../constants';
+
 
 const validate = (item, index, items) => {
   const filteredDepartments = items.filter((department, i) => i !== index);
@@ -30,7 +34,7 @@ const validate = (item, index, items) => {
   return errors;
 };
 
-const suppress = () => false;
+const suppress = getSourceSuppressor(RECORD_SOURCE.CONSORTIUM);
 
 const DepartmentsSettings = () => {
   const { formatMessage } = useIntl();

--- a/src/settings/PatronGroupsSettings.js
+++ b/src/settings/PatronGroupsSettings.js
@@ -5,10 +5,12 @@ import {
   injectIntl,
 } from 'react-intl';
 import { ControlledVocab } from '@folio/stripes/smart-components';
-import { withStripes } from '@folio/stripes/core';
+import { stripesConnect } from '@folio/stripes/core';
+import { getSourceSuppressor } from '@folio/stripes/util';
 
-const suppress = () => false;
-const actionSuppressor = { delete: suppress, edit: suppress };
+import { RECORD_SOURCE } from '../constants';
+
+const suppress = getSourceSuppressor(RECORD_SOURCE.CONSORTIUM);
 
 class PatronGroupsSettings extends React.Component {
   static propTypes = {
@@ -62,7 +64,6 @@ class PatronGroupsSettings extends React.Component {
         label={intl.formatMessage({ id: 'ui-users.information.patronGroups' })}
         labelSingular={intl.formatMessage({ id: 'ui-users.information.patronGroup' })}
         objectLabel={<FormattedMessage id="ui-users.information.patronGroup.users" />}
-        actionSuppressor={actionSuppressor}
         visibleFields={['group', 'desc', 'expirationOffsetInDays']}
         hiddenFields={['numberOfObjects']}
         columnMapping={{
@@ -75,9 +76,13 @@ class PatronGroupsSettings extends React.Component {
         id="patrongroups"
         sortby="group"
         canCreate={hasCreatePerm}
+        actionSuppressor={{
+          delete: item => !hasDeletePerm || suppress(item),
+          edit: (item) => !hasEditPerm || suppress(item),
+        }}
       />
     );
   }
 }
 
-export default injectIntl(withStripes(PatronGroupsSettings));
+export default injectIntl(stripesConnect(PatronGroupsSettings));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,6 +3,7 @@
 
 
 "@aashutoshrathi/word-wrap@^1.2.3", "@aashutoshrathi/word-wrap@^1.2.6", "word-wrap@npm:@aashutoshrathi/word-wrap@^1.2.6":
+  name word-wrap
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
@@ -9449,7 +9450,7 @@ postcss-calc@^9.0.1:
     postcss-selector-parser "^6.0.11"
     postcss-value-parser "^4.2.0"
 
-"postcss-color-function@github:folio-org/postcss-color-function":
+postcss-color-function@folio-org/postcss-color-function:
   version "4.1.0"
   resolved "https://codeload.github.com/folio-org/postcss-color-function/tar.gz/c128aad740ae740fb571c4b6493f467dd51efe85"
   dependencies:


### PR DESCRIPTION
`DepartmentSettings` and `PatronGroupsSettings` were tweaked in a8f397f213472b9c9558430330ddcce1375a875b to avoid ECS-related functionality that was not yet committed in `@folio/stripes-util` when this work began. But now it has been committed, and we can undo this change, bringing them back into sync, and restoring their tests.
