### PR TITLE
UIU-3184 - Use keywords CQL field for keyword user search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Fix date selection in "Expiration Date" Field after clearing expiration date field. Refs UIU-3176.
 * Populate the 'Address Type' Field in UserEdit and UserInfo Screen on user creation via edge module. Refs UIU-3180.
 * Mark check box column header as non interactive. Refs UIU-2940.
+* Use keywords CQL field for keyword user search. Refs UIU-3184.
 
 ## [10.1.1](https://github.com/folio-org/ui-users/tree/v10.1.1) (2024-05-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.0...v10.1.1)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       }
     ],
     "okapiInterfaces": {
-      "users": "16.0 16.1 16.2 16.3",
+      "users": "16.0 16.1 16.2",
       "configuration": "2.0",
       "permissions": "5.6",
       "login": "7.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       }
     ],
     "okapiInterfaces": {
-      "users": "16.0 16.1 16.2",
+      "users": "16.0 16.1 16.2 16.3",
       "configuration": "2.0",
       "permissions": "5.6",
       "login": "7.3",

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -33,7 +33,6 @@ const searchFields = [
   'externalSystemId="%{query}*"',
   'customFields="%{query}*"'
 ];
-const compileQuery = template(`(${searchFields.join(' or ')})`, { interpolate: /%{([\s\S]+?)}/g });
 
 /*
   Some of the special characters that are allowed while creating a tag are  "", \, *, ?
@@ -68,6 +67,10 @@ const escapeSpecialCharactersInTagFilters = (queryParams, resourceData) => {
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const customFilterConfig = buildFilterConfig(queryParams.filters);
   const newResourceData = escapeSpecialCharactersInTagFilters(queryParams, resourceData);
+
+  const compileQuery = props.stripes.hasInterface('users', '16.3') ?
+    template('keywords="%{query}*"', { interpolate: /%{([\s\S]+?)}/g }) :
+    template(`(${searchFields.join(' or ')})`, { interpolate: /%{([\s\S]+?)}/g });
 
   return makeQueryFunction(
     'cql.allRecords=1',

--- a/src/routes/UserSearchContainer.test.js
+++ b/src/routes/UserSearchContainer.test.js
@@ -12,7 +12,7 @@ const resourceData = {
 const logger = {
   log: jest.fn(),
 };
-const mockHasInterface = jest.fn().mockReturnValue(false);
+const mockHasInterface = jest.fn().mockReturnValue(0);
 const props = {
   stripes: {
     hasInterface: mockHasInterface,
@@ -24,8 +24,12 @@ describe('buildQuery', () => {
     expect(buildQuery({}, pathComponents, { query: {} }, logger, props)).toBeFalsy();
   });
 
-  it('should include username when building CQL query', () => {
-    mockHasInterface.mockReturnValue(true);
+  it('should include username when building CQL query when stripes "users" interface is less than 16.3', () => {
     expect(buildQuery(queryParams, pathComponents, resourceData, logger, props)).toEqual(expect.stringContaining('username="Joe*"'));
+  });
+
+  it('should include "keywords" when building CQL query when stripes "users" interface is 16.3', () => {
+    mockHasInterface.mockReturnValue(16.3);
+    expect(buildQuery(queryParams, pathComponents, resourceData, logger, props)).toEqual(expect.stringContaining('keywords="Joe*"'));
   });
 });


### PR DESCRIPTION
## Purpose
[UIU-3184](https://folio-org.atlassian.net/browse/UIU-3184) - Use keywords CQL field for keyword user search.

## Approach

The /users API has a new CQL search index keywords that significantly speeds up the search. This [implementation](https://folio-org.atlassian.net/browse/MODUSERS-457) bumped up users interface from 16.2 to 16.3 and it is backwards compatible.

Hence search query is updated to leverage the new search index.

## Screencast
when users interface is not 16.3 (here 16.2)
![oy75XkEaIB](https://github.com/user-attachments/assets/dab90a8e-ac97-434c-ad2d-073db6367dd5)

when users interface is 16.3
![chrome_JRyuAM0ew2](https://github.com/user-attachments/assets/e92e1208-24a7-40ea-81a7-eb531df0f8ad)


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
