### PR TITLE
UIU-3294: Provide correct role-assignment permissions for endpoints within withUserRoles HOC used with UserEdit. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fix issue with `Proxy borrower` field value. Refs UIU-3290.
 * Check if userId is present in withUserRoles HOC. Refs UIU-3273.
 * Add missed `circulation-storage.loans.item.get`, `inventory.items.item.get` permissions. Refs UIU-3291.
-* Add missed `roles.users.collection.get`, `users-keycloak.auth-users.item.get`, `roles.users.item.put`, `users-keycloak.auth-users.item.post` permissions. UIU-3294.
+* Add missed permissions for endpoints used in withUserRoles HOC. UIU-3294.
 
 
 ## [11.0.7](https://github.com/folio-org/ui-users/tree/v11.0.7) (2024-11-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix issue with `Proxy borrower` field value. Refs UIU-3290.
 * Check if userId is present in withUserRoles HOC. Refs UIU-3273.
 * Add missed `circulation-storage.loans.item.get`, `inventory.items.item.get` permissions. Refs UIU-3291.
+* Add missed `roles.users.collection.get`, `users-keycloak.auth-users.item.get`, `roles.users.item.put`, `users-keycloak.auth-users.item.post` permissions. UIU-3294.
 
 
 ## [11.0.7](https://github.com/folio-org/ui-users/tree/v11.0.7) (2024-11-30)

--- a/package.json
+++ b/package.json
@@ -85,7 +85,9 @@
           "user-settings.custom-fields.item.stats.get",
           "departments.collection.get",
           "departments.item.get",
-          "users.configurations.item.get"
+          "users.configurations.item.get",
+          "roles.users.collection.get",
+          "users-keycloak.auth-users.item.get"
         ],
         "visible": true
       },
@@ -102,7 +104,9 @@
           "tags.collection.get",
           "tags.item.post",
           "circulation-storage.request-preferences.item.post",
-          "circulation-storage.request-preferences.item.put"
+          "circulation-storage.request-preferences.item.put",
+          "roles.users.item.put",
+          "users-keycloak.auth-users.item.post"
         ],
         "visible": true
       },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
           "departments.item.get",
           "users.configurations.item.get",
           "roles.users.collection.get",
-          "users-keycloak.auth-users.item.get"
+          "users-keycloak.auth-users.item.get",
+          "roles.collection.get"
         ],
         "visible": true
       },

--- a/src/hooks/useAllRolesData/useAllRolesData.js
+++ b/src/hooks/useAllRolesData/useAllRolesData.js
@@ -20,8 +20,8 @@ function useAllRolesData() {
   const [namespace] = useNamespace();
 
   const { data, isLoading, isSuccess } = useQuery([namespace, 'user-roles'], () => {
-    return stripes.hasInterface('roles') && ky.get(`roles?limit=${stripes.config.maxUnpagedResourceCount}&query=cql.allRecords=1 sortby name`).json();
-  });
+    return ky.get(`roles?limit=${stripes.config.maxUnpagedResourceCount}&query=cql.allRecords=1 sortby name`).json();
+  }, { enabled: stripes.hasInterface('roles') });
 
   const allRolesMapStructure = useMemo(() => {
     const rolesMap = new Map();


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
[UIU-3294](https://folio-org.atlassian.net/browse/UIU-3294) - Error toasts when opening a user for edit without having "User Roles" capability set
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Approach
1. Check endpoints used in [withUserRoles](https://github.com/folio-org/ui-users/blob/UIU-3294/src/components/Wrappers/withUserRoles.js) HOC;
2. Add subPermissions to ui-users.view, ui-users.edit based on module-descriptors [mod-roles-keycloak](https://github.com/folio-org/mod-roles-keycloak/blob/master/descriptors/ModuleDescriptor-template.json) and [mod-users-keycloak](https://github.com/folio-org/mod-users-keycloak/blob/master/descriptors/ModuleDescriptor-template.json)

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
