### PR TITLE
UIU-3069 - Add optional chaining in AddServicePointModal in order to safely access assignedServicePoints from props.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Reset rotation when profile picture upload is canceled. Refs UIU-3071.
 * Restrict profile picture upload exceeding max file size from profile picture configuration. Refs UIU-3047.
 * Profile Pictures - basic error handling. Refs UIU-3070.
+* Add optional chaining in `AddServicePointModal` in order to safely access `assignedServicePoints` from props. Refs UIU-3069.
 
 ## [10.0.4](https://github.com/folio-org/ui-users/tree/v10.0.4) (2023-11-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.3...v10.0.4)

--- a/src/components/AddServicePointModal/AddServicePointModal.js
+++ b/src/components/AddServicePointModal/AddServicePointModal.js
@@ -33,7 +33,7 @@ class AddServicePointModal extends React.Component {
   }
 
   static getDerivedStateFromProps(props, state) {
-    const assignedServicePointIds = props.assignedServicePoints.map(({ id }) => id);
+    const assignedServicePointIds = props.assignedServicePoints?.map(({ id }) => id);
     const selectionIds = Object.keys(state.selection).filter(id => state.selection[id]);
 
     if (!isEqual(assignedServicePointIds, selectionIds)) {


### PR DESCRIPTION
## Purpose
[UIU-3069](https://folio-org.atlassian.net/browse/UIU-3069) - AddServicePointModal may throw NPE on props.assignedServicePoints.map

## Approach
Add optional chaining in AddServicePointModal in order to safely access assignedServicePoints from props.


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
