### PR TITLE
include @aashutoshrathi/word-wrap as a dev-dep

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -58,7 +58,7 @@ jobs:
           JOB_ID: ${{ github.run_number }}
 
       - name: Run yarn install
-        run: yarn install
+        run: yarn install --ignore-scripts --frozen-lockfile
 
       - name: Run yarn list
         run: yarn list --pattern @folio

--- a/package.json
+++ b/package.json
@@ -1070,6 +1070,7 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-users ./translations/ui-users/compiled"
   },
   "devDependencies": {
+    "@aashutoshrathi/word-wrap": "^1.2.6",
     "@babel/core": "^7.21.4",
     "@babel/eslint-parser": "^7.15.0",
     "@babel/plugin-proposal-class-properties": "^7.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,8 @@
 # yarn lockfile v1
 
 
-"@aashutoshrathi/word-wrap@^1.2.3", "word-wrap@npm:@aashutoshrathi/word-wrap@^1.2.6":
+"@aashutoshrathi/word-wrap@^1.2.3", "@aashutoshrathi/word-wrap@^1.2.6", "word-wrap@npm:@aashutoshrathi/word-wrap@^1.2.6":
+  name word-wrap
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
@@ -9645,7 +9646,7 @@ postcss-calc@^9.0.1:
     postcss-selector-parser "^6.0.11"
     postcss-value-parser "^4.2.0"
 
-"postcss-color-function@github:folio-org/postcss-color-function":
+postcss-color-function@folio-org/postcss-color-function:
   version "4.1.0"
   resolved "https://codeload.github.com/folio-org/postcss-color-function/tar.gz/c128aad740ae740fb571c4b6493f467dd51efe85"
   dependencies:


### PR DESCRIPTION
Include `@aashutoshrathi/word-wrap` as a dev-dep in addition to including it in `resolutions` where it is used as an alias to replace the (unmaintained) `word-wrap`. Just like peer-deps, yarn does not satisfy resolutions-deps, so if we want that reference in `resolutions` to be resolvable, we need to _actually_ depend on it elsewhere. `word-wrap` is a transitive dep via eslint > optionator, so I added `@aashutoshrathi/word-wrap` as a dev-dep. 

Some fool called @zburke introduced this bug -- trying to satisfy a resolutions-alias with a module that isn't included as a dependency -- in #2512. How did that ever work? What an idiot. Probably he added the dep manually, then added the alias, then manually removed the dep. Let this be a lesson to us all: always use tools to manipulate `package.json`, and always run a clean install/lint/test before committing. 

Additionally, unrelated to this change but important for the parent UIU-3072 PR: it is important to leave `--frozen-lockfile` in the `Run yarn install` instructions. Without it, there's not much point in committing `yarn.lock` because you would be free to update `package.json` by changing versions or even adding new dependencies and CI wouldn't warn you that `yarn.lock` and `package.json` were out of sync. This breaks the promise of reprodicble builds that committing `yarn.lock` provides.
