### PR TITLE
"add-info" interface is optional to prevent dependency cascades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Improve User Profile Picture quality. Refs UIU-3177.
 * Update expiration date format in export user details. Refs UIU-3174.
 * Success message toast for user details export for library card printing. Refs UIU-3171.
+* The interface used for adding patron/staff notes to loans is now optional, and the relevant code guarded with `<IfInterface>`. Fixes UIU-3182.
 
 ## [10.1.1](https://github.com/folio-org/ui-users/tree/v10.1.1) (2024-05-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.0...v10.1.1)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
       }
     ],
     "okapiInterfaces": {
-      "add-info": "0.1",
       "users": "16.0 16.1 16.2",
       "configuration": "2.0",
       "permissions": "5.6",
@@ -45,6 +44,7 @@
       "feesfines": "16.1 17.0 18.0 19.0",
       "loan-policy-storage": "1.0 2.0",
       "loan-storage": "4.0 5.0 6.0 7.0",
+      "add-info": "0.1",
       "notes": "2.0 3.0",
       "request-storage": "2.5 3.0 4.0 5.0 6.0",
       "batch-print": "1.0",

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -30,7 +30,7 @@ import {
   DropdownMenu,
   FormattedTime,
 } from '@folio/stripes/components';
-import { IfPermission, stripesConnect } from '@folio/stripes/core';
+import { IfPermission, IfInterface, stripesConnect } from '@folio/stripes/core';
 import { effectiveCallNumber } from '@folio/stripes/util';
 
 import PatronBlockModalWithOverrideModal from '../../components/PatronBlock/PatronBlockModalWithOverrideModal';
@@ -619,24 +619,26 @@ class LoanDetails extends React.Component {
                     <FormattedMessage id="ui-users.loans.declareLost" />
                   </Button>
                 </IfPermission>
-                <IfPermission perm="ui-users.loans.add-patron-info">
-                  <Button
-                    data-test-new-patron-info-button
-                    disabled={isVirtualPatron}
-                    onClick={() => addInfo(loan, 'patron')}
-                  >
-                    <FormattedMessage id="ui-users.loans.newPatronInfo" />
-                  </Button>
-                </IfPermission>
-                <IfPermission perm="ui-users.loans.add-staff-info">
-                  <Button
-                    data-test-new-staff-info-button
-                    disabled={isVirtualPatron}
-                    onClick={() => addInfo(loan, 'staff')}
-                  >
-                    <FormattedMessage id="ui-users.loans.newStaffInfo" />
-                  </Button>
-                </IfPermission>
+                <IfInterface name="add-info">
+                  <IfPermission perm="ui-users.loans.add-patron-info">
+                    <Button
+                      data-test-new-patron-info-button
+                      disabled={isVirtualPatron}
+                      onClick={() => addInfo(loan, 'patron')}
+                    >
+                      <FormattedMessage id="ui-users.loans.newPatronInfo" />
+                    </Button>
+                  </IfPermission>
+                  <IfPermission perm="ui-users.loans.add-staff-info">
+                    <Button
+                      data-test-new-staff-info-button
+                      disabled={isVirtualPatron}
+                      onClick={() => addInfo(loan, 'staff')}
+                    >
+                      <FormattedMessage id="ui-users.loans.newStaffInfo" />
+                    </Button>
+                  </IfPermission>
+                </IfInterface>
               </span>
             </Row>
             <Row>

--- a/src/views/LoanDetails/LoanDetails.test.js
+++ b/src/views/LoanDetails/LoanDetails.test.js
@@ -526,18 +526,6 @@ describe('LoanDetails', () => {
       });
       expect(screen.getByRole('button', { name:'ui-users.loans.declareLost' })).toBeDisabled();
     });
-    it('should disable "New patron info" button', () => {
-      renderLoanProxyDetails({
-        ...virtualPatronPropsData,
-      });
-      expect(screen.getByRole('button', { name:'ui-users.loans.newPatronInfo' })).toBeDisabled();
-    });
-    it('should disable "New staff info" button', () => {
-      renderLoanProxyDetails({
-        ...virtualPatronPropsData,
-      });
-      expect(screen.getByRole('button', { name:'ui-users.loans.newStaffInfo' })).toBeDisabled();
-    });
   });
 
   describe('when item is dcb item', () => {


### PR DESCRIPTION
The interface used for adding patron/staff notes to loans is now optional, and the relevant code guarded with `<IfInterface>`.

Fixes UIU-3182.
