### PR TITLE
bump workflow's upload-artifact action to v4

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -147,22 +147,22 @@ jobs:
           data: ${{ steps.moduleDescriptor.outputs.content }}
 
       - name: Upload event file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}
           retention-days: 30
-      
+
       - name: Upload Jest results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jest-test-results
           path: ${{ env.JEST_JUNIT_OUTPUT_DIR }}/*.xml
           retention-days: 30
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -87,7 +87,7 @@ jobs:
         run: cat module-descriptor.json
 
       - name: Upload event file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}
@@ -95,14 +95,14 @@ jobs:
 
       - name: Upload Jest results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jest-test-results
           path: ${{ env.JEST_JUNIT_OUTPUT_DIR }}/*.xml
           retention-days: 30
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report


### PR DESCRIPTION
GitHub deprecated v2 so that must change, and we might as well just use the current version (v4) across the board.
