### PR TITLE
UIU-3145-followup: use react-final-form OnChange listener to track the actual data of assignedRoleIds

### DIFF
--- a/src/components/EditSections/EditUserRoles/EditUserRoles.js
+++ b/src/components/EditSections/EditUserRoles/EditUserRoles.js
@@ -1,23 +1,20 @@
 import React, { useMemo, useState } from 'react';
-import { Accordion, Headline, Badge, Row, Col, List, Button, Icon, Loading, ConfirmationModal } from '@folio/stripes/components';
+import { Accordion, Headline, Badge, Row, Col, List, Button, Icon, ConfirmationModal } from '@folio/stripes/components';
 import { useIntl, FormattedMessage } from 'react-intl';
 import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
-import { useStripes } from '@folio/stripes/core';
 import { isEmpty } from 'lodash';
 import { FieldArray } from 'react-final-form-arrays';
-import { useUserTenantRoles, useAllRolesData } from '../../../hooks';
+import { OnChange } from 'react-final-form-listeners';
+import { useAllRolesData } from '../../../hooks';
 import UserRolesModal from './components/UserRolesModal/UserRolesModal';
 import { filtersConfig } from './helpers';
 
-function EditUserRoles({ match, accordionId, form:{ change }, assignedRoleIds }) {
+function EditUserRoles({ accordionId, form:{ change }, initialValues }) {
   const [isOpen, setIsOpen] = useState(false);
   const [unassignModalOpen, setUnassignModalOpen] = useState(false);
-  const { okapi } = useStripes();
+  const [assignedRoleIds, setAssignedRoleIds] = useState(initialValues.assignedRoleIds);
   const intl = useIntl();
-  const userId = match.params.id;
-
-  const { userRoles, isLoading } = useUserTenantRoles({ userId, tenantId: okapi.tenant });
 
   const { isLoading: isAllRolesDataLoading, allRolesMapStructure } = useAllRolesData();
 
@@ -98,7 +95,7 @@ function EditUserRoles({ match, accordionId, form:{ change }, assignedRoleIds })
       <Accordion
         label={<Headline size="large" tag="h3"><FormattedMessage id="ui-users.roles.userRoles" /></Headline>}
         id={accordionId}
-        displayWhenClosed={isLoading ? <Loading /> : <Badge>{userRoles.length}</Badge>}
+        displayWhenClosed={<Badge>{assignedRoleIds.length}</Badge>}
       >
         <Row>
           {renderUserRoles()}
@@ -108,7 +105,6 @@ function EditUserRoles({ match, accordionId, form:{ change }, assignedRoleIds })
       </Accordion>
       <UserRolesModal
         filtersConfig={filtersConfig}
-        assignedRoles={userRoles}
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         initialRoleIds={assignedRoleIds}
@@ -123,6 +119,12 @@ function EditUserRoles({ match, accordionId, form:{ change }, assignedRoleIds })
         cancelLabel={<FormattedMessage id="ui-users.no" />}
         confirmLabel={<FormattedMessage id="ui-users.yes" />}
       />
+      <OnChange name="assignedRoleIds">
+        {(userAssignedRoleIds) => {
+          const userRoleIds = isEmpty(userAssignedRoleIds) ? [] : userAssignedRoleIds;
+          setAssignedRoleIds(userRoleIds);
+        }}
+      </OnChange>
     </div>
   );
 }
@@ -131,7 +133,7 @@ EditUserRoles.propTypes = {
   match: PropTypes.shape({ params: { id: PropTypes.string } }),
   accordionId: PropTypes.string,
   form: PropTypes.object.isRequired,
-  assignedRoleIds: PropTypes.arrayOf(PropTypes.string)
+  initialValues: PropTypes.object.isRequired
 };
 
 export default withRouter(EditUserRoles);

