### PR TITLE
UIU-3171 - Success message for user details export for library card printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Export user details CSV file enhancements. Refs UIU-3175.
 * Improve User Profile Picture quality. Refs UIU-3177.
 * Update expiration date format in export user details. Refs UIU-3174.
+* Success message toast for user details export for library card printing. Refs UIU-3171.
 
 ## [10.1.1](https://github.com/folio-org/ui-users/tree/v10.1.1) (2024-05-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.0...v10.1.1)

--- a/src/components/PrintLibraryCardButton/PrintLibraryCardButton.js
+++ b/src/components/PrintLibraryCardButton/PrintLibraryCardButton.js
@@ -53,7 +53,7 @@ const PrintLibraryCardButton = ({ user, patronGroup }) => {
   const { formatDateToParts } = intl;
   const { personal: { profilePictureLink }, active, expirationDate, personal } = user;
   const isPatronOrStaffUser = isPatronUser(user) || isStaffUser(user);
-  const disabled = !active || !isPatronOrStaffUser;
+  const disabled = !active || !isPatronOrStaffUser || !profilePictureLink;
   const isProfilePicAValidUUID = profilePictureLink && isAValidUUID(profilePictureLink);
 
   const { profilePictureData } = useProfilePicture({ profilePictureId: profilePictureLink, isProfilePictureAUUID: isAValidUUID(profilePictureLink) });

--- a/src/components/PrintLibraryCardButton/PrintLibraryCardButton.js
+++ b/src/components/PrintLibraryCardButton/PrintLibraryCardButton.js
@@ -10,7 +10,7 @@ import {
   exportToCsv,
 } from '@folio/stripes/components';
 import { useProfilePicture } from '@folio/stripes/smart-components';
-import { isPatronUser, isStaffUser, base64ToBlob, isAValidUUID, isAValidURL } from '../util';
+import { isPatronUser, isStaffUser, base64ToBlob, isAValidUUID } from '../util';
 import { USER_INFO } from '../../constants';
 
 const { BARCODE, FIRST_NAME, LAST_NAME, MIDDLE_NAME, PATRON_GROUP, EXPIRATION_DATE, PROFILE_PICTURE_LINK } = USER_INFO;
@@ -45,6 +45,8 @@ const onlyFields = [
   },
 ];
 const dateFormat = { year: 'numeric', month: 'numeric', day: 'numeric' };
