### PR TITLE
UIU-3180 - Populate the 'Address Type' Field in UserEdit and UserInfo Screen on user creation via edge module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Update expiration date format in export user details. Refs UIU-3174.
 * Success message toast for user details export for library card printing. Refs UIU-3171.
 * The interface used for adding patron/staff notes to loans is now optional, and the relevant code guarded with `<IfInterface>`. Fixes UIU-3182.
+* Populate the 'Address Type' Field in UserEdit and UserInfo Screen on user creation via edge module. Refs UIU-3180.
 
 ## [10.1.1](https://github.com/folio-org/ui-users/tree/v10.1.1) (2024-05-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.0...v10.1.1)

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.js
@@ -25,6 +25,7 @@ const EditContactInfo = ({
   accordionId,
   addressTypes,
   preferredContactTypeId,
+  addressTypeId,
   intl,
   disabled,
   stripes,
@@ -47,6 +48,7 @@ const EditContactInfo = ({
         fullWidth: true,
         autoFocus: true,
         placeholder: intl.formatMessage({ id: 'ui-users.contact.selectAddressType' }),
+        defaultValue: { addressTypeId },
       },
     },
   };
@@ -157,6 +159,7 @@ EditContactInfo.propTypes = {
   accordionId: PropTypes.string.isRequired,
   addressTypes: PropTypes.arrayOf(PropTypes.object),
   preferredContactTypeId: PropTypes.string,
+  addressTypeId: PropTypes.string,
   intl: PropTypes.object.isRequired,
   disabled: PropTypes.bool,
   stripes: PropTypes.object.isRequired,

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.js
@@ -48,7 +48,7 @@ const EditContactInfo = ({
         fullWidth: true,
         autoFocus: true,
         placeholder: intl.formatMessage({ id: 'ui-users.contact.selectAddressType' }),
-        defaultValue: { addressTypeId },
+        defaultValue: addressTypeId,
       },
     },
   };

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.test.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.test.js
@@ -64,6 +64,7 @@ const props = {
     id: '123123132'
   }],
   preferredContactTypeId: '001',
+  addressTypeId: '93e38b6f-f499-4812-b272-721d232838ab',
   intl: {
     formatMessage : jest.fn()
   },

--- a/src/components/UserAddresses/UserAddresses.js
+++ b/src/components/UserAddresses/UserAddresses.js
@@ -76,7 +76,7 @@ class UserAddresses extends React.Component {
           dataOptions: toAddressTypeOptions(addressTypes),
           fullWidth: true,
           placeholder: intl.formatMessage({ id: 'ui-users.contact.selectAddressType' }),
-          defaultValue: 'addresses[0].addressType',
+          defaultValue: addresses[0]?.addressType,
         },
       },
     };

--- a/src/components/UserAddresses/UserAddresses.js
+++ b/src/components/UserAddresses/UserAddresses.js
@@ -76,6 +76,7 @@ class UserAddresses extends React.Component {
           dataOptions: toAddressTypeOptions(addressTypes),
           fullWidth: true,
           placeholder: intl.formatMessage({ id: 'ui-users.contact.selectAddressType' }),
+          defaultValue: 'addresses[0].addressType',
         },
       },
     };

--- a/src/components/UserAddresses/UserAddresses.test.js
+++ b/src/components/UserAddresses/UserAddresses.test.js
@@ -28,7 +28,7 @@ const props = {
     addressLine2: 'TestLine2',
     stateRegion: 'State',
     zipCode: '1',
-    addressType: 'AddressType',
+    addressType: 'home',
     city: 'city',
     country: 'country'
   }]

--- a/src/components/data/converters/address.js
+++ b/src/components/data/converters/address.js
@@ -2,7 +2,10 @@ import _ from 'lodash';
 import { hashCode } from 'hashcode';
 
 function toListAddress(addr) {
-  if (addr.id) return { ...addr };
+  if (addr.id) {
+    const { addressTypeId, ...rest } = addr;
+    return { ...rest, addressType: addressTypeId };
+  }
 
   const country = (addr.countryId) ? addr.countryId : '';
   const id = hashCode().value(addr).toString();

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -400,6 +400,7 @@ class UserForm extends React.Component {
                     accordionId="contactInfo"
                     addressTypes={formData.addressTypes}
                     preferredContactTypeId={initialValues.preferredContactTypeId}
+                    addressTypeId={initialValues.personal.addresses[0].addressType}
                     disabled={isShadowUser}
                     stripes={stripes}
                   />

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -400,7 +400,7 @@ class UserForm extends React.Component {
                     accordionId="contactInfo"
                     addressTypes={formData.addressTypes}
                     preferredContactTypeId={initialValues.preferredContactTypeId}
-                    addressTypeId={initialValues.personal.addresses[0].addressType}
+                    addressTypeId={initialValues.personal?.addresses[0]?.addressType}
                     disabled={isShadowUser}
                     stripes={stripes}
                   />

--- a/src/views/UserEdit/UserForm.test.js
+++ b/src/views/UserEdit/UserForm.test.js
@@ -31,6 +31,9 @@ const user = {
   id: 'user-id',
   personal: {
     firstName: 'Luke',
+    addresses: [{
+      addressTypeId: 'c42be2ab-c3fd-486c-a1fe-9e5ea0f10989',
+    }]
   },
   type: USER_TYPES.STAFF,
   proxies: [],


### PR DESCRIPTION
[UIU-3180](https://folio-org.atlassian.net/browse/UIU-3180) - Populate the 'Address Type' Field in UserEdit and UserInfo Screen on user creation via edge module.

## Screencast
https://github.com/user-attachments/assets/13e9dc01-097c-475b-9e2a-dd089ff6d05d

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
