### PR TITLE
UIU-3279 supply tenantId in all useUserTenantRoles queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [11.1.0] In progress
 * Update permissions for mod-patron. Ref UIU-3259
+* `useUserTenantRoles` supplies `tenantId` in all its queries. Refs UIU-3279.
 
 ## [11.0.5](https://github.com/folio-org/ui-users/tree/v11.0.5) (2024-11-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.3...v11.0.5)

--- a/src/hooks/useUserTenantRoles/useUserTenantRoles.js
+++ b/src/hooks/useUserTenantRoles/useUserTenantRoles.js
@@ -71,6 +71,7 @@ const useUserTenantRoles = (
     ids,
     queryEnabled: isSuccess,
     reduceFunction: chunkedRolesReducer,
+    tenantId,
   });
 
   return {


### PR DESCRIPTION
Supply the `tenantId` argument in all queries. It was present in the query for a user's roles, but missing from the follow-up join-query that retrieved those roles' details, and thus returned an empty list unless the selected-tenant matched that of the currently-authenticated user.

Refs [UIU-3279](https://folio-org.atlassian.net/browse/UIU-3279)
