### PR TITLE
UIU-3102: revert conditional use of the users-keycloak interface in UserRecordContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * Add `users-keycloak` permissions. Refs UIU-3068.
 * Omit permissions accordions and queries when `roles` interface is present. Refs UIU-3061, UIU-3062.
 * Retrieve user's central-tenant permission from `users-keycloak` endpoints when available. Refs UIU-3054.
+* Revert conditional use of the `users-keycloak` interface in UserRecordContainer. Refs UIU-3102.
 
 ## [10.1.2](https://github.com/folio-org/ui-users/tree/v10.1.2) (2024-09-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.1...v10.1.2)

--- a/src/routes/UserRecordContainer.js
+++ b/src/routes/UserRecordContainer.js
@@ -19,12 +19,7 @@ class UserRecordContainer extends React.Component {
     permUserId: {},   // ID of the current permissions user record (see UserEdit.js)
     selUser: {
       type: 'okapi',
-      path: (queryParams, pathComponents, resourceData, config, props) => {
-        if (props.stripes.hasInterface('users-keycloak')) {
-          return `users-keycloak/users/${pathComponents.id}`;
-        }
-        return `users/${pathComponents.id}`;
-      },
+      path: 'users/:{id}',
       clear: false,
       shouldRefresh: (resource, action, refresh) => {
         const { path, name } = action.meta;
@@ -34,12 +29,7 @@ class UserRecordContainer extends React.Component {
     },
     delUser: {
       type: 'okapi',
-      path: (queryParams, pathComponents, resourceData, config, props) => {
-        if (props.stripes.hasInterface('users-keycloak')) {
-          return `users-keycloak/users/${pathComponents.id}`;
-        }
-        return `bl-users/by-id/${pathComponents.id}`;
-      },
+      path: 'bl-users/by-id/:{id}',
       fetch: false,
     },
     // As the transaction check spans multiple modules the checks need to be done in mod-users-bl
@@ -125,12 +115,7 @@ class UserRecordContainer extends React.Component {
     records: {
       type: 'okapi',
       records: 'users',
-      path: (queryParams, pathComponents, resourceData, config, props) => {
-        if (props.stripes.hasInterface('users-keycloak')) {
-          return 'users-keycloak/users';
-        }
-        return 'users';
-      },
+      path: 'users',
       fetch: false,
     },
     creds: {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
[UIU-3102](https://folio-org.atlassian.net/browse/UIU-3102) - revert conditional use of the users-keycloak interface
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
