### PR TITLE
UIU-3275 - Change users interface to 16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,19 @@
 ## [11.1.0] In progress
 
 * Correctly import from `dompurify`. Refs UIU-3267.
+* Change users interface to "16.3". Refs UIU-3275.
 
+## [11.0.3](https://github.com/folio-org/ui-users/tree/v11.0.3) (2024-11-14)
+[Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.2...v11.0.3)
+
+* Correctly import from `dompurify`. Refs UIU-3267.
+
+## [11.0.2](https://github.com/folio-org/ui-users/tree/v11.0.2) (2024-11-08)
+[Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.1...v11.0.2)
+
+* If keycloak user record doesn't exist, create it before resetting password. Refs UIU-3236.
+* Conditionally use delete method of the `mod-users-keycloak` if `users-keycloak` interface is present in UserRecordContainer. Refs UIU-3234.
+* Fix user edit without "Auth-Users" capability sets. Refs UIU-3243.
 
 ## [11.0.1](https://github.com/folio-org/ui-users/tree/v11.0.1) (2024-11-08)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.0...v11.0.1)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       }
     ],
     "okapiInterfaces": {
-      "users": "16.0 16.1 16.2",
+      "users": "16.3",
       "configuration": "2.0",
       "permissions": "5.7",
       "login": "7.3",


### PR DESCRIPTION
## Purpose
[UIU-3275](https://folio-org.atlassian.net/browse/UIU-3275) - Update permission checks

## Approach
The requirement of the ticket was to support permission changes/updates leveraging `hasAnyPerm` and `IfAnyPermission `utilities from `stripes core`. **This is targeted for Ramsons bugfix.** 

ui-users is introduced as a breaking change for Ramsons. Hence, changing users interface from "16.0 16.1 16.2" to "16.3" should be fine. Also, this does not impact the permission checks, as 
1. permission checks have already been updated with new permission names - https://github.com/folio-org/ui-users/pull/2778/files
2. translations have already been updated with new permission names - https://github.com/folio-org/ui-users/pull/2778/files
3. translations have also been synced accordingly - https://github.com/folio-org/ui-users/pull/2792/files

Due to this interface version change, permission checks need not be updated with above stated utilities.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
