### PR TITLE
UIU-3216: Update permission name after Review and cleanup Module Descriptor for ui-checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 *  "borrower.patronGroup" print patron group's name based on id. Refs UIU-3228.
 * Rename permission names of permissions "Users: Can view reading room access" and "Users: Can view, and edit reading room access".
 * Create new user record from preregistration data when no matching folio user is found. Refs UIU-3223.
+* Update permission name after Review and cleanup Module Descriptor for ui-checkout. Refs UIU-3216.
 
 ## [10.1.2](https://github.com/folio-org/ui-users/tree/v10.1.2) (2024-09-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.1...v10.1.2)

--- a/src/components/PermissionsAccordion/components/PermissionsList/PermissionsList.test.js
+++ b/src/components/PermissionsAccordion/components/PermissionsList/PermissionsList.test.js
@@ -29,7 +29,7 @@ const props = {
       'moduleVersion' : '7.0.1000575',
     },
     {
-      'permissionName' : 'ui-checkout.viewRequests',
+      'permissionName' : 'ui-checkout.viewRequests.view',
       'displayName' : 'cq-ad',
       'id' : '607d641c-b67f-42a9-aee3-c440616133fa',
       'description' : 'Entire set of permissions needed to view requests',
@@ -79,7 +79,7 @@ describe('PermissionsList component', () => {
   it('checking each permission click status', () => {
     renderPermissionsList(props);
     fireEvent.click(document.querySelector('[data-permission-name="acq-admin"]'));
-    fireEvent.click(screen.getByText('ui-checkout.permission.viewRequests'));
+    fireEvent.click(screen.getByText('ui-checkout.permission.viewRequests.view'));
     expect(renderPermissionsList(props)).toBeTruthy();
   });
 });

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.test.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.test.js
@@ -26,7 +26,7 @@ const record = [
     'moduleName' : 'folio_agreements',
     'moduleVersion' : '8.0.1000774'
   }, {
-    'permissionName' : 'ui-checkout.viewFeeFines',
+    'permissionName' : 'ui-checkout.viewFeeFines.view',
     'displayName' : 'Check out: View fees/fines',
     'id' : '87a3f1b3-1e0a-4a4e-84de-31d417398257',
     'description' : 'Entire set of permissions needed to view fees/fines',
@@ -41,7 +41,7 @@ const record = [
     'moduleName' : 'folio_checkout',
     'moduleVersion' : '7.0.1000575'
   }, {
-    'permissionName' : 'ui-checkout.viewRequests',
+    'permissionName' : 'ui-checkout.viewRequests.view',
     'displayName' : '',
     'id' : '607d641c-b67f-42a9-aee3-c440616133fa',
     'description' : 'Entire set of permissions needed to view requests',

--- a/src/components/PermissionsAccordion/helpers/filtersConfig.test.js
+++ b/src/components/PermissionsAccordion/helpers/filtersConfig.test.js
@@ -17,7 +17,7 @@ const permissions = [
     'moduleName' : 'folio_agreements',
     'moduleVersion' : '8.0.1000774'
   }, {
-    'permissionName' : 'ui-checkout.viewFeeFines',
+    'permissionName' : 'ui-checkout.viewFeeFines.view',
     'displayName' : 'Check out: View fees/fines',
     'id' : '87a3f1b3-1e0a-4a4e-84de-31d417398257',
     'description' : 'Entire set of permissions needed to view fees/fines',
@@ -32,7 +32,7 @@ const permissions = [
     'moduleName' : 'folio_checkout',
     'moduleVersion' : '7.0.1000575'
   }, {
-    'permissionName' : 'ui-checkout.viewRequests',
+    'permissionName' : 'ui-checkout.viewRequests.view',
     'displayName' : '',
     'id' : '607d641c-b67f-42a9-aee3-c440616133fa',
     'description' : 'Entire set of permissions needed to view requests',


### PR DESCRIPTION
## Purpose
Update permission name after Review and cleanup Module Descriptor for ui-checkout

## Approach 
Consistency update permission with ui-checkout ( https://folio-org.atlassian.net/browse/UICHKOUT-919 )
Permissions renamed in according with Permissions naming convention ( https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/156368925/Permissions+naming+convention )

## Refs
https://issues.folio.org/browse/UIU-3216