### PR TITLE
UIU-2929 - fix two triangle icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [10.2.0] IN PROGRESS
 
+* Fix two "triangle down" icons in select element of "Copy existing fee/fine owner table entries" modal. Refs UIU-2929.
+
 
 ## [10.1.0](https://github.com/folio-org/ui-users/tree/v10.1.0) (2024-03-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.4...v10.1.0)

--- a/src/settings/FeeFinesTable/CopyModal.js
+++ b/src/settings/FeeFinesTable/CopyModal.js
@@ -75,13 +75,14 @@ class CopyForm extends React.Component {
             </Field>
           </Col>
           <Col>
-            <Field
-              className={css.ownerIdField}
-              name="ownerId"
-              component={Select}
-              dataOptions={options}
-              placeholder={this.props.intl.formatMessage({ id: 'ui-users.feefines.modal.placeholder' })}
-            />
+            <div className={css.ownerIdField}>
+              <Field
+                name="ownerId"
+                component={Select}
+                dataOptions={options}
+                placeholder={this.props.intl.formatMessage({ id: 'ui-users.feefines.modal.placeholder' })}
+              />
+            </div>
           </Col>
         </Row>
         <Button onClick={this.props.handleSubmit}>

--- a/src/settings/FeeFinesTable/FeeFinesTable.css
+++ b/src/settings/FeeFinesTable/FeeFinesTable.css
@@ -8,5 +8,4 @@
 
 .ownerIdField {
   margin-left: var(--gutter-static-two-thirds);
-  width: 120;
 }


### PR DESCRIPTION
## Purpose
[UIU-2929](https://folio-org.atlassian.net/jira/software/c/projects/UIU/boards/76?assignee=712020%3A5ca69dba-5ba2-4ee1-be22-97e32eeff056&selectedIssue=UIU-2929) - Fix two "triangle down" icons displayed in select element of "Copy existing fee/fine owner table entries" modal.

## Screencast
https://github.com/folio-org/ui-users/assets/105021655/a6a1c633-31cf-406b-b8c5-0c8dbb2d857c

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
