### PR TITLE
don't work so hard; CVE-2023-26115 was fixed upstream

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -58,7 +58,7 @@ jobs:
           JOB_ID: ${{ github.run_number }}
 
       - name: Run yarn install
-        run: yarn install
+        run: yarn install --ignore-scripts --frozen-lockfile
 
       - name: Run yarn list
         run: yarn list --pattern @folio

--- a/package.json
+++ b/package.json
@@ -1070,6 +1070,7 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-users ./translations/ui-users/compiled"
   },
   "devDependencies": {
+    "@aashutoshrathi/word-wrap": "^1.2.6",
     "@babel/core": "^7.21.4",
     "@babel/eslint-parser": "^7.15.0",
     "@babel/plugin-proposal-class-properties": "^7.13.0",

--- a/package.json
+++ b/package.json
@@ -1070,7 +1070,6 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-users ./translations/ui-users/compiled"
   },
   "devDependencies": {
-    "@aashutoshrathi/word-wrap": "^1.2.6",
     "@babel/core": "^7.21.4",
     "@babel/eslint-parser": "^7.15.0",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
@@ -1131,8 +1130,5 @@
   },
   "optionalDependencies": {
     "@folio/plugin-find-user": "^7.0.0"
-  },
-  "resolutions": {
-    "word-wrap": "npm:@aashutoshrathi/word-wrap@^1.2.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@aashutoshrathi/word-wrap@^1.2.3":
+"@aashutoshrathi/word-wrap@^1.2.3", "@aashutoshrathi/word-wrap@^1.2.6":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,8 @@
 # yarn lockfile v1
 
 
-"@aashutoshrathi/word-wrap@^1.2.3", "word-wrap@npm:@aashutoshrathi/word-wrap@^1.2.6":
+"@aashutoshrathi/word-wrap@^1.2.3", "@aashutoshrathi/word-wrap@^1.2.6", "word-wrap@npm:@aashutoshrathi/word-wrap@^1.2.6":
+  name word-wrap
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
@@ -9645,7 +9646,7 @@ postcss-calc@^9.0.1:
     postcss-selector-parser "^6.0.11"
     postcss-value-parser "^4.2.0"
 
-"postcss-color-function@github:folio-org/postcss-color-function":
+postcss-color-function@folio-org/postcss-color-function:
   version "4.1.0"
   resolved "https://codeload.github.com/folio-org/postcss-color-function/tar.gz/c128aad740ae740fb571c4b6493f467dd51efe85"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,8 +2,7 @@
 # yarn lockfile v1
 
 
-"@aashutoshrathi/word-wrap@^1.2.3", "@aashutoshrathi/word-wrap@^1.2.6", "word-wrap@npm:@aashutoshrathi/word-wrap@^1.2.6":
-  name word-wrap
+"@aashutoshrathi/word-wrap@^1.2.3":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
@@ -9646,7 +9645,7 @@ postcss-calc@^9.0.1:
     postcss-selector-parser "^6.0.11"
     postcss-value-parser "^4.2.0"
 
-postcss-color-function@folio-org/postcss-color-function:
+"postcss-color-function@github:folio-org/postcss-color-function":
   version "4.1.0"
   resolved "https://codeload.github.com/folio-org/postcss-color-function/tar.gz/c128aad740ae740fb571c4b6493f467dd51efe85"
   dependencies:


### PR DESCRIPTION
We were subject to CVE-2023-26115 via a transitive vulnerability from eslint > optionator > word-wrap. [optionator noticed the same vulnerability](https://github.com/gkz/optionator/issues/44) and made the same fix in [`06fd3a`](https://github.com/gkz/optionator/commit/06fd3a54a9b22bd9a5938c416fd491da6ff9eef1) so the best thing we can do here is ... nothing.