### PR TITLE
UIU-2531: Implement support for loans without item for Loan Detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add `pronouns` field to user view form. Refs UIU-3118.
 * Pronouns Field - add Character Limit Warning. Refs UIU-3324.
 * Add ability to create/edit role assignments for all of a user's affiliations. Refs UIU-3179.
+* Implement support for loans without item information. Refs UIU-2531.
 
 ## [11.0.11](https://github.com/folio-org/ui-users/tree/v11.0.11) (2025-01-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.10...v11.0.11)

--- a/src/components/Loans/OpenLoans/OpenLoansControl.js
+++ b/src/components/Loans/OpenLoans/OpenLoansControl.js
@@ -134,7 +134,9 @@ class OpenLoansControl extends React.Component {
   toggleAll = e => {
     const { loans } = this.props;
     const checkedLoans = e.target.checked
-      ? loans.reduce((memo, loan) => Object.assign(memo, { [loan.id]: loan }), {})
+      ? loans
+        .filter(loan => loan?.item)
+        .reduce((memo, loan) => Object.assign(memo, { [loan.id]: loan }), {})
       : {};
 
     this.setState(({ allChecked }) => ({

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -39,6 +39,9 @@ class ActionsDropdown extends React.Component {
     intl: PropTypes.object.isRequired,
     user: PropTypes.object.isRequired,
     patronGroup: PropTypes.object.isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func,
+    }).isRequired,
   };
 
   renderMenu = ({ onToggle }) => {
@@ -51,7 +54,8 @@ class ActionsDropdown extends React.Component {
       disableFeeFineDetails,
       match: { params },
       user,
-      patronGroup
+      patronGroup,
+      history,
     } = this.props;
 
     const itemStatusName = loan?.item?.status?.name;
@@ -61,6 +65,13 @@ class ActionsDropdown extends React.Component {
     const isUserActive = checkUserActive(user);
     const isVirtualUser = isDcbUser(user);
     const isVirtualItem = isDcbItem(loan?.item);
+    const isItemAbsent = !loan?.item;
+    const goToItemDetails = () => {
+      history.push(itemDetailsLink);
+    };
+    const createNewFeeFine = () => {
+      history.push(getChargeFineToLoanPath(params.id, loan.id));
+    };
 
     return (
       <DropdownMenu data-role="menu">
@@ -69,8 +80,8 @@ class ActionsDropdown extends React.Component {
             !isVirtualItem && (
               <Button
                 buttonStyle="dropdownItem"
-                to={itemDetailsLink}
-                disabled={!loan?.item}
+                onClick={goToItemDetails}
+                disabled={isItemAbsent}
               >
                 <FormattedMessage id="ui-users.itemDetails" />
               </Button>
@@ -81,6 +92,7 @@ class ActionsDropdown extends React.Component {
           { isUserActive && !isVirtualUser && itemStatusName !== itemStatuses.CLAIMED_RETURNED &&
             <Button
               buttonStyle="dropdownItem"
+              disabled={isItemAbsent}
               data-test-dropdown-content-renew-button
               onClick={e => {
                 handleOptionsChange({ loan, action: 'renew' });
@@ -95,6 +107,7 @@ class ActionsDropdown extends React.Component {
           { itemStatusName !== itemStatuses.CLAIMED_RETURNED && !isVirtualUser &&
             <Button
               buttonStyle="dropdownItem"
+              disabled={isItemAbsent}
               data-test-dropdown-content-claim-returned-button
               onClick={e => {
                 handleOptionsChange({ loan, action:'claimReturned', itemRequestCount });
@@ -112,6 +125,7 @@ class ActionsDropdown extends React.Component {
             !isVirtualUser &&
             <Button
               buttonStyle="dropdownItem"
+              disabled={isItemAbsent}
               data-test-dropdown-content-change-due-date-button
               onClick={(e) => {
                 handleOptionsChange({ loan, action:'changeDueDate' });
@@ -128,6 +142,7 @@ class ActionsDropdown extends React.Component {
               {(print) => (
                 <Button
                   buttonStyle="dropdownItem"
+                  disabled={isItemAbsent}
                   data-test-dropdown-content-print-due-date-button
                   onClick={(e) => {
                     print();
@@ -144,6 +159,7 @@ class ActionsDropdown extends React.Component {
           { itemStatusName !== itemStatuses.DECLARED_LOST && !isVirtualUser &&
             <Button
               buttonStyle="dropdownItem"
+              disabled={isItemAbsent}
               data-test-dropdown-content-declare-lost-button
               onClick={e => {
                 handleOptionsChange({ loan, action:'declareLost', itemRequestCount });
@@ -158,6 +174,7 @@ class ActionsDropdown extends React.Component {
           { itemStatusName === itemStatuses.CLAIMED_RETURNED && !isVirtualUser &&
           <Button
             buttonStyle="dropdownItem"
+            disabled={isItemAbsent}
             data-test-dropdown-content-mark-as-missing-button
             onClick={e => {
               handleOptionsChange({ loan, action:'markAsMissing', itemRequestCount });
@@ -185,8 +202,8 @@ class ActionsDropdown extends React.Component {
             !isVirtualUser && (
               <Button
                 buttonStyle="dropdownItem"
-                disabled={buttonDisabled}
-                to={getChargeFineToLoanPath(params.id, loan.id)}
+                disabled={buttonDisabled || !loan?.item}
+                onClick={createNewFeeFine}
               >
                 <FormattedMessage id="ui-users.loans.newFeeFine" />
               </Button>

--- a/src/components/Loans/OpenLoans/components/ContributorsView/ContributorsView.js
+++ b/src/components/Loans/OpenLoans/components/ContributorsView/ContributorsView.js
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 
-import { Popover } from '@folio/stripes/components';
+import {
+  Popover,
+  NoValue,
+} from '@folio/stripes/components';
 
 import getListPresentation from '../../helpers/getListPresentation';
 
@@ -17,7 +20,7 @@ const ContributorsView = (props) => {
   const contributorsListString = contributorsList.join(' ');
   // Truncate if no of contributors > 2
   const listTodisplay = isEmpty(contributorsList)
-    ? '-'
+    ? <NoValue />
     : getListPresentation(contributorsList, contributorsListString);
 
   return (contributorsList.length > 2)

--- a/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
+++ b/src/components/Loans/OpenLoans/helpers/getListDataFormatter.js
@@ -4,6 +4,7 @@ import {
   Checkbox,
   FormattedDate,
   FormattedTime,
+  NoValue,
 } from '@folio/stripes/components';
 
 import { effectiveCallNumber } from '@folio/stripes/util';
@@ -32,7 +33,8 @@ export default function getListDataFormatter(
       key : '  ',
       formatter: loan => (
         <Checkbox
-          checked={isLoanChecked(loan.id)}
+          disabled={!loan?.item}
+          checked={loan?.item && isLoanChecked(loan.id)}
           onClick={e => toggleItem(e, loan)}
           onChange={e => toggleItem(e, loan)}
           ariaLabel={formatMessage({ id: 'ui-users.loans.rows.select' })}
@@ -48,20 +50,20 @@ export default function getListDataFormatter(
           const titleToDisplay = (title.length >= 77) ? `${title.substring(0, 77)}...` : title;
           return `${titleToDisplay} (${get(loan, ['item', 'materialType', 'name'])})`;
         }
-        return '-';
+        return <NoValue />;
       },
       sorter: loan => get(loan, ['item', 'title'])?.toLowerCase(),
     },
     'itemStatus': {
       key: 'itemStatus',
       view: formatMessage({ id: 'ui-users.loans.columns.itemStatus' }),
-      formatter:  loan => `${get(loan, ['item', 'status', 'name'], '')}`,
+      formatter:  loan => get(loan, ['item', 'status', 'name'], <NoValue />),
       sorter: loan => get(loan, ['item', 'status', 'name'], ''),
     },
     'barcode': {
       key: 'barcode',
       view: formatMessage({ id: 'ui-users.loans.columns.barcode' }),
-      formatter: loan => get(loan, ['item', 'barcode'], ''),
+      formatter: loan => get(loan, ['item', 'barcode'], <NoValue />),
       sorter: loan => get(loan, ['item', 'barcode']),
     },
     'feefineIncurred': {
@@ -85,7 +87,7 @@ export default function getListDataFormatter(
     'callNumber': {
       key:'callNumber',
       view: formatMessage({ id: 'ui-users.loans.details.effectiveCallNumber' }),
-      formatter: loan => (<div data-test-list-call-numbers>{effectiveCallNumber(loan)}</div>),
+      formatter: loan => (<div data-test-list-call-numbers>{effectiveCallNumber(loan) || <NoValue />}</div>),
       sorter: loan => effectiveCallNumber(loan),
     },
     'loanPolicy': {
@@ -128,7 +130,7 @@ export default function getListDataFormatter(
     'location': {
       key:'location',
       view: formatMessage({ id: 'ui-users.loans.details.location' }),
-      formatter: loan => `${get(loan, ['item', 'location', 'name'], '')}`,
+      formatter: loan => `${get(loan, ['item', 'location', 'name'], <NoValue />)}`,
       sorter: loan => get(loan, ['item', 'location', 'name'], ''),
     },
     ' ': {

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -334,6 +334,11 @@ class LoanDetails extends React.Component {
 
   showBarcode(loan) {
     this.loan = loan;
+
+    if (!this.loan?.item) {
+      return <NoValue />;
+    }
+
     const instanceId = get(this.loan, ['item', 'instanceId'], '');
     const holdingsRecordId = get(this.loan, ['item', 'holdingsRecordId'], '');
     const itemId = get(this.loan, ['itemId'], '');
@@ -487,7 +492,7 @@ class LoanDetails extends React.Component {
     const loanStatus = get(loan, ['status', 'name'], '-');
     const overduePolicyName = get(loan, ['overdueFinePolicy', 'name'], '-');
     const lostItemPolicyName = get(loan, ['lostItemPolicy', 'name'], '-');
-    const itemStatus = get(loan, ['item', 'status', 'name'], '-');
+    const itemStatus = get(loan, ['item', 'status', 'name'], <NoValue />);
     const claimedReturnedDate = itemStatus === itemStatuses.CLAIMED_RETURNED && loan.claimedReturnedDate;
     const isClaimedReturnedItem = itemStatus === itemStatuses.CLAIMED_RETURNED;
     const isDeclaredLostItem = itemStatus === itemStatuses.DECLARED_LOST;
@@ -505,9 +510,10 @@ class LoanDetails extends React.Component {
       lostDate = get(lostAndPaidActions[0], ['declaredLostDate']);
     }
 
-    const buttonDisabled = (loanStatus && loanStatus === 'Closed');
+    const isItemAbsent = !loan?.item;
+    const buttonDisabled = (loanStatus && loanStatus === 'Closed') || isItemAbsent;
     // Number of characters to truncate the string = 77
-    const listTodisplay = (contributorsList === '-') ? '-' : (contributorsListString.length >= 77) ? `${contributorsListString.substring(0, 77)}...` : `${contributorsListString.substring(0, contributorsListString.length - 2)}`;
+    const listTodisplay = (contributorsList[0] === '-') ? <NoValue /> : (contributorsListString.length >= 77) ? `${contributorsListString.substring(0, 77)}...` : `${contributorsListString.substring(0, contributorsListString.length - 2)}`;
     const nonRenewedLabel = <FormattedMessage id="ui-users.loans.items.nonRenewed.label" />;
     const failedRenewalsSubHeading = (
       <p>
@@ -574,7 +580,7 @@ class LoanDetails extends React.Component {
                         <Button
                           buttonStyle="dropdownItem"
                           data-test-dropdown-content-mark-as-missing-button
-                          disabled={isVirtualPatron}
+                          disabled={isVirtualPatron || isItemAbsent}
                           onClick={() => markAsMissing(loan, itemRequestCount)}
                         >
                           <FormattedMessage id="ui-users.loans.markAsMissing" />
@@ -697,13 +703,13 @@ class LoanDetails extends React.Component {
               <Col xs={2}>
                 <KeyValue
                   label={<FormattedMessage id="ui-users.loans.details.location" />}
-                  value={get(loan, ['item', 'location', 'name'], '-')}
+                  value={get(loan, ['item', 'location', 'name'], <NoValue />)}
                 />
               </Col>
               <Col xs={2}>
                 <KeyValue
                   label={<FormattedMessage id="ui-users.loans.details.checkinServicePoint" />}
-                  value={get(loan, ['checkinServicePoint', 'name'], '-')}
+                  value={get(loan, ['checkinServicePoint', 'name'], <NoValue />)}
                 />
               </Col>
             </Row>


### PR DESCRIPTION
## Purpose
Add functionality for handling absence of `loan.item` property in a case when item was deleted or data were corrupted.

## Refs
[UIU-2531](https://folio-org.atlassian.net/browse/UIU-2531)


## ToDos and open questions
There is a Sonar issues related to analysis generation. Working on fixing it. 
