### PR TITLE
UIU-2879 - Set Users date format as per Session Locale Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Make dependency on mod-reading-rooms optional. Refs UIU-3146.
 * Make Reading Room Filter case insensitive. Refs UIU-3150.
 * Improve UX of Reading Room Access accordion selection box in user profile edit. Refs UIU-3151.
+* Set Users date format in all date input fields as per Session Locale Settings. Refs UIU-2879.
 
 ## [10.1.1](https://github.com/folio-org/ui-users/tree/v10.1.1) (2024-05-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.0...v10.1.1)

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -119,7 +119,7 @@ class EditExtendedInfo extends Component {
             <Field
               component={Datepicker}
               label={<FormattedMessage id="ui-users.extended.dateEnrolled" />}
-              dateFormat="YYYY-MM-DD"
+              backendDateStandard="YYYY-MM-DD"
               name="enrollmentDate"
               id="adduser_enrollmentdate"
               validate={validateMinDate('ui-users.errors.extended.dateEnrolled')}
@@ -146,7 +146,6 @@ class EditExtendedInfo extends Component {
             <Field
               component={Datepicker}
               label={<FormattedMessage id="ui-users.extended.birthDate" />}
-              dateFormat="YYYY-MM-DD"
               name="personal.dateOfBirth"
               id="adduser_dateofbirth"
               timeZone="UTC"

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -347,9 +347,9 @@ class EditUserInfo extends React.Component {
                 </Col>
                 <Col xs={12} md={3}>
                   <Field
+                    backendDateStandard="YYYY-MM-DD"
                     component={Datepicker}
                     label={<FormattedMessage id="ui-users.expirationDate" />}
-                    dateFormat="YYYY-MM-DD"
                     defaultValue={initialValues.expirationDate}
                     name="expirationDate"
                     id="adduser_expirationdate"

--- a/src/components/PatronBlock/PatronBlockForm.js
+++ b/src/components/PatronBlock/PatronBlockForm.js
@@ -322,7 +322,6 @@ class PatronBlockForm extends React.Component {
                       <Field
                         name="expirationDate"
                         component={Datepicker}
-                        dateFormat="YYYY-MM-DD"
                         label={<FormattedMessage id="ui-users.blocks.form.label.date" />}
                         backendDateStandard="YYYY-MM-DD"
                         timeZone="UTC"

--- a/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.js
+++ b/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.js
@@ -181,7 +181,7 @@ class ProxyEditItem extends React.Component {
                   <Field
                     component={Datepicker}
                     label={<FormattedMessage id="ui-users.expirationDate" />}
-                    dateFormat="YYYY-MM-DD"
+                    backendDateStandard="YYYY-MM-DD"
                     name={`${name}.proxy.expirationDate`}
                     validate={validateMinDate('ui-users.errors.expirationDate')}
                   />


### PR DESCRIPTION
[UIU-2879](https://folio-org.atlassian.net/browse/UIU-2879) -  Set Users date format in all date input fields as per Session Locale Settings.

This PR address the following date input fields in ui-users :- 
- Expiration Date in => UserInfo Screen > Patron Blocks Accordion > Create  Block > Block Information Accordion.
- Expiration date, Date enrolled and Birth date => UserEdit Screen.
- Expiration date => UserEdit Screen > Proxy/Sponser Accordion. 

## Screencast 
https://github.com/folio-org/ui-users/assets/105021655/60f43f05-5887-47bb-b3b6-f24762765741

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
