### PR TITLE
UIU-3125: Make unblocked fee-fine actions if item is claimed returned and loan is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Make dependency on mod-reading-rooms optional. Refs UIU-3146.
 * Make Reading Room Filter case insensitive. Refs UIU-3150.
 * Improve UX of Reading Room Access accordion selection box in user profile edit. Refs UIU-3151.
+* Make unblocked fee-fine actions if item is claimed returned and loan is closed. Refs UIU-3125.
 
 ## [10.1.1](https://github.com/folio-org/ui-users/tree/v10.1.1) (2024-05-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.0...v10.1.1)

--- a/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
+++ b/src/components/Accounts/ViewFeesFines/ViewFeesFines.js
@@ -18,7 +18,10 @@ import {
 } from '@folio/stripes/components';
 import { stripesConnect, stripesShape } from '@folio/stripes/core';
 
-import { itemStatuses } from '../../../constants';
+import {
+  itemStatuses,
+  loanStatuses,
+} from '../../../constants';
 import {
   calculateSortParams,
   nav,
@@ -279,11 +282,11 @@ class ViewFeesFines extends React.Component {
     const values = Object.values(checkedAccounts);
 
     let selected = 0;
-    let someIsClaimReturnedItem = false;
+    let isActionOptionDisabled = false;
     values.forEach((v) => {
       selected += (v.remaining * 100);
       const loan = this.getLoan(v);
-      someIsClaimReturnedItem = (someIsClaimReturnedItem || (loan.item && loan.item.status && loan.item.status.name && loan.item.status.name === itemStatuses.CLAIMED_RETURNED));
+      isActionOptionDisabled = (isActionOptionDisabled || (loan?.status?.name === loanStatuses.OPEN && (loan?.item?.status?.name === itemStatuses.CLAIMED_RETURNED)));
     });
     selected /= 100;
     this.props.onChangeSelected(selected, values);
@@ -291,10 +294,10 @@ class ViewFeesFines extends React.Component {
     const open = selected > 0;
     const closed = values.length > 0;
     this.props.onChangeActions({
-      waive: open && !someIsClaimReturnedItem,
-      transfer: open && !someIsClaimReturnedItem,
-      refund: ((open && !someIsClaimReturnedItem) || closed),
-      regularpayment: open && !someIsClaimReturnedItem,
+      waive: open && !isActionOptionDisabled,
+      transfer: open && !isActionOptionDisabled,
+      refund: ((open && !isActionOptionDisabled) || closed),
+      regularpayment: open && !isActionOptionDisabled,
     });
   }
 
@@ -411,27 +414,30 @@ class ViewFeesFines extends React.Component {
 
     // disable ellipses menu actions based on permissions
     const buttonDisabled = !this.props.stripes.hasPerm('ui-users.feesfines.actions.all');
-    const isClaimReturnedItem = (loan.item && loan.item.status && loan.item.status.name && loan.item.status.name === itemStatuses.CLAIMED_RETURNED);
+    const isClaimReturnedItem = loan?.item?.status?.name === itemStatuses.CLAIMED_RETURNED;
+    const isLoanOpened = loan?.status?.name === loanStatuses.OPEN;
+    const isMenuButtonDisabled = isClaimReturnedItem && isLoanOpened;
     const loanText = isDisabled.loan ? 'ui-users.accounts.history.button.loanAnonymized' : 'ui-users.accounts.history.button.loanDetails';
+
     return (
       <Dropdown
         renderTrigger={this.renderToggle}
         usePortal
       >
         <DropdownMenu id="ellipsis-drop-down">
-          <this.MenuButton disabled={isDisabled.pay || buttonDisabled || isClaimReturnedItem} account={a} action="pay">
+          <this.MenuButton disabled={isDisabled.pay || buttonDisabled || isMenuButtonDisabled} account={a} action="pay">
             <FormattedMessage id="ui-users.accounts.history.button.pay" />
           </this.MenuButton>
-          <this.MenuButton disabled={isDisabled.waive || buttonDisabled || isClaimReturnedItem} account={a} action="waive">
+          <this.MenuButton disabled={isDisabled.waive || buttonDisabled || isMenuButtonDisabled} account={a} action="waive">
             <FormattedMessage id="ui-users.accounts.history.button.waive" />
           </this.MenuButton>
-          <this.MenuButton disabled={isDisabled.refund || buttonDisabled || isClaimReturnedItem} account={a} action="refund">
+          <this.MenuButton disabled={isDisabled.refund || buttonDisabled || isMenuButtonDisabled} account={a} action="refund">
             <FormattedMessage id="ui-users.accounts.history.button.refund" />
           </this.MenuButton>
-          <this.MenuButton disabled={isDisabled.transfer || buttonDisabled || isClaimReturnedItem} account={a} action="transfer">
+          <this.MenuButton disabled={isDisabled.transfer || buttonDisabled || isMenuButtonDisabled} account={a} action="transfer">
             <FormattedMessage id="ui-users.accounts.history.button.transfer" />
           </this.MenuButton>
-          <this.MenuButton disabled={isDisabled.error || buttonDisabled || isClaimReturnedItem} account={a} action="cancel">
+          <this.MenuButton disabled={isDisabled.error || buttonDisabled || isMenuButtonDisabled} account={a} action="cancel">
             <FormattedMessage id="ui-users.accounts.button.error" />
           </this.MenuButton>
           <hr />

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,6 +18,7 @@ export const itemStatuses = {
 
 export const loanStatuses = {
   CLOSED: 'Closed',
+  OPEN: 'Open',
 };
 
 export const accountStatuses = {

--- a/src/constants.test.js
+++ b/src/constants.test.js
@@ -22,7 +22,7 @@ describe('Constants', () => {
     expect(Object.keys(itemStatuses).length).toEqual(4);
   });
   test('loanStatuses', () => {
-    expect(Object.keys(loanStatuses).length).toEqual(1);
+    expect(Object.keys(loanStatuses).length).toEqual(2);
   });
   test('accountStatuses', () => {
     expect(Object.keys(accountStatuses).length).toEqual(2);

--- a/src/views/AccountDetails/AccountDetails.js
+++ b/src/views/AccountDetails/AccountDetails.js
@@ -43,6 +43,7 @@ import FeeFineReport from '../../components/data/reports/FeeFineReport';
 import {
   itemStatuses,
   refundClaimReturned,
+  loanStatuses,
 } from '../../constants';
 
 import css from './AccountDetails.css';
@@ -325,13 +326,14 @@ feeFineActions
       resources,
       itemDetails
     } = this.props;
-
+    const relatedLoan = (resources?.loans?.records || []).filter((loan) => loan.id === account.loanId);
     const feeFineActions = resources?.feefineactions?.records || [];
     const isAccountsPending = resources?.accounts?.isPending ?? true;
     const isActionsPending = resources?.accountActions?.isPending ?? true;
     const allFeeFineActions = resources?.feefineactions?.records || [];
-    const isClaimReturnedItem = (itemDetails?.statusItemName === itemStatuses.CLAIMED_RETURNED);
-
+    const isClaimReturnedItem = itemDetails?.statusItemName === itemStatuses.CLAIMED_RETURNED;
+    const isLoanOpened = relatedLoan[0]?.status?.name === loanStatuses.OPEN;
+    const isMenuButtonDisabled = isActionsPending || isAccountsPending || (isClaimReturnedItem && isLoanOpened);
     const disabled = account.remaining === 0;
     const buttonDisabled = !this.props.stripes.hasPerm('ui-users.feesfines.actions.all');
     const refundAllowed = isRefundAllowed(account, feeFineActions);
@@ -345,7 +347,7 @@ feeFineActions
           <Button
             id="payAccountActionsHistory"
             buttonStyle="dropdownItem"
-            disabled={disabled || buttonDisabled || isActionsPending || isAccountsPending || isClaimReturnedItem}
+            disabled={disabled || buttonDisabled || isMenuButtonDisabled}
             onClick={this.pay}
           >
             <Icon icon="cart">
@@ -355,7 +357,7 @@ feeFineActions
           <Button
             id="waiveAccountActionsHistory"
             buttonStyle="dropdownItem"
-            disabled={disabled || buttonDisabled || isActionsPending || isAccountsPending || isClaimReturnedItem}
+            disabled={disabled || buttonDisabled || isMenuButtonDisabled}
             onClick={this.waive}
           >
             <Icon icon="cancel">
@@ -365,7 +367,7 @@ feeFineActions
           <Button
             id="refundAccountActionsHistory"
             buttonStyle="dropdownItem"
-            disabled={!refundAllowed || buttonDisabled || isActionsPending || isAccountsPending || isClaimReturnedItem}
+            disabled={!refundAllowed || buttonDisabled || isMenuButtonDisabled}
             onClick={this.refund}
           >
             <Icon icon="replace">
@@ -375,7 +377,7 @@ feeFineActions
           <Button
             id="transferAccountActionsHistory"
             buttonStyle="dropdownItem"
-            disabled={disabled || buttonDisabled || isActionsPending || isAccountsPending || isClaimReturnedItem}
+            disabled={disabled || buttonDisabled || isMenuButtonDisabled}
             onClick={this.transfer}
           >
             <Icon icon="transfer">
@@ -385,7 +387,7 @@ feeFineActions
           <Button
             id="errorAccountActionsHistory"
             buttonStyle="dropdownItem"
-            disabled={disabled || buttonDisabled || isActionsPending || isAccountsPending || !cancelAllowed || isClaimReturnedItem}
+            disabled={disabled || buttonDisabled || !cancelAllowed || isMenuButtonDisabled}
             onClick={this.error}
           >
             <Icon icon="trash">


### PR DESCRIPTION
## Purpose
When loan was closed by check in and when it has open fees or fines and if item is checked out again and gets claimed returned the previous borrower blocked from paying (waiving/transferring/canceling) their fees or fines.

## Approach
Initially we had disabled pay, waive, transfer, refund, cancel buttons if item had a status "Claimed returned". But now we additionally rely on loan status that should have value 'Closed'. In this case all mentioned buttons will be enabled.
(Approach confirmed by PO).

## Refs
[UIU-3125](https://folio-org.atlassian.net/browse/UIU-3125)