### PR TITLE
[UIU-3301] Add missing .edit subpermission to roles.manage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
         "description": "",
         "subPermissions": [
           "ui-users.view",
+          "ui-users.edit",
           "ui-authorization-roles.users.settings.manage"
         ],
         "visible": true


### PR DESCRIPTION
- Follow-on from [[UIU-3301] Improve capability sets for role assignment/unassignment](https://github.com/folio-org/ui-users/pull/2833) and [[UIU-3301] Add ui-users.view as subpermission to roles permission sets](https://github.com/folio-org/ui-users/pull/2839)
- Added missing subpermission `ui-users.edit` to `ui-users.roles.manage` as reported by QA. This makes sense to add since you cannot manage user roles on the User detail screen. You must be on the Edit User screen, so without this subpermission, manage user roles is inaccessible. 