### PR TITLE
[UIU-3236] Cannot reset password for user not having a Keycloak record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * Update translations for pre registrations value. Refs UIU-3241.
 * Display a message to a user without permission on the “Patron preregistration record results” page. Refs UIU-3242.
 * Display preregistration data appropriately. Refs UIU-3247.
+* If keycloak user record doesn't exist, create it before resetting password. Refs UIU-3236.
 
 ## [10.1.2](https://github.com/folio-org/ui-users/tree/v10.1.2) (2024-09-05)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v10.1.1...v10.1.2)

--- a/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.js
+++ b/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.js
@@ -52,6 +52,7 @@ class CreateResetPasswordControl extends React.Component {
     }
   });
 
+
   constructor(props) {
     super(props);
     this.state = {
@@ -88,11 +89,11 @@ class CreateResetPasswordControl extends React.Component {
           // If user not found in keycloak, then create record before resetting password.
           if (response.httpStatus === 404) {
             keycloakUser.POST({ userId })
-              .then(this.handleResetPassword())
+              .then(this.handleResetPassword());
           } else { // 204 no-content response means record exists but is treated as an error by stripes-connect.
             this.handleResetPassword();
           }
-        })
+        });
     } else {
       this.handleResetPassword();
     }

--- a/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.test.js
+++ b/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.test.js
@@ -16,15 +16,19 @@ const resetPasswordPostMockFn = jest.fn(() => new Promise((resolve, _) => {
   resolve({ ok: true, link: 'bl-users/password-reset/link' });
 }));
 
-const keycloakUserGetMockFn = jest.fn(() => new Promise((resolve, _) => {
-  resolve({ ok: true });
+const keycloakUserFoundGetMockFn = jest.fn(() => new Promise((resolve, _) => {
+  resolve({ httpStatus: 204 });
+}));
+
+const keycloakUserNotFoundGetMockFn = jest.fn(() => new Promise((resolve, _) => {
+  resolve({ httpStatus: 404 });
 }));
 
 const keycloakUserPostMockFn = jest.fn(() => new Promise((resolve, _) => {
   resolve({ ok: true });
 }));
 
-const propData = (resetPasswordPostMock, keycloakUserGetMock, keycloakUserPostMock, disabled = false) => {
+const propData = (resetPasswordPostMock, keycloakUserGetMock, keycloakUserPostMock, disabled = false, isEureka = false) => {
   return {
     email: 'testemail@email.com',
     name: 'sample',
@@ -40,7 +44,7 @@ const propData = (resetPasswordPostMock, keycloakUserGetMock, keycloakUserPostMo
     },
     disabled,
     stripes: {
-      hasInterface: jest.fn()
+      hasInterface: jest.fn().mockReturnValue(isEureka)
     },
   };
 };
@@ -49,22 +53,34 @@ describe('CreateResetPasswordControl component', () => {
   afterEach(cleanup);
   it('If CreateResetPasswordControl Renders', () => {
     renderCreateResetPasswordControl(
-      propData(resetPasswordPostMockFn, keycloakUserGetMockFn, keycloakUserPostMockFn)
+      propData(resetPasswordPostMockFn, keycloakUserFoundGetMockFn, keycloakUserPostMockFn)
     );
     expect(screen.getByText('ui-users.extended.sendResetPassword')).toBeInTheDocument();
   });
   it('If reset password must be open with copy link', async () => {
     await waitFor(() => renderCreateResetPasswordControl(
-      propData(resetPasswordPostMockFn, keycloakUserGetMockFn, keycloakUserPostMockFn)
+      propData(resetPasswordPostMockFn, keycloakUserFoundGetMockFn, keycloakUserPostMockFn)
     ));
     await waitFor(() => userEvent.click(screen.getByText('ui-users.extended.sendResetPassword')));
     await waitFor(() => expect(screen.getByText('ui-users.extended.copyLink')).toBeInTheDocument());
   });
   it('should link be disabled', () => {
     renderCreateResetPasswordControl(
-      propData(resetPasswordPostMockFn, keycloakUserGetMockFn, keycloakUserPostMockFn, true)
+      propData(resetPasswordPostMockFn, keycloakUserFoundGetMockFn, keycloakUserPostMockFn, true)
     );
     expect(screen.getByText('ui-users.extended.sendResetPassword')).toBeDisabled();
+  });
+  it('shouldn\'t create keycloak user if using roles and account exists', () => {
+    renderCreateResetPasswordControl(
+      propData(resetPasswordPostMockFn, keycloakUserFoundGetMockFn, keycloakUserPostMockFn, false, false)
+    );
+    expect(screen.getByText('ui-users.extended.sendResetPassword')).toBeInTheDocument();
+  });
+  it('should create keycloak user if using roles and account doesn\'t exist', () => {
+    renderCreateResetPasswordControl(
+      propData(resetPasswordPostMockFn, keycloakUserNotFoundGetMockFn, keycloakUserPostMockFn, false, true)
+    );
+    expect(screen.getByText('ui-users.extended.sendResetPassword')).toBeInTheDocument();
   });
   /* Can be uncommented after the  createResetpasswordControl modal logic is reworked. Should add an assertion at the end after the results */
   // it('If it redirects after POST fails', async () => {

--- a/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.test.js
+++ b/src/components/EditSections/EditExtendedInfo/CreateResetPasswordControl/CreateResetPasswordControl.test.js
@@ -39,6 +39,9 @@ const propData = (resetPasswordPostMock, keycloakUserGetMock, keycloakUserPostMo
       }
     },
     disabled,
+    stripes: {
+      hasInterface: jest.fn()
+    },
   };
 };
 


### PR DESCRIPTION
- Fixes [UIU-3236](https://folio-org.atlassian.net/browse/UIU-3236) which only affects Eureka environments.
- When trying to reset a password for a user which does not have a record in Keycloak (which could be users created before an environment migrates to Eureka), the password reset request will fail. This change first checks keycloak to see if it has a record of the user. If not, it creates the record and then proceeds to generate the password reset link.  