### PR TITLE
UIU-3078: use Save & close button label stripes-component translation key 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [10.2.0] IN PROGRESS
 
+* UX consistency: Use Save & close button label stripes-component translation key. Refs UIU-3078.
 
 ## [10.1.0](https://github.com/folio-org/ui-users/tree/v10.1.0) (2024-03-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.4...v10.1.0)

--- a/src/components/AddServicePointModal/AddServicePointModal.js
+++ b/src/components/AddServicePointModal/AddServicePointModal.js
@@ -92,7 +92,7 @@ class AddServicePointModal extends React.Component {
           id="save-service-point-btn"
           onClick={this.onSaveAndClose}
         >
-          <FormattedMessage id="ui-users.saveAndClose" />
+          <FormattedMessage id="stripes-components.saveAndClose" />
         </Button>
         <Button
           onClick={this.onCancel}

--- a/src/components/AddServicePointModal/AddServicePointModal.test.js
+++ b/src/components/AddServicePointModal/AddServicePointModal.test.js
@@ -56,7 +56,7 @@ describe('AddServicePointModal Component', () => {
       expect(screen.getByText('Circ Desk 1')).toBeInTheDocument();
     });
     it('Checking Save and Cancel Operation', async () => {
-      await userEvent.click(screen.getByText('ui-users.saveAndClose'));
+      await userEvent.click(screen.getByText(/saveAndClose/i));
       expect(onSaveMock).toHaveBeenCalled();
       await userEvent.click(screen.getByText('stripes-core.button.cancel'));
       expect(onCancelMock).toHaveBeenCalled();

--- a/src/components/AffiliationsManager/AffiliationsManager.test.js
+++ b/src/components/AffiliationsManager/AffiliationsManager.test.js
@@ -75,7 +75,7 @@ describe('AffiliationsManager', () => {
     });
 
     it('should handle affiliations assignment when \'Save & close\' button was clicked', async () => {
-      await userEvent.click(await screen.findByText('ui-users.saveAndClose'));
+      await userEvent.click(await screen.findByText(/saveAndClose/));
 
       expect(defaultProps.onUpdateAffiliations).toHaveBeenCalled();
     });

--- a/src/components/AffiliationsManager/AffiliationsManagerModal/AffiliationsManagerModalFooter.js
+++ b/src/components/AffiliationsManager/AffiliationsManagerModal/AffiliationsManagerModalFooter.js
@@ -32,7 +32,7 @@ const AffiliationsManagerModalFooter = ({
         buttonStyle="primary"
         onClick={onSubmit}
       >
-        <FormattedMessage id="ui-users.saveAndClose" />
+        <FormattedMessage id="stripes-components.saveAndClose" />
       </Button>
     </Layout>
   );

--- a/src/components/EditSections/EditServicePoints/EditServicePoints.test.js
+++ b/src/components/EditSections/EditServicePoints/EditServicePoints.test.js
@@ -95,7 +95,7 @@ describe('Edit Service Points Component', () => {
     it('Add service points functionality ', async () => {
       await userEvent.click(document.querySelector('[id=add-service-point-btn]'));
       await userEvent.click(document.querySelector('[data-test-sp-modal-checkbox="7c5abc9f-f3d7-4856-b8d7-6712462ca007"]'));
-      await userEvent.click(screen.getByText('ui-users.saveAndClose'));
+      await userEvent.click(screen.getByText(/saveAndClose/));
       expect(onChangeMock).toHaveBeenCalled();
     });
     it('Remove service points functionality ', async () => {

--- a/src/components/EditSections/EditUserInfo/components/LocalFileModal/LocalFileModal.js
+++ b/src/components/EditSections/EditUserInfo/components/LocalFileModal/LocalFileModal.js
@@ -63,7 +63,7 @@ const LocalFileModal = ({ open, onClose, imageSrc, rotation, setRotation, onSave
           id="save-local-file-btn"
           onClick={handleSaveProfilePictureLocalFile}
         >
-          <FormattedMessage id="ui-users.saveAndClose" />
+          <FormattedMessage id="stripes-components.saveAndClose" />
         </Button>
         <Button
           onClick={handleClose}

--- a/src/components/EditSections/EditUserInfo/components/LocalFileModal/LocalFileModal.test.js
+++ b/src/components/EditSections/EditUserInfo/components/LocalFileModal/LocalFileModal.test.js
@@ -40,7 +40,7 @@ describe('LocalFileModal', () => {
     expect(screen.getByText('rotate')).toBeInTheDocument();
   });
   it('should call onSave', async () => {
-    const saveButton = screen.getByRole('button', { name: 'ui-users.saveAndClose' });
+    const saveButton = screen.getByRole('button', { name: /saveAndClose/ });
     await userEvent.click(saveButton);
 
     expect(props.setRotation).toHaveBeenCalled();

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -387,7 +387,7 @@ class PermissionsModal extends React.Component {
               buttonStyle="primary"
               onClick={this.onSave}
             >
-              <FormattedMessage id="ui-users.saveAndClose" />
+              <FormattedMessage id="stripes-components.saveAndClose" />
             </Button>
           </div>
         }

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.test.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.test.js
@@ -313,7 +313,7 @@ describe('PermissionsModal', () => {
     fireEvent.click(document.querySelector('[data-permission-name="ui-agreements.resources.edit"]'));
 
     // save
-    fireEvent.click(screen.getByText('ui-users.saveAndClose'));
+    fireEvent.click(screen.getByText(/saveAndClose/));
 
     // removes permission if clicked twice
     fireEvent.click(document.querySelector('[data-permission-name="ui-agreements.resources.edit"]'));
@@ -382,7 +382,7 @@ describe('PermissionsModal', () => {
 
     expect.assertions(2);
     await waitFor(() => expect(renderPermissionsModal(props)).toBeDefined());
-    fireEvent.click(screen.getByText('ui-users.saveAndClose'));
+    fireEvent.click(screen.getByText(/saveAndClose/));
     // Previously, saving a new set of permissions via the modal would delete
     // any invisible permissions that were assigned. Thus, we should have the
     // same number of (invisible) perms that we started with.

--- a/src/components/ReportModals/CashDrawerReportModal.js
+++ b/src/components/ReportModals/CashDrawerReportModal.js
@@ -85,7 +85,7 @@ const CashDrawerReportModal = (props) => {
         buttonStyle="primary"
         onClick={props.form.submit}
       >
-        <FormattedMessage id="ui-users.saveAndClose" />
+        <FormattedMessage id="stripes-components.saveAndClose" />
       </Button>
       <Button
         marginBottom0

--- a/src/components/ReportModals/FinancialTransactionsReportModal.js
+++ b/src/components/ReportModals/FinancialTransactionsReportModal.js
@@ -78,7 +78,7 @@ const FinancialTransactionsReportModal = (props) => {
         buttonStyle="primary"
         onClick={props.form.submit}
       >
-        <FormattedMessage id="ui-users.saveAndClose" />
+        <FormattedMessage id="stripes-components.saveAndClose" />
       </Button>
       <Button
         marginBottom0

--- a/src/components/ReportModals/RefundsReportModal.js
+++ b/src/components/ReportModals/RefundsReportModal.js
@@ -58,7 +58,7 @@ const RefundsReportModal = (props) => {
         buttonStyle="primary"
         onClick={props.form.submit}
       >
-        <FormattedMessage id="ui-users.saveAndClose" />
+        <FormattedMessage id="stripes-components.saveAndClose" />
       </Button>
       <Button
         data-test-refunds-report-cancel-btn

--- a/src/components/UserDetailSections/UserAffiliations/UserAffiliations.test.js
+++ b/src/components/UserDetailSections/UserAffiliations/UserAffiliations.test.js
@@ -114,10 +114,10 @@ describe('UserAffiliations', () => {
       checked: true,
     });
     expect(listOfAssignedTenants).toHaveLength(affiliations.length - 1);
-    const saveAndCloseButton = screen.getByText('ui-users.saveAndClose');
+    const saveAndCloseButton = screen.getByText(/saveAndClose/);
     await userEvent.click(saveAndCloseButton);
 
     expect(handleAssignment).toHaveBeenCalled();
-    expect(screen.queryByText('ui-users.saveAndClose')).toBeNull();
+    expect(screen.queryByText(/saveAndClose/)).toBeNull();
   });
 });

--- a/src/components/Wrappers/withAddInfo.js
+++ b/src/components/Wrappers/withAddInfo.js
@@ -50,7 +50,7 @@ const withAddInfo = WrappedComponent => class withAddInfoComponent extends React
             modalLabel={modalLabel}
             open={addInfoDialogOpen}
             onClose={this.hideAddInfoDialog}
-            confirmTag="ui-users.saveAndClose"
+            confirmTag="stripes-components.saveAndClose"
           />
         }
       </>

--- a/src/settings/patronBlocks/BlockTemplates/BlockTemplateForm.js
+++ b/src/settings/patronBlocks/BlockTemplates/BlockTemplateForm.js
@@ -90,7 +90,7 @@ function BlockTemplateForm(props) {
         marginBottom0
         disabled={pristine || submitting}
       >
-        <FormattedMessage id="ui-users.saveAndClose" />
+        <FormattedMessage id="stripes-components.saveAndClose" />
       </Button>
     );
 

--- a/src/settings/patronBlocks/BlockTemplates/BlockTemplateForm.test.js
+++ b/src/settings/patronBlocks/BlockTemplates/BlockTemplateForm.test.js
@@ -55,7 +55,7 @@ describe('BlockTemplateForm', () => {
   });
 
   it('should disable the save button when pristine or submitting', () => {
-    const saveButton = screen.getByRole('button', { name: 'ui-users.saveAndClose' });
+    const saveButton = screen.getByRole('button', { name: /saveAndClose/ });
     expect(saveButton).toBeDisabled();
     const templateInformationButton = screen.getByRole('button', { name: 'Icon (caret-up) ui-users.manualBlockTemplates.templateInformation' });
     userEvent.click(templateInformationButton);
@@ -72,7 +72,7 @@ describe('BlockTemplateForm', () => {
     expect(nameInput).toHaveValue('Test Block Template Enter Something');
     const ConfirmationButton = screen.getByRole('button', { name: 'Confirmation' });
     await userEvent.click(ConfirmationButton);
-    const saveButton = screen.getByRole('button', { name: 'ui-users.saveAndClose' });
+    const saveButton = screen.getByRole('button', { name: /saveAndClose/ });
     expect(saveButton).toBeEnabled();
     userEvent.click(saveButton);
   });

--- a/src/settings/permissions/PermissionSetForm.js
+++ b/src/settings/permissions/PermissionSetForm.js
@@ -134,7 +134,7 @@ class PermissionSetForm extends React.Component {
         marginBottom0
         disabled={(pristine || submitting)}
       >
-        <FormattedMessage id="ui-users.saveAndClose" />
+        <FormattedMessage id="stripes-components.saveAndClose" />
       </Button>
     );
 

--- a/src/settings/permissions/PermissionSetForm.test.js
+++ b/src/settings/permissions/PermissionSetForm.test.js
@@ -44,12 +44,12 @@ describe('PermissionSetForm', () => {
   it('show if component renders data with no inital values', () => {
     renderPermissionSetForm();
 
-    expect(screen.getByText('ui-users.saveAndClose')).toBeDefined();
+    expect(screen.getByText(/saveAndClose/)).toBeDefined();
   });
   it('show if component renders data with empty inital values', () => {
     renderPermissionSetForm(initialVal);
 
-    expect(screen.getByText('ui-users.saveAndClose')).toBeDefined();
+    expect(screen.getByText(/saveAndClose/)).toBeDefined();
   });
   it('Permission list check', () => {
     renderPermissionSetForm(initialVal);

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -250,7 +250,7 @@ class UserForm extends React.Component {
         disabled={disabled}
         buttonRef={this.saveButton}
       >
-        <FormattedMessage id="ui-users.saveAndClose" />
+        <FormattedMessage id="stripes-components.saveAndClose" />
       </Button>
     );
 

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -406,7 +406,6 @@
   "expirationDate": "Expiration date",
   "by": "by",
   "delete": "Delete",
-  "saveAndClose": "Save & close",
   "save": "Save",
   "edit": "Edit",
   "okay": "OK",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIU-3078
We removed local `saveAndClose` label and replace it with `stripes-components.saveAndClose`. Also all related tests updated