### PR TITLE
UIU-3193: Fix issue when slash character in item barcode creates 404 error when adding fee/fine at check in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Populate the 'Address Type' Field in UserEdit and UserInfo Screen on user creation via edge module. Refs UIU-3180.
 * Mark check box column header as non interactive. Refs UIU-2940.
 * Use keywords CQL field for keyword user search. Refs UIU-3184.
+* Fix issue when slash character in item barcode creates 404 error when adding fee/fine at check in. Refs UIU-3193.
 
 ## [10.1.1](https://github.com/folio-org/ui-users/tree/v10.1.1) (2024-05-07)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.0...v10.1.1)

--- a/src/routes/ChargeFeesFinesContainer.js
+++ b/src/routes/ChargeFeesFinesContainer.js
@@ -57,7 +57,7 @@ class ChargeFeesFinesContainer extends React.Component {
         const { resources: { loanItem, activeRecord } } = props;
         if ((activeRecord && activeRecord.barcode) || (loanItem && loanItem.records.length > 0)) {
           const itemBar = activeRecord.barcode || loanItem.records[0].barcode;
-          return itemBar ? `inventory/items?query=barcode==${itemBar}` : null;
+          return itemBar ? `inventory/items?query=barcode=="${itemBar}"` : null;
         }
         return null;
       },


### PR DESCRIPTION
## Purpose
Fix issue when slash character in item barcode creates 404 error when adding fee/fine at check in.

## Approach
Wrap item barcode by double quotes. In this case server correctly handles item barcode.

## Refs
[UIU-3193](https://folio-org.atlassian.net/browse/UIU-3193)