### PR TITLE
UIU-2158 omit extra curly-brace

### DIFF
--- a/src/components/EditSections/EditServicePoints/EditServicePoints.js
+++ b/src/components/EditSections/EditServicePoints/EditServicePoints.js
@@ -140,7 +140,7 @@ class EditServicePoints extends React.Component {
       <Row>
         <Col xs={12} md={6}>
           <Field
-            label={`${intl.formatMessage({ id: 'ui-users.sp.servicePointPreference' })}} *`}
+            label={`${intl.formatMessage({ id: 'ui-users.sp.servicePointPreference' })} *`}
             name="preferredServicePoint"
             id="servicePointPreference"
             component={Select}


### PR DESCRIPTION
> This developer needs a copy-editor!

-- Zak Burke, FOLIO

* Remove the extra `}` that's plagued the service-points headline for the last three years since PR #1724. Can't believe we didn't notice!

Refs [UIU-2158](https://folio-org.atlassian.net/browse/UIU-2158)