+const ERROR = 'error';
+const SUCCESS = 'success';
 
 const PrintLibraryCardButton = ({ user, patronGroup }) => {
   const callout = useCallout();
@@ -53,6 +55,7 @@ const PrintLibraryCardButton = ({ user, patronGroup }) => {
   const { personal: { profilePictureLink }, active } = user;
   const isPatronOrStaffUser = isPatronUser(user) || isStaffUser(user);
   const disabled = !active || !isPatronOrStaffUser;
+  const isProfilePicAValidUUID = profilePictureLink && isAValidUUID(profilePictureLink);
 
   const { profilePictureData } = useProfilePicture({ profilePictureId: profilePictureLink, isProfilePictureAUUID: isAValidUUID(profilePictureLink) });
 
@@ -65,20 +68,26 @@ const PrintLibraryCardButton = ({ user, patronGroup }) => {
     return modifiedUser;
   }, [user, patronGroup, formatDate]);
 
-  const showCallout = () => {
+  const showCallout = (type) => {
+    const successMessage = type === SUCCESS && (
+      isProfilePicAValidUUID ?
+        <FormattedMessage id="ui-users.printLibraryCard.successMessage.withLocallyUploadedProfilePicture" /> :
+        <FormattedMessage id="ui-users.printLibraryCard.successMessage.withExternallyLinkedProfilePicture" />
+    );
+    const message = type === ERROR ? <FormattedMessage id="ui-users.errors.generic" /> : successMessage;
     callout.sendCallout({
-      message: <FormattedMessage id="ui-users.errors.generic" />,
-      type: 'error',
+      message,
+      type,
     });
   };
 
   const getOnlyFields = useCallback(() => {
     const fields = [...onlyFields];
-    if (profilePictureLink && isAValidURL(profilePictureLink)) {
+    if (profilePictureLink && !isProfilePicAValidUUID) {
       fields.push(profilePictureField);
     }
     return fields;
-  }, [profilePictureLink]);
+  }, [isProfilePicAValidUUID, profilePictureLink]);
 
   const exportUserDetails = () => {
     const exportOptions = {
@@ -87,12 +96,7 @@ const PrintLibraryCardButton = ({ user, patronGroup }) => {
     };
     const data = [updateUserForExport()];
 
-    try {
-      exportToCsv(data, exportOptions);
-    } catch (error) {
-      console.error('Error downloading the csv:', error); // eslint-disable-line no-console
-      showCallout();
-    }
+    exportToCsv(data, exportOptions);
   };
 
   const downloadImage = (blob) => {
@@ -124,20 +128,9 @@ const PrintLibraryCardButton = ({ user, patronGroup }) => {
     }
   };
 
-  const exportUserProfPicFromBase64String = () => {
-    try {
-      const blob = base64ToBlob(profilePictureData, 'image/png');
-      downloadImage(blob);
-    } catch (error) {
-      console.error('Error downloading the image:', error); // eslint-disable-line no-console
-      showCallout();
-    }
-  };
-
   const exportUserProfilePicture = () => {
-    if (isAValidUUID(profilePictureLink)) {
-      exportUserProfPicFromBase64String();
-    }
+    const blob = base64ToBlob(profilePictureData, 'image/png');
+    downloadImage(blob);
   };
 
   /* ************************************************************************
@@ -147,8 +140,16 @@ const PrintLibraryCardButton = ({ user, patronGroup }) => {
   *    and user has one image against his profile
   ************************************************************************* */
   const handlePrintLibraryCard = () => {
-    exportUserDetails();
-    if (profilePictureLink) exportUserProfilePicture();
+    try {
+      exportUserDetails();
+      if (isProfilePicAValidUUID) {
+        exportUserProfilePicture();
+      }
+      showCallout(SUCCESS);
+    } catch (e) {
+      console.error('Error downloading the image:', e); // eslint-disable-line no-console
+      showCallout(ERROR);
+    }
   };
 
   return (

--- a/src/components/PrintLibraryCardButton/PrintLibraryCardButton.test.js
+++ b/src/components/PrintLibraryCardButton/PrintLibraryCardButton.test.js
@@ -23,63 +23,6 @@ describe('PrintLibraryCard', () => {
   const sendCallout = jest.fn();
 
   describe('when user is active and type is patron or staff', () => {
-    describe('when user do not have profile picture', () => {
-      const props = {
-        user: {
-          expirationDate: '2024-07-09T23:59:59.000+00:00',
-          active: true,
-          type: 'staff',
-          personal: {
-            firstName: 'firstName',
-            lastName: 'lastName',
-          },
-          patronGroup: 'patronGroupId'
-        },
-        patronGroup: 'patronGroup',
-      };
-
-      beforeEach(() => {
-        useProfilePicture
-          .mockClear()
-          .mockReturnValue({ profilePictureData: 'profilePictureData' });
-      });
-
-      it('should display print library card button', () => {
-        render(<PrintLibraryCardButton {...props} />);
-
-        expect(screen.getByText('ui-users.printLibraryCard')).toBeInTheDocument();
-      });
-
-      it('should export CSV file', async () => {
-        render(<PrintLibraryCardButton {...props} />);
-
-        const printLibraryCardButton = screen.getByTestId('print-library-card');
-        await userEvent.click(printLibraryCardButton);
-
-        await waitFor(() => expect(exportToCsv).toHaveBeenCalled());
-      });
-
-      describe('when exportToCSV throws and error', () => {
-        beforeEach(() => {
-          sendCallout.mockClear();
-          useCallout.mockClear().mockReturnValue({ sendCallout });
-          exportToCsv
-            .mockClear()
-            .mockImplementationOnce(() => {
-              throw new Error('Fetch failed');
-            });
-          render(<PrintLibraryCardButton {...props} />);
-        });
-
-        it('should call show callout', async () => {
-          const printLibraryCardButton = screen.getByTestId('print-library-card');
-          await userEvent.click(printLibraryCardButton);
-
-          await waitFor(() => expect(sendCallout).toHaveBeenCalled());
-        });
-      });
-    });
-
     describe('when user has profile picture - uuid for profile picture link in user personal details', () => {
       beforeEach(() => {
         useProfilePicture
@@ -189,14 +132,14 @@ describe('PrintLibraryCard', () => {
     });
   });
 
-  describe('when user is not active or type is other than patron or staff', () => {
+  describe('when user is not active or type is other than patron or staff or user data do not have a profilePictureLink', () => {
     beforeEach(() => {
       useProfilePicture
         .mockClear()
         .mockReturnValue({ profilePictureData: 'profilePictureData' });
     });
 
-    it('should disable printLibraryCardButton', () => {
+    it('should disable printLibraryCardButton for inactive user', () => {
       const props = {
         user: {
           expirationDate: '2024-07-09T23:59:59.000+00:00',
@@ -214,7 +157,7 @@ describe('PrintLibraryCard', () => {
       expect(screen.getByTestId('print-library-card')).toBeDisabled();
     });
 
-    it('should disable printLibraryCardButton', () => {
+    it('should disable printLibraryCardButton for user who is not of type patron or staff', () => {
       const props = {
         user: {
           expirationDate: '2024-07-09T23:59:59.000+00:00',
@@ -229,6 +172,73 @@ describe('PrintLibraryCard', () => {
       };
       render(<PrintLibraryCardButton {...props} />);
       expect(screen.getByTestId('print-library-card')).toBeDisabled();
+    });
+
+    it('should disable printLibraryCardButton for user data do not have profile picture link', () => {
+      const props = {
+        user: {
+          expirationDate: '2024-07-09T23:59:59.000+00:00',
+          active: true,
+          type: 'staff',
+          personal: {
+            firstName: 'firstName',
+            lastName: 'lastName',
+          },
+          patronGroup: 'patronGroupId'
+        },
+        patronGroup: 'staff',
+      };
+      render(<PrintLibraryCardButton {...props} />);
+      expect(screen.getByTestId('print-library-card')).toBeDisabled();
+    });
+  });
+
+  describe('when exportToCSV throws an error', () => {
+    const props = {
+      user: {
+        expirationDate: '2024-07-09T23:59:59.000+00:00',
+        active: true,
+        type: 'staff',
+        personal: {
+          firstName: 'firstName',
+          lastName: 'lastName',
+          profilePictureLink: '60312a8f-a6e5-47a2-bbdc-cee579c8d215'
+        },
+        patronGroup: 'patronGroupId'
+      },
+      patronGroup: 'patronGroup',
+    };
+
+    beforeEach(() => {
+      sendCallout.mockClear();
+      useCallout.mockClear().mockReturnValue({ sendCallout });
+      exportToCsv
+        .mockClear()
+        .mockImplementationOnce(() => {
+          throw new Error('Fetch failed');
+        });
+      render(<PrintLibraryCardButton {...props} />);
+    });
+
+    it('should call show callout', async () => {
+      const printLibraryCardButton = screen.getByTestId('print-library-card');
+      await userEvent.click(printLibraryCardButton);
+
+      await waitFor(() => expect(sendCallout).toHaveBeenCalled());
+    });
+
+    it('should not export profile picture', async () => {
+      global.URL.createObjectURL = jest.fn();
+      global.Blob = jest.fn();
+      global.navigator.msSaveBlob = jest.fn();
+      const spy = jest.spyOn(global.navigator, 'msSaveBlob');
+
+      const printLibraryCardButton = screen.getByTestId('print-library-card');
+      await userEvent.click(printLibraryCardButton);
+
+      await waitFor(() => expect(spy).not.toHaveBeenCalled());
+
+      spy.mockRestore();
     });
   });
 });

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -440,7 +440,7 @@ class UserDetail extends React.Component {
     const accounts = get(resources, ['accounts', 'records'], []);
     const { personal: { profilePictureLink } } = user;
     const loans = get(resources, ['loanRecords', 'records'], []);
-    const settings = (resources.settings || {}).records || [];
+    const settings = resources?.settings?.records || [];
     const isShadowUserType = isShadowUser(user);
     const isVirtualPatron = isDcbUser(user);
     const displayPrintLibraryCardButton = Boolean(settings.length) && settings[0].enabled && profilePictureLink;

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -439,10 +439,10 @@ class UserDetail extends React.Component {
     const feeFineActions = get(resources, ['feefineactions', 'records'], []);
     const accounts = get(resources, ['accounts', 'records'], []);
     const loans = get(resources, ['loanRecords', 'records'], []);
-    const settings = resources?.settings?.records || [];
+    const settings = resources?.settings?.records;
     const isShadowUserType = isShadowUser(user);
     const isVirtualPatron = isDcbUser(user);
-    const isProfilePictureFeatureEnabled = Boolean(settings.length) && settings[0].enabled;
+    const isProfilePictureFeatureEnabled = Boolean(settings?.length) && settings[0].enabled;
 
     const feesFinesReportData = {
       user,

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -438,12 +438,11 @@ class UserDetail extends React.Component {
     const patronGroup = this.getPatronGroup(user);
     const feeFineActions = get(resources, ['feefineactions', 'records'], []);
     const accounts = get(resources, ['accounts', 'records'], []);
-    const { personal: { profilePictureLink } } = user;
     const loans = get(resources, ['loanRecords', 'records'], []);
     const settings = resources?.settings?.records || [];
     const isShadowUserType = isShadowUser(user);
     const isVirtualPatron = isDcbUser(user);
-    const displayPrintLibraryCardButton = Boolean(settings.length) && settings[0].enabled && profilePictureLink;
+    const isProfilePictureFeatureEnabled = Boolean(settings.length) && settings[0].enabled;
 
     const feesFinesReportData = {
       user,
@@ -490,7 +489,7 @@ class UserDetail extends React.Component {
             />
           </IfInterface>
           {
-            displayPrintLibraryCardButton && (
+            isProfilePictureFeatureEnabled && (
               <PrintLibraryCardButton
                 user={user}
                 patronGroup={patronGroup?.group}

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -438,9 +438,12 @@ class UserDetail extends React.Component {
     const patronGroup = this.getPatronGroup(user);
     const feeFineActions = get(resources, ['feefineactions', 'records'], []);
     const accounts = get(resources, ['accounts', 'records'], []);
+    const { personal: { profilePictureLink } } = user;
     const loans = get(resources, ['loanRecords', 'records'], []);
+    const settings = (resources.settings || {}).records || [];
     const isShadowUserType = isShadowUser(user);
     const isVirtualPatron = isDcbUser(user);
+    const displayPrintLibraryCardButton = Boolean(settings.length) && settings[0].enabled && profilePictureLink;
 
     const feesFinesReportData = {
       user,
@@ -486,10 +489,14 @@ class UserDetail extends React.Component {
               callout={this.callout}
             />
           </IfInterface>
-          <PrintLibraryCardButton
-            user={user}
-            patronGroup={patronGroup?.group}
-          />
+          {
+            displayPrintLibraryCardButton && (
+              <PrintLibraryCardButton
+                user={user}
+                patronGroup={patronGroup?.group}
+              />
+            )
+          }
           <ActionMenuDeleteButton
             handleDeleteClick={this.handleDeleteClick}
             id={this.props.match.params.id}

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -428,6 +428,8 @@
   "save": "Save",
   "edit": "Edit",
   "printLibraryCard": "Print library card",
+  "printLibraryCard.successMessage.withLocallyUploadedProfilePicture": "Export complete. Profile picture exported in separate file.",
+  "printLibraryCard.successMessage.withExternallyLinkedProfilePicture": "Export complete. Profile picture URL included in exported file",  
   "okay": "OK",
   "cancel": "Cancel",
   "description": "Description",

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -429,7 +429,7 @@
   "edit": "Edit",
   "printLibraryCard": "Print library card",
   "printLibraryCard.successMessage.withLocallyUploadedProfilePicture": "Export complete. Profile picture exported in separate file.",
-  "printLibraryCard.successMessage.withExternallyLinkedProfilePicture": "Export complete. Profile picture URL included in exported file",  
+  "printLibraryCard.successMessage.withExternallyLinkedProfilePicture": "Export complete. Profile picture URL included in exported file.",  
   "okay": "OK",
   "cancel": "Cancel",
   "description": "Description",


### PR DESCRIPTION
## Purpose
[UIU-3171](https://folio-org.atlassian.net/browse/UIU-3171) - Success message for user details export for library card printing

## Approach
1. Display success toasts on user details and user profile picture export.
2. Hide "Print Library Button" when either profile picture feature is not enabled.
3. Disable "PrintLibraryCard" button when profile picture feature is enabled and user do not have an image attached to his profile.

## Screencast
Display success toasts on user details and user profile picture export.
![qYV5DvUrJs](https://github.com/user-attachments/assets/9f1ee54c-b9ac-4200-ba25-97e73f8d774f)

Hide "Print Library Button" when either profile picture feature is not enabled and disable "PrintLibraryCard" button when profile picture feature is enabled and user do not have an image attached to his profile.
![yhnOzovcsd](https://github.com/user-attachments/assets/0589ef0f-9198-40b7-b7fe-625cde6e1e99)



<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
