### PR TITLE
restore useProfilePicture

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -8,4 +8,5 @@ export { default as useUserTenantPermissions } from './useUserTenantPermissions'
 export { default as useUserTenantRoles } from './useUserTenantRoles';
 export { default as useLocalizedCurrency } from './useLocalizedCurrency';
 export { default as useAllRolesData } from './useAllRolesData';
+export { default as useProfilePicture } from './useProfilePicture';
 


### PR DESCRIPTION
The hook is present; we're just missing the top-level export. It got lost in the backporting of role-related work from #keycloak-ramsons onto #keycloak-quesnelia. 