### PR TITLE
UIU-3224 Implement duplicates users view

### DIFF
--- a/src/components/AssignedUsers/constants.js
+++ b/src/components/AssignedUsers/constants.js
@@ -13,8 +13,6 @@ export const COLUMN_WIDTH = {
   groupName: '50%',
 };
 
-export const USERS_API = 'users';
-export const GROUPS_API = 'groups';
 export const PERMISSIONS_API = 'perms/users';
 
 export const CHUNK_SIZE = 25;

--- a/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.js
+++ b/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.js
@@ -8,9 +8,11 @@ import {
 
 import {
   GROUPS_API,
+  USERS_API,
+} from '../../../../constants';
+import {
   MAX_RECORDS,
   PERMISSIONS_API,
-  USERS_API,
 } from '../../constants';
 import {
   batchRequest,

--- a/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.test.js
+++ b/src/components/AssignedUsers/hooks/useAssignedUsers/useAssignedUsers.test.js
@@ -6,7 +6,11 @@ import {
 
 import { useOkapiKy } from '@folio/stripes/core';
 
-import { GROUPS_API, PERMISSIONS_API, USERS_API } from '../../constants';
+import {
+  GROUPS_API,
+  USERS_API,
+} from '../../../../constants';
+import { PERMISSIONS_API } from '../../constants';
 import { batchRequest } from '../utils';
 import useAssignedUsers from './useAssignedUsers';
 

--- a/src/components/LinkToPatronPreRegistrations/LinkToPatronPreRegistrations.js
+++ b/src/components/LinkToPatronPreRegistrations/LinkToPatronPreRegistrations.js
@@ -12,7 +12,7 @@ const LinkToPatronPreRegistrations = () => {
   const history = useHistory();
 
   return (
-    <IfPermission perm="ui-users.patron-pre-registrations-view">
+    <IfPermission perm="ui-users.patron-pre-registrations.view">
       <Button
         to={{
           pathname: '/users/pre-registration-records',

--- a/src/constants.js
+++ b/src/constants.js
@@ -336,6 +336,7 @@ export const CONFIGURATIONS_ENTRIES_API = `${CONFIGURATIONS_API}/entries`;
 export const CONSORTIA_API = 'consortia';
 export const CONSORTIA_TENANTS_API = 'tenants';
 export const CONSORTIA_USER_TENANTS_API = 'user-tenants';
+export const GROUPS_API = 'groups';
 export const PROFILE_PIC_API = 'users/profile-picture';
 export const USERS_API = 'users';
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -339,6 +339,7 @@ export const CONSORTIA_USER_TENANTS_API = 'user-tenants';
 export const GROUPS_API = 'groups';
 export const PROFILE_PIC_API = 'users/profile-picture';
 export const USERS_API = 'users';
+export const PATRON_PREREGISTRATIONS_API = 'staging-users';
 
 export const RECORD_SOURCE = {
   CONSORTIUM: 'consortium',

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -10,4 +10,5 @@ export { default as useLocalizedCurrency } from './useLocalizedCurrency';
 export { default as useAllRolesData } from './useAllRolesData';
 export { default as useCreateAuthUserKeycloak } from './useCreateAuthUserKeycloak';
 export { default as usePatronGroups } from './usePatronGroups';
+export { default as useStagingUsersQuery } from './useStagingUsersQuery';
 export { default as useUsersQuery } from './useUsersQuery';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -8,4 +8,5 @@ export { default as useUserTenantPermissions } from './useUserTenantPermissions'
 export { default as useUserTenantRoles } from './useUserTenantRoles';
 export { default as useLocalizedCurrency } from './useLocalizedCurrency';
 export { default as useAllRolesData } from './useAllRolesData';
-
+export { default as usePatronGroups } from './usePatronGroups';
+export { default as useUsersQuery } from './useUsersQuery';

--- a/src/hooks/usePatronGroups/index.js
+++ b/src/hooks/usePatronGroups/index.js
@@ -1,0 +1,1 @@
+export { default } from './usePatronGroups';

--- a/src/hooks/usePatronGroups/usePatronGroups.js
+++ b/src/hooks/usePatronGroups/usePatronGroups.js
@@ -1,0 +1,51 @@
+import { useQuery } from 'react-query';
+
+import {
+  useNamespace,
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
+
+import {
+  GROUPS_API,
+  MAX_RECORDS,
+} from '../../constants';
+
+const DEFAULT_DATA = [];
+
+const usePatronGroups = (options = {}) => {
+  const {
+    enabled = true,
+    tenantId,
+    ...queryOptions
+  } = options;
+
+  const stripes = useStripes();
+  const ky = useOkapiKy({ tenant: tenantId });
+  const [namespace] = useNamespace();
+
+  const searchParams = {
+    query: 'cql.allRecords=1 sortby group',
+    limit: stripes?.config?.maxUnpagedResourceCount || MAX_RECORDS,
+  };
+
+  const {
+    data,
+    isFetching,
+    isLoading,
+  } = useQuery({
+    queryKey: ['patronGroups', namespace, tenantId],
+    queryFn: async ({ signal }) => ky.get(GROUPS_API, { searchParams, signal }).json(),
+    enabled,
+    ...queryOptions,
+  });
+
+  return {
+    isFetching,
+    isLoading,
+    patronGroups: data?.usergroups ?? DEFAULT_DATA,
+    totalRecords: data?.totalRecords ?? 0,
+  };
+};
+
+export default usePatronGroups;

--- a/src/hooks/usePatronGroups/usePatronGroups.test.js
+++ b/src/hooks/usePatronGroups/usePatronGroups.test.js
@@ -20,7 +20,7 @@ const wrapper = ({ children }) => (
 
 const usergroups = [{ id: 'ug-1' }];
 
-describe('useUserAffiliations', () => {
+describe('usePatronGroups', () => {
   const mockGet = jest.fn(() => ({
     json: () => Promise.resolve({ usergroups }),
   }));

--- a/src/hooks/usePatronGroups/usePatronGroups.test.js
+++ b/src/hooks/usePatronGroups/usePatronGroups.test.js
@@ -1,0 +1,43 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import {
+  renderHook,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useOkapiKy } from '@folio/stripes/core';
+
+import usePatronGroups from './usePatronGroups';
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+const usergroups = [{ id: 'ug-1' }];
+
+describe('useUserAffiliations', () => {
+  const mockGet = jest.fn(() => ({
+    json: () => Promise.resolve({ usergroups }),
+  }));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useOkapiKy.mockReturnValue({
+      get: mockGet,
+    });
+  });
+
+  it('should fetch patron groups', async () => {
+    const { result } = renderHook(() => usePatronGroups(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.patronGroups).toEqual(usergroups);
+  });
+});

--- a/src/hooks/useStagingUsersQuery/index.js
+++ b/src/hooks/useStagingUsersQuery/index.js
@@ -1,0 +1,1 @@
+export { default } from './useStagingUsersQuery';

--- a/src/hooks/useStagingUsersQuery/useStagingUsersQuery.js
+++ b/src/hooks/useStagingUsersQuery/useStagingUsersQuery.js
@@ -15,6 +15,7 @@ const DEFAULT_DATA = [];
 
 const useStagingUsersQuery = (params = {}, options = {}) => {
   const stripes = useStripes();
+  const [namespace] = useNamespace('staging-users');
 
   const {
     limit = stripes?.config?.maxUnpagedResourceCount || MAX_RECORDS,
@@ -29,21 +30,16 @@ const useStagingUsersQuery = (params = {}, options = {}) => {
   } = options;
 
   const ky = useOkapiKy({ tenant: tenantId });
-  const [namespace] = useNamespace();
 
-  const searchParams = {
-    query,
-    limit,
-    offset,
-  };
+  const searchParams = { limit, offset, query };
 
   const {
     data,
+    isFetched,
     isFetching,
     isLoading,
-    isFetched,
   } = useQuery({
-    queryKey: ['staging-users', namespace, tenantId, query, limit, offset],
+    queryKey: ['staging-users', limit, namespace, tenantId, offset, query],
     queryFn: ({ signal }) => ky.get(PATRON_PREREGISTRATIONS_API, { searchParams, signal }).json(),
     enabled,
     ...queryOptions,
@@ -53,8 +49,8 @@ const useStagingUsersQuery = (params = {}, options = {}) => {
     isFetched,
     isFetching,
     isLoading,
-    users: data?.staging_users ?? DEFAULT_DATA,
     totalRecords: data?.totalRecords ?? 0,
+    users: data?.staging_users ?? DEFAULT_DATA,
   };
 };
 

--- a/src/hooks/useStagingUsersQuery/useStagingUsersQuery.js
+++ b/src/hooks/useStagingUsersQuery/useStagingUsersQuery.js
@@ -1,0 +1,61 @@
+import { useQuery } from 'react-query';
+
+import {
+  useNamespace,
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
+
+import {
+  MAX_RECORDS,
+  PATRON_PREREGISTRATIONS_API,
+} from '../../constants';
+
+const DEFAULT_DATA = [];
+
+const useStagingUsersQuery = (params = {}, options = {}) => {
+  const stripes = useStripes();
+
+  const {
+    limit = stripes?.config?.maxUnpagedResourceCount || MAX_RECORDS,
+    offset = 0,
+    query = 'cql.allRecords=1',
+  } = params;
+
+  const {
+    enabled = true,
+    tenantId,
+    ...queryOptions
+  } = options;
+
+  const ky = useOkapiKy({ tenant: tenantId });
+  const [namespace] = useNamespace();
+
+  const searchParams = {
+    query,
+    limit,
+    offset,
+  };
+
+  const {
+    data,
+    isFetching,
+    isLoading,
+    isFetched,
+  } = useQuery({
+    queryKey: ['staging-users', namespace, tenantId, query, limit, offset],
+    queryFn: ({ signal }) => ky.get(PATRON_PREREGISTRATIONS_API, { searchParams, signal }).json(),
+    enabled,
+    ...queryOptions,
+  });
+
+  return {
+    isFetched,
+    isFetching,
+    isLoading,
+    users: data?.staging_users ?? DEFAULT_DATA,
+    totalRecords: data?.totalRecords ?? 0,
+  };
+};
+
+export default useStagingUsersQuery;

--- a/src/hooks/useStagingUsersQuery/useStagingUsersQuery.test.js
+++ b/src/hooks/useStagingUsersQuery/useStagingUsersQuery.test.js
@@ -1,0 +1,81 @@
+/* Developed collaboratively using AI (GitHub Copilot) */
+
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import {
+  renderHook,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useOkapiKy } from '@folio/stripes/core';
+
+import {
+  MAX_RECORDS,
+  PATRON_PREREGISTRATIONS_API,
+} from '../../constants';
+import useStagingUsersQuery from './useStagingUsersQuery';
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useStagingUsersQuery', () => {
+  const mockKy = {
+    get: jest.fn(() => ({
+      json: jest.fn(() => Promise.resolve({
+        users: [{ id: '1', name: 'Test User' }],
+        totalRecords: 1,
+      })),
+    })),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useOkapiKy.mockReturnValue(mockKy);
+  });
+
+  it('should fetch staging users with default parameters', async () => {
+    const { result } = renderHook(() => useStagingUsersQuery(), { wrapper });
+
+    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+
+    expect(mockKy.get).toHaveBeenCalledWith(PATRON_PREREGISTRATIONS_API, expect.objectContaining({
+      searchParams: {
+        query: 'cql.allRecords=1',
+        limit: MAX_RECORDS,
+        offset: 0,
+      },
+    }));
+
+    expect(result.current.users).toEqual([{ id: '1', name: 'Test User' }]);
+    expect(result.current.totalRecords).toBe(1);
+  });
+
+  it('should fetch staging users with custom parameters', async () => {
+    const params = {
+      limit: 10,
+      offset: 5,
+      query: 'username="test"',
+    };
+    const { result } = renderHook(() => useStagingUsersQuery(params), { wrapper });
+
+    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+
+    expect(mockKy.get).toHaveBeenCalledWith(PATRON_PREREGISTRATIONS_API, expect.objectContaining({
+      searchParams: {
+        query: 'username="test"',
+        limit: 10,
+        offset: 5,
+      },
+    }));
+
+    expect(result.current.users).toEqual([{ id: '1', name: 'Test User' }]);
+    expect(result.current.totalRecords).toBe(1);
+  });
+});

--- a/src/hooks/useStagingUsersQuery/useStagingUsersQuery.test.js
+++ b/src/hooks/useStagingUsersQuery/useStagingUsersQuery.test.js
@@ -28,7 +28,7 @@ describe('useStagingUsersQuery', () => {
   const mockKy = {
     get: jest.fn(() => ({
       json: jest.fn(() => Promise.resolve({
-        users: [{ id: '1', name: 'Test User' }],
+        staging_users: [{ id: '1', name: 'Test User' }],
         totalRecords: 1,
       })),
     })),

--- a/src/hooks/useUsersQuery/index.js
+++ b/src/hooks/useUsersQuery/index.js
@@ -1,0 +1,1 @@
+export { default } from './useUsersQuery';

--- a/src/hooks/useUsersQuery/useUsersQuery.js
+++ b/src/hooks/useUsersQuery/useUsersQuery.js
@@ -1,0 +1,61 @@
+import { useQuery } from 'react-query';
+
+import {
+  useNamespace,
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
+
+import {
+  MAX_RECORDS,
+  USERS_API,
+} from '../../constants';
+
+const DEFAULT_DATA = [];
+
+const useUsersQuery = (params = {}, options = {}) => {
+  const stripes = useStripes();
+
+  const {
+    limit = stripes?.config?.maxUnpagedResourceCount || MAX_RECORDS,
+    offset = 0,
+    query = 'cql.allRecords=1',
+  } = params;
+
+  const {
+    enabled = true,
+    tenantId,
+    ...queryOptions
+  } = options;
+
+  const ky = useOkapiKy({ tenant: tenantId });
+  const [namespace] = useNamespace();
+
+  const searchParams = {
+    query,
+    limit,
+    offset,
+  };
+
+  const {
+    data,
+    isFetching,
+    isLoading,
+    isFetched,
+  } = useQuery({
+    queryKey: ['users', namespace, tenantId, query, limit, offset],
+    queryFn: async ({ signal }) => ky.get(USERS_API, { searchParams, signal }).json(),
+    enabled,
+    ...queryOptions,
+  });
+
+  return {
+    isFetched,
+    isFetching,
+    isLoading,
+    users: data?.users ?? DEFAULT_DATA,
+    totalRecords: data?.totalRecords ?? 0,
+  };
+};
+
+export default useUsersQuery;

--- a/src/hooks/useUsersQuery/useUsersQuery.js
+++ b/src/hooks/useUsersQuery/useUsersQuery.js
@@ -44,7 +44,7 @@ const useUsersQuery = (params = {}, options = {}) => {
     isFetched,
   } = useQuery({
     queryKey: ['users', namespace, tenantId, query, limit, offset],
-    queryFn: async ({ signal }) => ky.get(USERS_API, { searchParams, signal }).json(),
+    queryFn: ({ signal }) => ky.get(USERS_API, { searchParams, signal }).json(),
     enabled,
     ...queryOptions,
   });

--- a/src/hooks/useUsersQuery/useUsersQuery.test.js
+++ b/src/hooks/useUsersQuery/useUsersQuery.test.js
@@ -1,0 +1,81 @@
+/* Developed collaboratively using AI (GitHub Copilot) */
+
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import {
+  renderHook,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useOkapiKy } from '@folio/stripes/core';
+
+import {
+  MAX_RECORDS,
+  USERS_API,
+} from '../../constants';
+import useUsersQuery from './useUsersQuery';
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useUsersQuery', () => {
+  const mockKy = {
+    get: jest.fn(() => ({
+      json: jest.fn(() => Promise.resolve({
+        users: [{ id: '1', name: 'Test User' }],
+        totalRecords: 1,
+      })),
+    })),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useOkapiKy.mockReturnValue(mockKy);
+  });
+
+  it('should fetch users with default parameters', async () => {
+    const { result } = renderHook(() => useUsersQuery(), { wrapper });
+
+    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+
+    expect(mockKy.get).toHaveBeenCalledWith(USERS_API, expect.objectContaining({
+      searchParams: {
+        query: 'cql.allRecords=1',
+        limit: MAX_RECORDS,
+        offset: 0,
+      },
+    }));
+
+    expect(result.current.users).toEqual([{ id: '1', name: 'Test User' }]);
+    expect(result.current.totalRecords).toBe(1);
+  });
+
+  it('should fetch users with custom parameters', async () => {
+    const params = {
+      limit: 10,
+      offset: 5,
+      query: 'username="test"',
+    };
+    const { result } = renderHook(() => useUsersQuery(params), { wrapper });
+
+    await waitFor(() => expect(result.current.isFetching).toBeFalsy());
+
+    expect(mockKy.get).toHaveBeenCalledWith(USERS_API, expect.objectContaining({
+      searchParams: {
+        query: 'username="test"',
+        limit: 10,
+        offset: 5,
+      },
+    }));
+
+    expect(result.current.users).toEqual([{ id: '1', name: 'Test User' }]);
+    expect(result.current.totalRecords).toBe(1);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,7 @@ class UsersRouting extends React.Component {
               <Route
                 path={`${base}/pre-registration-records/duplicates`}
                 render={props => (
-                  <IfPermission perm="ui-users.patron-pre-registrations-view">
+                  <IfPermission perm="ui-users.patron-pre-registrations.view">
                     <Routes.PatronPreRegistrationRecordsDuplicatesPage {...props} />
                   </IfPermission>
                 )}
@@ -226,7 +226,7 @@ class UsersRouting extends React.Component {
               <Route
                 path={`${base}/pre-registration-records`}
                 render={props => (
-                  <IfPermission perm="ui-users.patron-pre-registrations-view">
+                  <IfPermission perm="ui-users.patron-pre-registrations.view">
                     <Routes.PatronPreRegistrationRecordsContainer {...props} />
                   </IfPermission>
                 )}

--- a/src/index.js
+++ b/src/index.js
@@ -216,7 +216,7 @@ class UsersRouting extends React.Component {
               <Route path={`${base}/create`} component={Routes.UserEditContainer} />
               <Route path={`${base}/lost-items`} component={Routes.LostItemsContainer} />
               <Route
-                path={`${base}/pre-registration-records/duplicates`}
+                path={`${base}/pre-registration-records/duplicates/:id`}
                 render={props => (
                   <IfPermission perm="ui-users.patron-pre-registrations.view">
                     <Routes.PatronPreRegistrationRecordsDuplicatesPage {...props} />

--- a/src/routes/PatronPreRegistrationRecordsDuplicatesPage.js
+++ b/src/routes/PatronPreRegistrationRecordsDuplicatesPage.js
@@ -1,8 +1,27 @@
+import {
+  useHistory,
+  useLocation,
+} from 'react-router-dom';
+
 import { PatronPreRegistrationRecordsDuplicates } from '../views';
 
-const PatronPreRegistrationRecordsDuplicatesPage = () => {
+export const PatronPreRegistrationRecordsDuplicatesPage = () => {
+  const history = useHistory();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+
+  const onClose = () => {
+    history.push({
+      pathname: '/users/pre-registration-records',
+      search: location.state?.search,
+    });
+  };
+
   return (
-    <PatronPreRegistrationRecordsDuplicates />
+    <PatronPreRegistrationRecordsDuplicates
+      email={searchParams.get('email')}
+      onClose={onClose}
+    />
   );
 };
 

--- a/src/routes/PatronPreRegistrationRecordsDuplicatesPage.js
+++ b/src/routes/PatronPreRegistrationRecordsDuplicatesPage.js
@@ -1,14 +1,24 @@
 import {
   useHistory,
   useLocation,
+  useParams,
 } from 'react-router-dom';
 
+import { useStagingUsersQuery } from '../hooks';
 import { PatronPreRegistrationRecordsDuplicates } from '../views';
 
 export const PatronPreRegistrationRecordsDuplicatesPage = () => {
+  const { id: stagingUserId } = useParams();
   const history = useHistory();
   const location = useLocation();
-  const searchParams = new URLSearchParams(location.search);
+
+  const {
+    isLoading,
+    users,
+  } = useStagingUsersQuery(
+    { query: `id=="${stagingUserId}"` },
+    { enabled: Boolean(stagingUserId) },
+  );
 
   const onClose = () => {
     history.push({
@@ -19,8 +29,9 @@ export const PatronPreRegistrationRecordsDuplicatesPage = () => {
 
   return (
     <PatronPreRegistrationRecordsDuplicates
-      email={searchParams.get('email')}
+      user={users[0]}
       onClose={onClose}
+      isLoading={isLoading}
     />
   );
 };

--- a/src/routes/PatronPreRegistrationRecordsDuplicatesPage.test.js
+++ b/src/routes/PatronPreRegistrationRecordsDuplicatesPage.test.js
@@ -1,0 +1,92 @@
+import {
+  useHistory,
+  useLocation,
+} from 'react-router-dom';
+
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+
+import renderWithRouter from 'helpers/renderWithRouter';
+import {
+  usePatronGroups,
+  useUsersQuery,
+} from '../hooks';
+import { PatronPreRegistrationRecordsDuplicatesPage } from './PatronPreRegistrationRecordsDuplicatesPage';
+
+jest.unmock('@folio/stripes/components');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: jest.fn(),
+  useLocation: jest.fn(),
+}));
+jest.mock('react-virtualized-auto-sizer', () => ({ children }) => children({ height: 500, width: 500 }));
+jest.mock('../hooks', () => ({
+  ...jest.requireActual('../hooks'),
+  usePatronGroups: jest.fn(),
+  useUsersQuery: jest.fn(),
+}));
+
+const renderComponent = (props = {}) => renderWithRouter(
+  <PatronPreRegistrationRecordsDuplicatesPage
+    {...props}
+  />
+);
+
+
+describe('PatronPreRegistrationRecordsDuplicatesPage', () => {
+  const pushMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useHistory.mockReturnValue({
+      push: pushMock,
+    });
+    useLocation.mockReturnValue({
+      search: '?email=ex@mp.le',
+      state: {
+        search: 'query',
+      },
+    });
+
+    usePatronGroups.mockReturnValue({
+      patronGroups: [{
+        id: '3684a786-6671-4268-8ed0-9db82ebca60b',
+        group: 'test',
+      }],
+    });
+    useUsersQuery.mockReturnValue({
+      users: [{
+        active: true,
+        personal: {
+          firstName: 'John',
+          lastName: 'Galt',
+          email: 'ex@mp.le',
+        },
+        username: 'test',
+        type: 'patron',
+        patronGroup: '3684a786-6671-4268-8ed0-9db82ebca60b',
+        barcode: '123456789',
+      }],
+    });
+  });
+
+  it('should render duplicates page', () => {
+    renderComponent();
+
+    expect(screen.getByText('ui-users.stagingRecords.duplicates.results.paneTitle')).toBeInTheDocument();
+    expect(screen.getByText('ui-users.stagingRecords.duplicates.results.warning')).toBeInTheDocument();
+  });
+
+  it('should close duplicates page', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', { name: 'stripes-components.closeItem' }));
+
+    expect(pushMock).toHaveBeenCalledWith({
+      pathname: '/users/pre-registration-records',
+      search: 'query',
+    });
+  });
+});

--- a/src/routes/PatronPreRegistrationRecordsDuplicatesPage.test.js
+++ b/src/routes/PatronPreRegistrationRecordsDuplicatesPage.test.js
@@ -9,6 +9,7 @@ import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import renderWithRouter from 'helpers/renderWithRouter';
 import {
   usePatronGroups,
+  useStagingUsersQuery,
   useUsersQuery,
 } from '../hooks';
 import { PatronPreRegistrationRecordsDuplicatesPage } from './PatronPreRegistrationRecordsDuplicatesPage';
@@ -24,6 +25,7 @@ jest.mock('react-virtualized-auto-sizer', () => ({ children }) => children({ hei
 jest.mock('../hooks', () => ({
   ...jest.requireActual('../hooks'),
   usePatronGroups: jest.fn(),
+  useStagingUsersQuery: jest.fn(),
   useUsersQuery: jest.fn(),
 }));
 
@@ -55,6 +57,20 @@ describe('PatronPreRegistrationRecordsDuplicatesPage', () => {
         id: '3684a786-6671-4268-8ed0-9db82ebca60b',
         group: 'test',
       }],
+    });
+    useStagingUsersQuery.mockReturnValue({
+      users: [{
+        id: '11997fe2-785c-418f-9739-de1d08ffc84b',
+        isEmailVerified: true,
+        status: 'TIER-2',
+        generalInfo: {
+          firstName: 'John',
+          lastName: 'Galt'
+        },
+        contactInfo: {
+          email: 'ex@mp.le'
+        },
+      }]
     });
     useUsersQuery.mockReturnValue({
       users: [{

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.js
@@ -1,11 +1,67 @@
+import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-const PatronPreRegistrationRecordsDuplicates = () => {
-  return (
-    <div>
-      <FormattedMessage id="ui-users.stagingRecords.duplicates.results.paneTitle" />
-    </div>
+import {
+  MessageBanner,
+  Pane,
+  Paneset,
+} from '@folio/stripes/components';
+
+import { useUsersQuery } from '../../hooks';
+import { getPatronDuplicatesQuery } from '../../utils';
+import PreRegistrationRecordsDuplicatesList from './PreRegistrationRecordsDuplicatesList';
+
+const PatronPreRegistrationRecordsDuplicates = ({
+  email,
+  onClose,
+}) => {
+  const {
+    isFetched,
+    isLoading,
+    users,
+    totalRecords,
+  } = useUsersQuery(
+    { query: getPatronDuplicatesQuery({ email }) },
+    { enabled: Boolean(email) },
   );
+
+  const paneSub = isFetched
+    ? (
+      <FormattedMessage
+        id="stripes-smart-components.searchResultsCountHeader"
+        values={{ count: totalRecords }}
+      />
+    )
+    : <FormattedMessage id="stripes-smart-components.searchCriteria" />;
+
+  return (
+    <Paneset isRoot>
+      <Pane
+        id="pane-user-duplicates"
+        defaultWidth="100%"
+        dismissible
+        onClose={onClose}
+        paneTitle={<FormattedMessage id="ui-users.stagingRecords.duplicates.results.paneTitle" />}
+        paneSub={paneSub}
+      >
+        <MessageBanner type="warning">
+          <FormattedMessage id="ui-users.stagingRecords.duplicates.results.warning" />
+        </MessageBanner>
+
+        <PreRegistrationRecordsDuplicatesList
+          isLoading={isLoading}
+          email={email}
+          users={users}
+          totalRecords={totalRecords}
+        />
+      </Pane>
+    </Paneset>
+  );
+};
+
+PatronPreRegistrationRecordsDuplicates.propTypes = {
+  email: PropTypes.string,
+  onClose: PropTypes.func.isRequired,
 };
 
 export default PatronPreRegistrationRecordsDuplicates;

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.js
@@ -1,9 +1,15 @@
 import PropTypes from 'prop-types';
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import {
   MessageBanner,
   Pane,
+  PaneHeader,
   Paneset,
 } from '@folio/stripes/components';
 
@@ -15,6 +21,39 @@ const PatronPreRegistrationRecordsDuplicates = ({
   email,
   onClose,
 }) => {
+  const [wrapperHeight, setWrapperHeight] = useState();
+  const listWrapperRef = useRef(null);
+
+  /*
+    * Adjust the height of the list wrapper to fill the available space
+    * between the list wrapper and the bottom of the screen.
+  */
+  useLayoutEffect(() => {
+    const observedElement = listWrapperRef.current;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      if (!entries.length) return;
+
+      const { target } = entries[0];
+
+      if (listWrapperRef.current?.parentElement) {
+        const paddingBottom = parseFloat(window.getComputedStyle(listWrapperRef.current.parentElement).paddingBottom);
+
+        setWrapperHeight(listWrapperRef.current.parentElement.clientHeight - target.offsetTop - paddingBottom);
+      }
+    });
+
+    if (observedElement) {
+      resizeObserver.observe(observedElement);
+    }
+
+    return () => {
+      if (observedElement) {
+        resizeObserver.unobserve(observedElement);
+      }
+    };
+  }, []);
+
   const {
     isFetched,
     isLoading,
@@ -39,21 +78,30 @@ const PatronPreRegistrationRecordsDuplicates = ({
       <Pane
         id="pane-user-duplicates"
         defaultWidth="100%"
-        dismissible
-        onClose={onClose}
-        paneTitle={<FormattedMessage id="ui-users.stagingRecords.duplicates.results.paneTitle" />}
-        paneSub={paneSub}
+        renderHeader={() => (
+          <PaneHeader
+            dismissible
+            onClose={onClose}
+            paneTitle={<FormattedMessage id="ui-users.stagingRecords.duplicates.results.paneTitle" />}
+            paneSub={paneSub}
+          />
+        )}
       >
         <MessageBanner type="warning">
           <FormattedMessage id="ui-users.stagingRecords.duplicates.results.warning" />
         </MessageBanner>
 
-        <PreRegistrationRecordsDuplicatesList
-          isLoading={isLoading}
-          email={email}
-          users={users}
-          totalRecords={totalRecords}
-        />
+        <div
+          ref={listWrapperRef}
+          style={{ height: wrapperHeight }}
+        >
+          <PreRegistrationRecordsDuplicatesList
+            isLoading={isLoading}
+            email={email}
+            users={users}
+            totalRecords={totalRecords}
+          />
+        </div>
       </Pane>
     </Paneset>
   );

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.js
@@ -1,3 +1,4 @@
+import debounce from 'lodash/debounce';
 import PropTypes from 'prop-types';
 import {
   useLayoutEffect,
@@ -31,7 +32,7 @@ const PatronPreRegistrationRecordsDuplicates = ({
   useLayoutEffect(() => {
     const observedElement = listWrapperRef.current;
 
-    const resizeObserver = new ResizeObserver((entries) => {
+    const resizeObserver = new ResizeObserver(debounce((entries) => {
       if (!entries.length) return;
 
       const { target } = entries[0];
@@ -41,7 +42,7 @@ const PatronPreRegistrationRecordsDuplicates = ({
 
         setWrapperHeight(listWrapperRef.current.parentElement.clientHeight - target.offsetTop - paddingBottom);
       }
-    });
+    }, 100));
 
     if (observedElement) {
       resizeObserver.observe(observedElement);

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.js
@@ -19,11 +19,24 @@ import { getPatronDuplicatesQuery } from '../../utils';
 import PreRegistrationRecordsDuplicatesList from './PreRegistrationRecordsDuplicatesList';
 
 const PatronPreRegistrationRecordsDuplicates = ({
-  email,
+  isLoading,
+  user,
   onClose,
 }) => {
   const [wrapperHeight, setWrapperHeight] = useState();
   const listWrapperRef = useRef(null);
+
+  const email = user?.contactInfo?.email;
+
+  const {
+    isFetched,
+    isLoading: isUsersLoading,
+    users,
+    totalRecords,
+  } = useUsersQuery(
+    { query: getPatronDuplicatesQuery({ email }) },
+    { enabled: Boolean(email) },
+  );
 
   /*
     * Adjust the height of the list wrapper to fill the available space
@@ -54,16 +67,6 @@ const PatronPreRegistrationRecordsDuplicates = ({
       }
     };
   }, []);
-
-  const {
-    isFetched,
-    isLoading,
-    users,
-    totalRecords,
-  } = useUsersQuery(
-    { query: getPatronDuplicatesQuery({ email }) },
-    { enabled: Boolean(email) },
-  );
 
   const paneSub = isFetched
     ? (
@@ -97,8 +100,8 @@ const PatronPreRegistrationRecordsDuplicates = ({
           style={{ height: wrapperHeight }}
         >
           <PreRegistrationRecordsDuplicatesList
-            isLoading={isLoading}
-            email={email}
+            isLoading={isLoading || isUsersLoading}
+            user={user}
             users={users}
             totalRecords={totalRecords}
           />
@@ -109,8 +112,9 @@ const PatronPreRegistrationRecordsDuplicates = ({
 };
 
 PatronPreRegistrationRecordsDuplicates.propTypes = {
-  email: PropTypes.string,
+  isLoading: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
+  user: PropTypes.object,
 };
 
 export default PatronPreRegistrationRecordsDuplicates;

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.test.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.test.js
@@ -2,8 +2,13 @@ import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 
-import { usePatronGroups, useUsersQuery } from '../../hooks';
+import {
+  usePatronGroups,
+  useUsersQuery,
+} from '../../hooks';
 import PatronPreRegistrationRecordsDuplicates from './PatronPreRegistrationRecordsDuplicates';
+
+jest.unmock('@folio/stripes/components');
 
 jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.test.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PatronPreRegistrationRecordsDuplicates.test.js
@@ -2,13 +2,45 @@ import { screen } from '@folio/jest-config-stripes/testing-library/react';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 
+import { usePatronGroups, useUsersQuery } from '../../hooks';
 import PatronPreRegistrationRecordsDuplicates from './PatronPreRegistrationRecordsDuplicates';
+
+jest.mock('../../hooks', () => ({
+  ...jest.requireActual('../../hooks'),
+  usePatronGroups: jest.fn(),
+  useUsersQuery: jest.fn(),
+}));
 
 const renderComponent = (props) => renderWithRouter(
   <PatronPreRegistrationRecordsDuplicates {...props} />
 );
 
 describe('PatronsPreRegistrationListContainer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    usePatronGroups.mockReturnValue({
+      patronGroups: [{
+        id: '3684a786-6671-4268-8ed0-9db82ebca60b',
+        group: 'test',
+      }],
+    });
+    useUsersQuery.mockReturnValue({
+      users: [{
+        active: true,
+        personal: {
+          firstName: 'John',
+          lastName: 'Galt',
+          email: 'ex@mp.le'
+        },
+        username: 'test',
+        type: 'patron',
+        patronGroup: '3684a786-6671-4268-8ed0-9db82ebca60b',
+        barcode: '123456789',
+      }],
+    });
+  });
+
   it('should render component', () => {
     renderComponent();
 

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesList.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesList.js
@@ -1,0 +1,109 @@
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { useLocation } from 'react-router';
+
+import {
+  Button,
+  Layout,
+  MultiColumnList,
+  NoValue,
+  TextLink,
+} from '@folio/stripes/components';
+import { AppIcon } from '@folio/stripes/core';
+import { getFullName } from '@folio/stripes/util';
+
+import css from '../../UserSearch/UserSearch.css';
+
+const getResultsFormatter = ({ onMerge, patronGroups, location }) => {
+  const getRowURL = (userId) => {
+    return {
+      pathname: `/users/view/${userId}`,
+      state: {
+        referrer: {
+          pathname: location.pathname,
+          search: location.search,
+          state: location.state,
+        }
+      },
+    };
+  };
+
+  return {
+    action: user => (
+      <Layout className="full flex centerContent">
+        <Button
+          onClick={() => onMerge(user)}
+          marginBottom0
+        >
+          <FormattedMessage id="ui-users.stagingRecords.merge" />
+        </Button>
+      </Layout>
+    ),
+    active: user => {
+      return user.active
+        ? <FormattedMessage id="ui-users.active" />
+        : <FormattedMessage id="ui-users.inactive" />;
+    },
+    name: user => (
+      <>
+        <AppIcon
+          app="users"
+          size="small"
+          className={user.active ? undefined : css.inactiveAppIcon}
+        />
+        &nbsp;
+        <TextLink to={getRowURL(user.id)}>{getFullName(user)}</TextLink>
+      </>
+    ),
+    barcode: user => user.barcode || <NoValue />,
+    patronGroup: (user) => patronGroups.find(g => g.id === user.patronGroup)?.group || '?',
+    username: user => user.username || <NoValue />,
+    email: user => user?.personal?.email || <NoValue />,
+  };
+};
+
+const COLUMN_MAPPING = {
+  action: <FormattedMessage id="ui-users.action" />,
+  name: <FormattedMessage id="ui-users.information.name" />,
+  active: <FormattedMessage id="ui-users.active" />,
+  barcode: <FormattedMessage id="ui-users.information.barcode" />,
+  patronGroup: <FormattedMessage id="ui-users.information.patronGroup" />,
+  username: <FormattedMessage id="ui-users.information.username" />,
+  email: <FormattedMessage id="ui-users.contact.email" />,
+};
+
+const VISIBLE_COLUMNS = Object.keys(COLUMN_MAPPING);
+
+const PreRegistrationRecordsDuplicatesList = ({
+  isLoading,
+  onMerge,
+  patronGroups,
+  totalRecords,
+  users,
+}) => {
+  const location = useLocation();
+
+  return (
+    <MultiColumnList
+      id="patron-user-duplicates-list"
+      virtualize
+      isLoading={isLoading}
+      columnMapping={COLUMN_MAPPING}
+      contentData={users}
+      formatter={getResultsFormatter({ onMerge, patronGroups, location })}
+      totalCount={totalRecords}
+      visibleColumns={VISIBLE_COLUMNS}
+      interactive={false}
+    />
+  );
+};
+
+PreRegistrationRecordsDuplicatesList.propTypes = {
+  isLoading: PropTypes.bool,
+  onMerge: PropTypes.func.isRequired,
+  patronGroups: PropTypes.arrayOf(PropTypes.object),
+  totalRecords: PropTypes.number,
+  users: PropTypes.arrayOf(PropTypes.object),
+};
+
+export default PreRegistrationRecordsDuplicatesList;

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesList.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesList.js
@@ -86,6 +86,7 @@ const PreRegistrationRecordsDuplicatesList = ({
   return (
     <MultiColumnList
       id="patron-user-duplicates-list"
+      autosize
       virtualize
       isLoading={isLoading}
       columnMapping={COLUMN_MAPPING}

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesList.test.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesList.test.js
@@ -1,0 +1,63 @@
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+
+import renderWithRouter from 'helpers/renderWithRouter';
+
+import PreRegistrationRecordsDuplicatesList from './PreRegistrationRecordsDuplicatesList';
+
+jest.unmock('@folio/stripes/components');
+jest.mock('react-virtualized-auto-sizer', () => ({ children }) => children({ height: 500, width: 500 }));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn().mockReturnValue({
+    pathname: '/users',
+    search: '',
+    state: {},
+  }),
+}));
+
+const patronGroups = [{
+  id: '3684a786-6671-4268-8ed0-9db82ebca60b',
+  group: 'test',
+}];
+
+const users = [{
+  active: true,
+  personal: {
+    firstName: 'John',
+    lastName: 'Galt',
+    email: 'ex@mp.le'
+  },
+  username: 'test',
+  type: 'patron',
+  patronGroup: '3684a786-6671-4268-8ed0-9db82ebca60b',
+  barcode: '123456789',
+}];
+
+const defaultProps = {
+  isLoading: false,
+  onMerge: jest.fn(),
+  patronGroups,
+  totalRecords: users.length,
+  users,
+};
+
+const renderComponent = (props) => renderWithRouter(
+  <PreRegistrationRecordsDuplicatesList
+    {...defaultProps}
+    {...props}
+  />
+);
+
+describe('PreRegistrationRecordsDuplicatesList', () => {
+  it('should render component', () => {
+    renderComponent();
+
+    // MCL columns
+    expect(screen.getByText('ui-users.action')).toBeInTheDocument();
+    expect(screen.getByText('ui-users.information.name')).toBeInTheDocument();
+    expect(screen.getByText('ui-users.information.barcode')).toBeInTheDocument();
+    expect(screen.getByText('ui-users.information.patronGroup')).toBeInTheDocument();
+    expect(screen.getByText('ui-users.information.username')).toBeInTheDocument();
+    expect(screen.getByText('ui-users.contact.email')).toBeInTheDocument();
+  });
+});

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesListContainer.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesListContainer.js
@@ -6,15 +6,15 @@ import { usePatronGroups } from '../../../hooks';
 import PreRegistrationRecordsDuplicatesList from './PreRegistrationRecordsDuplicatesList';
 
 const PreRegistrationRecordsDuplicatesListContainer = ({
-  email,
   isLoading,
   totalRecords,
+  user,
   users,
 }) => {
   const {
     isLoading: isPatronGroupsLoading,
     patronGroups,
-  } = usePatronGroups({ enabled: Boolean(email) });
+  } = usePatronGroups({ enabled: Boolean(user?.id) });
 
   // TODO: https://folio-org.atlassian.net/browse/UIU-3225
   const onMerge = () => noop();
@@ -31,9 +31,9 @@ const PreRegistrationRecordsDuplicatesListContainer = ({
 };
 
 PreRegistrationRecordsDuplicatesListContainer.propTypes = {
-  email: PropTypes.string,
   isLoading: PropTypes.bool,
   totalRecords: PropTypes.number,
+  user: PropTypes.object,
   users: PropTypes.arrayOf(PropTypes.object),
 };
 

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesListContainer.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesListContainer.js
@@ -1,3 +1,4 @@
+import noop from 'lodash/noop';
 import PropTypes from 'prop-types';
 
 import { usePatronGroups } from '../../../hooks';
@@ -15,7 +16,8 @@ const PreRegistrationRecordsDuplicatesListContainer = ({
     patronGroups,
   } = usePatronGroups({ enabled: Boolean(email) });
 
-  const onMerge = () => console.log('merge');
+  // TODO: https://folio-org.atlassian.net/browse/UIU-3225
+  const onMerge = () => noop();
 
   return (
     <PreRegistrationRecordsDuplicatesList

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesListContainer.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/PreRegistrationRecordsDuplicatesListContainer.js
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types';
+
+import { usePatronGroups } from '../../../hooks';
+
+import PreRegistrationRecordsDuplicatesList from './PreRegistrationRecordsDuplicatesList';
+
+const PreRegistrationRecordsDuplicatesListContainer = ({
+  email,
+  isLoading,
+  totalRecords,
+  users,
+}) => {
+  const {
+    isLoading: isPatronGroupsLoading,
+    patronGroups,
+  } = usePatronGroups({ enabled: Boolean(email) });
+
+  const onMerge = () => console.log('merge');
+
+  return (
+    <PreRegistrationRecordsDuplicatesList
+      isLoading={isLoading || isPatronGroupsLoading}
+      patronGroups={patronGroups}
+      users={users}
+      totalRecords={totalRecords}
+      onMerge={onMerge}
+    />
+  );
+};
+
+PreRegistrationRecordsDuplicatesListContainer.propTypes = {
+  email: PropTypes.string,
+  isLoading: PropTypes.bool,
+  totalRecords: PropTypes.number,
+  users: PropTypes.arrayOf(PropTypes.object),
+};
+
+export default PreRegistrationRecordsDuplicatesListContainer;

--- a/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/index.js
+++ b/src/views/PatronPreRegistrationRecordsDuplicates/PreRegistrationRecordsDuplicatesList/index.js
@@ -1,0 +1,1 @@
+export { default } from './PreRegistrationRecordsDuplicatesListContainer';

--- a/src/views/PatronsPreRegistrationListContainer/PatronsPreRegistrationList.test.js
+++ b/src/views/PatronsPreRegistrationListContainer/PatronsPreRegistrationList.test.js
@@ -15,6 +15,11 @@ import { MultiColumnList } from '@folio/stripes/components';
 import { useUserDuplicatesCheck } from './hooks';
 import PatronsPreRegistrationList from './PatronsPreRegistrationList';
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({ search: '' }),
+}));
+
 jest.mock('./hooks', () => ({
   ...jest.requireActual('./hooks'),
   useUserDuplicatesCheck: jest.fn(),

--- a/src/views/PatronsPreRegistrationListContainer/hooks/useNewRecordHandler.js
+++ b/src/views/PatronsPreRegistrationListContainer/hooks/useNewRecordHandler.js
@@ -1,18 +1,23 @@
 import noop from 'lodash/noop';
 import { useMutation } from 'react-query';
-import { useHistory } from 'react-router-dom';
+import {
+  useHistory,
+  useLocation,
+} from 'react-router-dom';
 
 import useUserDuplicatesCheck from './useUserDuplicatesCheck';
 
-const handleDuplicates = (user, history) => {
+const handleDuplicates = (user, history, location) => {
   history.push({
     pathname: '/users/pre-registration-records/duplicates',
     search: `?email=${user?.contactInfo?.email}`,
+    state: { search: location.search },
   });
 };
 
 const useNewRecordHandler = () => {
   const history = useHistory();
+  const location = useLocation();
   const { checkDuplicates } = useUserDuplicatesCheck();
 
   const {
@@ -21,9 +26,13 @@ const useNewRecordHandler = () => {
   } = useMutation({
     mutationFn: checkDuplicates,
     onSuccess: (hasDuplicates, user) => {
-      const handleSuccess = hasDuplicates ? handleDuplicates : noop;
+      const handleSuccess = () => (
+        hasDuplicates
+          ? handleDuplicates(user, history, location)
+          : noop()
+      );
 
-      handleSuccess(user, history);
+      handleSuccess();
     },
   });
 

--- a/src/views/PatronsPreRegistrationListContainer/hooks/useNewRecordHandler.js
+++ b/src/views/PatronsPreRegistrationListContainer/hooks/useNewRecordHandler.js
@@ -9,8 +9,7 @@ import useUserDuplicatesCheck from './useUserDuplicatesCheck';
 
 const handleDuplicates = (user, history, location) => {
   history.push({
-    pathname: '/users/pre-registration-records/duplicates',
-    search: `?email=${user?.contactInfo?.email}`,
+    pathname: `/users/pre-registration-records/duplicates/${user.id}`,
     state: { search: location.search },
   });
 };

--- a/src/views/PatronsPreRegistrationListContainer/hooks/useNewRecordHandler.test.js
+++ b/src/views/PatronsPreRegistrationListContainer/hooks/useNewRecordHandler.test.js
@@ -15,6 +15,7 @@ jest.mock('react-query', () => ({
 
 jest.mock('react-router-dom', () => ({
   useHistory: jest.fn(),
+  useLocation: jest.fn(() => ({ search: '' })),
 }));
 
 jest.mock('./useUserDuplicatesCheck', () => jest.fn());
@@ -50,6 +51,7 @@ describe('useNewRecordHandler', () => {
     expect(mockHistoryPush).toHaveBeenCalledWith({
       pathname: '/users/pre-registration-records/duplicates',
       search: '?email=test@example.com',
+      state: { search: '' },
     });
   });
 });

--- a/src/views/PatronsPreRegistrationListContainer/hooks/useNewRecordHandler.test.js
+++ b/src/views/PatronsPreRegistrationListContainer/hooks/useNewRecordHandler.test.js
@@ -45,12 +45,14 @@ describe('useNewRecordHandler', () => {
     const { result } = renderHook(() => useNewRecordHandler());
 
     await act(async () => {
-      await result.current.handle({ contactInfo: { email: 'test@example.com' } });
+      await result.current.handle({
+        id: 'userId',
+        contactInfo: { email: 'test@example.com' },
+      });
     });
 
     expect(mockHistoryPush).toHaveBeenCalledWith({
-      pathname: '/users/pre-registration-records/duplicates',
-      search: '?email=test@example.com',
+      pathname: '/users/pre-registration-records/duplicates/userId',
       state: { search: '' },
     });
   });

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -360,13 +360,26 @@ class UserDetail extends React.Component {
     return `/users/${params.id}/edit${search}`;
   }
 
+  getLocationReferrer = () => {
+    const { location } = this.props;
+
+    return (
+      location.state?.referrer || (
+        // Check if the referrer is from the same origin
+        document.referrer.startsWith(window.location.origin)
+          ? document.referrer.replace(window.location.origin, '')
+          : null
+      )
+    );
+  }
+
   onClose = () => {
     const {
       history,
-      location
+      location,
     } = this.props;
 
-    history.push(`/users${location.search}`);
+    history.push(this.getLocationReferrer() || `/users${location.search}`);
   }
 
   getPatronGroup(user) {

--- a/src/views/UserDetail/UserDetail.test.js
+++ b/src/views/UserDetail/UserDetail.test.js
@@ -423,4 +423,50 @@ describe('UserDetail', () => {
       expect(screen.queryByText('Actions')).toBeNull();
     });
   });
+
+  describe('when user close users view', () => {
+    const history = { push: jest.fn() };
+
+    beforeEach(() => {
+      Object.defineProperty(document, 'referrer', { value: '', configurable: true });
+      history.push.mockClear();
+    });
+
+    it('should navigate to the referrer from location state which opened the view', async () => {
+      const location = {
+        state: {
+          referrer: '/route',
+        }
+      };
+
+      renderUserDetail(stripes, { history, location });
+
+      await userEvent.click(screen.getByTestId('close-pane'));
+
+      expect(history.push).toHaveBeenCalledWith(location.state.referrer);
+    });
+
+    it('should navigate to the referrer that opened view in a new tab', async () => {
+      const location = {};
+      const route = '/referrer-route';
+
+      renderUserDetail(stripes, { history, location });
+
+      Object.defineProperty(document, 'referrer', { value: `${global.location.origin}${route}` });
+
+      await userEvent.click(screen.getByTestId('close-pane'));
+
+      expect(history.push).toHaveBeenCalledWith(route);
+    });
+
+    it('should navigate to users list by default', async () => {
+      const location = { search: '?query=test' };
+
+      renderUserDetail(stripes, { history, location });
+
+      await userEvent.click(screen.getByTestId('close-pane'));
+
+      expect(history.push).toHaveBeenCalledWith(`/users${location.search}`);
+    });
+  });
 });

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -162,10 +162,18 @@ jest.mock('@folio/stripes/components', () => ({
   // destructure appIcon and dismissible so they aren't incorrectly
   // applied as DOM attributes via ...rest.
   // eslint-disable-next-line no-unused-vars
-  Pane: jest.fn(({ children, className, defaultWidth, paneTitle, firstMenu, lastMenu, actionMenu, appIcon, dismissible, ...rest }) => {
+  Pane: jest.fn(({ children, className, defaultWidth, paneTitle, firstMenu, lastMenu, actionMenu, appIcon, dismissible, onClose, ...rest }) => {
     return (
       <div className={className} {...rest} style={{ width: defaultWidth }}>
         <div>
+          {dismissible && (
+            <button
+              type="button"
+              data-testid="close-pane"
+              label="Close"
+              onClick={onClose}
+            />
+          )}
           {firstMenu ?? null}
           {paneTitle}
           {actionMenu ? actionMenu({ onToggle: jest.fn() }) : null}

--- a/test/jest/__mock__/stripesUtils.mock.js
+++ b/test/jest/__mock__/stripesUtils.mock.js
@@ -6,4 +6,5 @@ jest.mock('@folio/stripes/util', () => ({
   getHeaderWithCredentials: jest.fn(() => ({
     headers: {}
   })),
+  getFullName: jest.fn(),
 }));

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -1228,5 +1228,6 @@
   "stagingRecords.list.columnNames.submissionDate": "Submission date",
   "stagingRecords.list.columnNames.emailVerification": "Email verification",
   "stagingRecords.activated": "Activated",
-  "stagingRecords.notActivated": "Not activated"
+  "stagingRecords.notActivated": "Not activated",
+  "stagingRecords.merge": "Merge"
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->
https://folio-org.atlassian.net/browse/UIU-3224

Display a list of duplicates for pre-stage patron user.

---
The first part of UIU-3224 - #2769 

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

 - Create a separate route for viewing duplicates of pre-stage users;
 - An autosized MCL will occupy the entire height of the parent Pane element, which has a set pixel value. Since, in addition to the MCL, there is also a banner inside the Pane, it is necessary to calculate the height of the container in which the MCL will be stored without an unnecessary scrollbar. For this, ResizeObserver should be used.
-  To preserve information about filters between pages, we will use location state. Since the user information page can be opened in a new tab from the duplicates page, for better UX, you should check the "referrer" property when closing the page. For security, you should also make sure the links comply with the same origin policy.

## Screenshot

https://github.com/user-attachments/assets/69075248-64b8-4beb-8481-bb77680f9a4a

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
