### PR TITLE
use data-testid, not data-testId, to avoid React complaints

### DIFF
--- a/src/components/EditSections/EditUserRoles/EditUserRoles.js
+++ b/src/components/EditSections/EditUserRoles/EditUserRoles.js
@@ -103,8 +103,8 @@ function EditUserRoles({ match, accordionId, form:{ change }, initialValues }) {
       >
         <Row>
           {renderUserRoles()}
-          <Button data-testId="add-roles-button" onClick={() => setIsOpen(true)}><FormattedMessage id="ui-users.roles.addRoles" /></Button>
-          <Button data-testId="unassign-all-roles-button" disabled={isEmpty(listItemsData)} onClick={() => setUnassignModalOpen(true)}><FormattedMessage id="ui-users.roles.unassignAllRoles" /></Button>
+          <Button data-testid="add-roles-button" onClick={() => setIsOpen(true)}><FormattedMessage id="ui-users.roles.addRoles" /></Button>
+          <Button data-testid="unassign-all-roles-button" disabled={isEmpty(listItemsData)} onClick={() => setUnassignModalOpen(true)}><FormattedMessage id="ui-users.roles.unassignAllRoles" /></Button>
         </Row>
       </Accordion>
       <UserRolesModal

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -310,7 +310,7 @@ class LoanDetails extends React.Component {
       const formattedValue = `${titleTodisplay} (${get(this.loan, ['item', 'materialType', 'name'])})`;
       return (
         <KeyValue
-          data-testId="item-title"
+          data-testid="item-title"
           label={<FormattedMessage id="ui-users.loans.columns.title" />}
           value={
             isVirtualItem ?
@@ -662,7 +662,7 @@ class LoanDetails extends React.Component {
               </Col>
               <Col xs={2}>
                 <KeyValue
-                  data-testId="item-barcode"
+                  data-testid="item-barcode"
                   label={<FormattedMessage id="ui-users.loans.columns.barcode" />}
                   value={this.showBarcode(loan)}
                 />


### PR DESCRIPTION
Resolve the following console error:

> Warning: React does not recognize the `data-testId` prop on a DOM
> element. If you intentionally want it to appear in the DOM as a custom
> attribute, spell it as lowercase `data-testid` instead. If you
> accidentally passed it from a parent component, remove it from the DOM
> element.
