### PR TITLE
UIU-3224 Avoid using `document.referrer` to identify back path route

### DIFF
--- a/src/views/PatronsPreRegistrationListContainer/PatronsPreRegistrationList.js
+++ b/src/views/PatronsPreRegistrationListContainer/PatronsPreRegistrationList.js
@@ -53,7 +53,7 @@ const PatronsPreRegistrationList = ({
     [COLUMNS_NAME.PHONE_NUMBER]: user => get(user, ['contactInfo', 'phone']),
     [COLUMNS_NAME.MOBILE_NUMBER]: user => get(user, ['contactInfo', 'mobilePhone']),
     [COLUMNS_NAME.ADDRESS]: user => {
-      const addressInfo = get(user, 'addressInfo');
+      const addressInfo = get(user, 'addressInfo', {});
       return Object.values(addressInfo).join(',');
     },
     [COLUMNS_NAME.EMAIL_COMMUNICATION_PREFERENCES]: user => get(user, ['preferredEmailCommunication']).join(','),

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -363,14 +363,7 @@ class UserDetail extends React.Component {
   getLocationReferrer = () => {
     const { location } = this.props;
 
-    return (
-      location.state?.referrer || (
-        // Check if the referrer is from the same origin
-        document.referrer.startsWith(window.location.origin)
-          ? document.referrer.replace(window.location.origin, '')
-          : null
-      )
-    );
+    return location.state?.referrer;
   }
 
   onClose = () => {

--- a/src/views/UserDetail/UserDetail.test.js
+++ b/src/views/UserDetail/UserDetail.test.js
@@ -428,7 +428,6 @@ describe('UserDetail', () => {
     const history = { push: jest.fn() };
 
     beforeEach(() => {
-      Object.defineProperty(document, 'referrer', { value: '', configurable: true });
       history.push.mockClear();
     });
 
@@ -444,19 +443,6 @@ describe('UserDetail', () => {
       await userEvent.click(screen.getByTestId('close-pane'));
 
       expect(history.push).toHaveBeenCalledWith(location.state.referrer);
-    });
-
-    it('should navigate to the referrer that opened view in a new tab', async () => {
-      const location = {};
-      const route = '/referrer-route';
-
-      renderUserDetail(stripes, { history, location });
-
-      Object.defineProperty(document, 'referrer', { value: `${global.location.origin}${route}` });
-
-      await userEvent.click(screen.getByTestId('close-pane'));
-
-      expect(history.push).toHaveBeenCalledWith(route);
     });
 
     it('should navigate to users list by default', async () => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->
https://folio-org.atlassian.net/browse/UIU-3224

The value of `document.referrer` stores the value of the page from which the original transition to the new tab was made. When navigating the page, this value does not change, which may lead to incorrect redirection when closing user details.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
