### PR TITLE
UIU-3291: Permissions error when adding a Fee-Fine via the User's app and Check-in.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Add permission to access users-keycloak delete method. Refs UIU-3282.
 * Fix issue with `Proxy borrower` field value. Refs UIU-3290.
 * Check if userId is present in withUserRoles HOC. Refs UIU-3273.
-
+* Add missed `circulation-storage.loans.item.get` permission. Refs UIU-3291.
 
 
 ## [11.0.7](https://github.com/folio-org/ui-users/tree/v11.0.7) (2024-11-30)

--- a/package.json
+++ b/package.json
@@ -705,7 +705,8 @@
           "feesfines.accounts.cancel.item.post",
           "feesfines.accounts-bulk.cancel.item.post",
           "feesfines.accounts.refund.item.post",
-          "feesfines.accounts-bulk.refund.item.post"
+          "feesfines.accounts-bulk.refund.item.post",
+          "circulation-storage.loans.item.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Add missed `circulation-storage.loans.item.get` sub-permission to be able to create new fee-fine if used has "Users: Can create, edit and remove fees/fines" permission

## Refs
[UIU-3291](https://folio-org.atlassian.net/browse/UIU-3291)