### PR TITLE
UIU-3230 isDcbItem must handle sparse data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * Open loans: Print Due date receipt for single open loans. Refs UIU-3208.
 * Open loans: Print Due date receipt for multiple open loans. Refs UIU-3209.
 * Loan details: Print Due date receipt. Refs UIU-3210.
+* Open loans: `isDcbItem()` must tolerate sparse data. Refs UIU-3230.
 
 ## [10.1.2](https://github.com/folio-org/ui-users/tree/v10.1.2) (2024-09-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.1...v10.1.2)

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -212,7 +212,7 @@ export const isAffiliationsEnabled = (user) => {
   return !isPatronUser(user) && !isDcbUser(user);
 };
 
-export const isDcbItem = (item) => item.instanceId === DCB_INSTANCE_ID && item.holdingsRecordId === DCB_HOLDINGS_RECORD_ID;
+export const isDcbItem = (item) => item?.instanceId === DCB_INSTANCE_ID && item?.holdingsRecordId === DCB_HOLDINGS_RECORD_ID;
 
 export const isAValidUUID = (str) => {
   const regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/src/components/util/util.test.js
+++ b/src/components/util/util.test.js
@@ -474,6 +474,20 @@ describe('isDcbItem ', () => {
     };
     expect(isDcbItem(item)).toBeFalsy();
   });
+
+  describe('should return false if the record is sparsely populated', () => {
+    it('handles missing instanceId', () => {
+      const item = {
+      };
+      expect(isDcbItem(item)).toBeFalsy();
+    });
+    it('handles missing instanceId', () => {
+      const item = {
+        instanceId: DCB_INSTANCE_ID,
+      };
+      expect(isDcbItem(item)).toBeFalsy();
+    });
+  });
 });
 
 describe('isAValidImageUrl', () => {


### PR DESCRIPTION
Sometimes, item records are removed even when they are attached to open loans.  Optional chaining in `isDcbItem()` prevents an NPE in this circumstance.

Refs [UIU-3230](https://folio-org.atlassian.net/browse/UIU-3230)
