### PR TITLE
UIU-3094: "Total paid amount" value is set as "$NaN" on "Refund fee/fine" modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix incorrect translation key having count-disagreements in Pay fees/fines modal in Fees/Fines Page. Refs UIU-1097.
 * Trim input values and delete properties with empty string when user record save. Refs UIU-2049.
 * Update username field validation to trim leading and trailing spaces. Refs UIU-3099.
+* Fix "Total paid amount" value that set as "$NaN" on "Refund fee/fine" modal. Refs UIU-3094.
 
 ## [10.1.0](https://github.com/folio-org/ui-users/tree/v10.1.0) (2024-03-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.0.4...v10.1.0)

--- a/src/components/Accounts/Actions/ActionModal.js
+++ b/src/components/Accounts/Actions/ActionModal.js
@@ -380,7 +380,7 @@ class ActionModal extends React.Component {
                     :
                   </Col>
                   <Col xs={4}>
-                    {localizeCurrencyAmount(totalPaidAmount, stripes.currency, intl)}
+                    {totalPaidAmount}
                   </Col>
                 </Row>
               ) : (


### PR DESCRIPTION
## Purpose
Fix issue with "Total paid amount" value that has incorrect view.

## Approach
Property that is used for "Total paid amount" value is `totalPaidAmount`. At the parent component this property was handled by `localizeCurrencyAmount` method and then inside `ActionModal` component it was handled by that method one more time. As a result we had `$NaN`. To fix this problem I had to remove one unnecessary handling.

## Refs
[UIU-3094](https://folio-org.atlassian.net/browse/UIU-3094)