--- a/src/components/EditSections/EditUserRoles/EditUserRoles.test.js
+++ b/src/components/EditSections/EditUserRoles/EditUserRoles.test.js
@@ -9,11 +9,10 @@ import {
 import { Form } from 'react-final-form';
 import EditUserRoles from './EditUserRoles';
 
-import { useAllRolesData, useUserTenantRoles } from '../../../hooks';
+import { useAllRolesData } from '../../../hooks';
 
 jest.mock('../../../hooks', () => ({
   ...jest.requireActual('../../../hooks'),
-  useUserTenantRoles: jest.fn(),
   useAllRolesData: jest.fn()
 }));
 
@@ -88,19 +87,15 @@ const propsData = {
   form: {
     change: mockChangeFunction,
   },
-  assignedRoleIds: ['1', '2']
+  initialValues: {
+    assignedRoleIds: ['1', '2'],
+  },
 };
 
 describe('EditUserRoles Component', () => {
   beforeEach(() => {
     useStripes.mockClear().mockReturnValue(STRIPES);
     useAllRolesData.mockClear().mockReturnValue(mockAllRolesData);
-    useUserTenantRoles.mockClear().mockReturnValue({
-      isFetching: false,
-      userRoles: [{ id: '1', name: 'test role' },
-        { id: '2', name: 'admin role' }
-      ]
-    });
   });
   afterEach(cleanup);
 

--- a/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.js
+++ b/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.js
@@ -13,7 +13,6 @@ import useRolesModalFilters from './useRolesModalFilters';
 
 export default function UserRolesModal({ isOpen,
   onClose,
-  assignedRoles,
   changeUserRoles,
   initialRoleIds }) {
   const [filterPaneIsVisible, setFilterPaneIsVisible] = useState(true);
@@ -65,7 +64,6 @@ export default function UserRolesModal({ isOpen,
   const getFilterConfigGroups = () => [filtersConfig].map(({ filter, ...filterConfig }) => (filterConfig));
 
   const resetSearchForm = () => {
-    setAssignedRoleIds(assignedRoles.map(role => role.id));
     setSubmittedSearchTerm('');
     resetFilters();
   };

--- a/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.test.js
+++ b/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.test.js
@@ -43,7 +43,6 @@ describe('UserRoleModal', () => {
   it('should select/unselect all roles, and ', async () => {
     renderComponent({ isOpen: true,
       onClose: mockOnClose,
-      assignedRoles: mockAssignedRoles,
       initialRoleIds: ['1'],
       changeUserRoles:jest.fn() });
 
@@ -64,7 +63,6 @@ describe('UserRoleModal', () => {
   it('should show assigned roles only', async () => {
     const { queryByText } = renderComponent({ isOpen: true,
       onClose: mockOnClose,
-      assignedRoles: mockAssignedRoles,
       initialRoleIds: ['1'],
       changeUserRoles:jest.fn() });
 
@@ -79,7 +77,6 @@ describe('UserRoleModal', () => {
   it('should show unassigned roles only', async () => {
     const { getAllByRole } = renderComponent({ isOpen: true,
       onClose: mockOnClose,
-      assignedRoles: mockAssignedRoles,
       initialRoleIds: ['1'],
       changeUserRoles:jest.fn() });
 
@@ -101,7 +98,6 @@ describe('UserRoleModal', () => {
 
     renderComponent({ isOpen: true,
       onClose: mockOnClose,
-      assignedRoles: mockAssignedRoles,
       initialRoleIds: ['1'],
       changeUserRoles:jest.fn() });
 
@@ -113,7 +109,6 @@ describe('UserRoleModal', () => {
   it('should toggle filters pane', async () => {
     const { getByText } = renderComponent({ isOpen: true,
       onClose: mockOnClose,
-      assignedRoles: mockAssignedRoles,
       initialRoleIds: ['1'],
       changeUserRoles:jest.fn() });
 
@@ -130,7 +125,6 @@ describe('UserRoleModal', () => {
     const mockChangeUserRoles = jest.fn();
     const { getByRole } = renderComponent({ isOpen: true,
       onClose: mockOnClose,
-      assignedRoles: mockAssignedRoles,
       initialRoleIds: ['1', '4'],
       changeUserRoles:mockChangeUserRoles });
     const submitButton = getByRole('button', { name: 'stripes-components.saveAndClose' });

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -444,7 +444,7 @@ class UserForm extends React.Component {
                           setButtonRef={this.setButtonRef}
                         /> : <EditUserRoles
                           form={form}
-                          assignedRoleIds={form.getFieldState('assignedRoleIds')?.value || []}
+                          initialValues={initialValues}
                           accordionId="userRoles"
                         />
                       }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

Fixing [comment](https://folio-org.atlassian.net/browse/UIU-3145?focusedCommentId=220800) from the [UIU-3145](https://folio-org.atlassian.net/browse/UIU-3145) - Not all roles are shown in “User roles“ accordion in user edit view after assigning multiple roles.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
react-final-form provides a form API that includes getFieldState, which is not reactive. In order to track the changes of the form, a listener component is required. Use OnChange component to track the _assignedRoleIds_ fields from the form.  

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
