### PR TITLE
Show all patron notice print jobs, in correct order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Correctly import from `dompurify`. Refs UIU-3267.
 * Change users interface to "16.3". Refs UIU-3275.
+* Show all patron notice print jobs (not just ten random ones), in correct order. Fixes UIU-3269.
 
 ## [11.0.3](https://github.com/folio-org/ui-users/tree/v11.0.3) (2024-11-14)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.2...v11.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,19 @@
 ## [11.1.0] In progress
 
 * Correctly import from `dompurify`. Refs UIU-3267.
+* Change users interface to "16.3". Refs UIU-3275.
 
+## [11.0.3](https://github.com/folio-org/ui-users/tree/v11.0.3) (2024-11-14)
+[Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.2...v11.0.3)
+
+* Correctly import from `dompurify`. Refs UIU-3267.
+
+## [11.0.2](https://github.com/folio-org/ui-users/tree/v11.0.2) (2024-11-08)
+[Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.1...v11.0.2)
+
+* If keycloak user record doesn't exist, create it before resetting password. Refs UIU-3236.
+* Conditionally use delete method of the `mod-users-keycloak` if `users-keycloak` interface is present in UserRecordContainer. Refs UIU-3234.
+* Fix user edit without "Auth-Users" capability sets. Refs UIU-3243.
 
 ## [11.0.1](https://github.com/folio-org/ui-users/tree/v11.0.1) (2024-11-08)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.0...v11.0.1)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       }
     ],
     "okapiInterfaces": {
-      "users": "16.0 16.1 16.2",
+      "users": "16.3",
       "configuration": "2.0",
       "permissions": "5.7",
       "login": "7.3",

--- a/src/routes/PatronNoticePrintJobsContainer.js
+++ b/src/routes/PatronNoticePrintJobsContainer.js
@@ -35,8 +35,8 @@ PatronNoticePrintJobsContainer.manifest = {
     type: 'okapi',
     path: 'print/entries',
     params: {
-      query: 'type="BATCH"',
-      sortby: 'created/sort.descending'
+      query: 'type="BATCH" sortby created/sort.descending',
+      limit: '100',
     },
     records: 'items',
     throwErrors: false,

--- a/src/views/PatronNoticePrintJobs/PatronNoticePrintJobs.js
+++ b/src/views/PatronNoticePrintJobs/PatronNoticePrintJobs.js
@@ -1,5 +1,4 @@
 
-import { orderBy } from 'lodash';
 import { Button, Pane, MenuSection, MultiColumnList, Checkbox, FormattedDate, FormattedTime, TextLink } from '@folio/stripes/components';
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
@@ -72,7 +71,7 @@ const PatronNoticePrintJobs = (props) => {
 
   useEffect(() => {
     const updatedRecords =
-      orderBy(records, (item) => item.created, sortOrder === DESC ? 'desc' : 'asc')
+      records
         .map(record => ({
           ...record,
           selected: !!record.selected,


### PR DESCRIPTION
We now show the top 100 patron notice print jobs, not 10.

More importantly, they are now sorted correctly (reverse chronological) on the server side, so even if the list grows past 100 and so is truncated in the UI at the first hundred, they will be the _right_ (most recent) first hundred.

Fixes UIU-3269.
