### PR TITLE
UIU-3312 provide itemToString to correctly serialize options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Update fee/fine actions column UX for accessibility. Refs UIU-3027.
 * Rename permission after BE changes. Refs UIU-3309.
 * Change import of `exportToCsv` from `stripes-util` to `stripes-components`. Refs UIU-3202.
+* Provide `itemToString` to create unique `key` attributes. Refs UIU-3312.
 
 ## [11.0.10](https://github.com/folio-org/ui-users/tree/v11.0.10) (2025-01-10)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.9...v11.0.10)

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.js
@@ -136,6 +136,7 @@ const EditContactInfo = ({
                 fullWidth
                 disabled={disabled}
                 filter={prefEmailCommFilterOptions}
+                itemToString={(option) => option.value}
               />
             </Col>
           </Row>


### PR DESCRIPTION
`MultiSelection` creates unique `key` attributes for its options with a default function of
```
(option) => option ? option.label : ''
```
but the `label` attribute here is a `<FormattedMessage>`, leading that function to serialize all options as `[object Object]`. Since we know the `value` attribute here is a unique string, we use that instead.

Refs [UIU-3312](https://folio-org.atlassian.net/browse/UIU-3312)

