### PR TITLE
UIU-3335: "Preferred email communications" field clicking causes error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * New fields are included when printing a due-date receipt, e.g. `{{item.physicalDescriptions}}`. Fixes UIU-3332.
 * Hide an affiliation accordion for system users. Refs UIU-3308.
 * Ensure user detail page updates with latest roles after adding/removing roles. Refs UIU-3333.
+* Fix "Preferred email communications" `itemToString` error. Refs UIU-3335.
 
 ## [11.0.11](https://github.com/folio-org/ui-users/tree/v11.0.11) (2025-01-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.10...v11.0.11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * New fields are included when printing a due-date receipt, e.g. `{{item.physicalDescriptions}}`. Fixes UIU-3332.
 * Hide an affiliation accordion for system users. Refs UIU-3308.
 * Ensure user detail page updates with latest roles after adding/removing roles. Refs UIU-3333.
-* Fix "Preferred email communications" `itemToString` error. Refs UIU-3335.
+* Add fallback / optional chaining guard for "Preferred email communications" `itemToString` prop for when `option` is `null` or `undefined`. Refs UIU-3335.
 
 ## [11.0.11](https://github.com/folio-org/ui-users/tree/v11.0.11) (2025-01-15)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v11.0.10...v11.0.11)

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.js
@@ -136,7 +136,7 @@ const EditContactInfo = ({
                 fullWidth
                 disabled={disabled}
                 filter={prefEmailCommFilterOptions}
-                itemToString={(option) => option.value}
+                itemToString={(option) => option?.value ?? ''}
               />
             </Col>
           </Row>


### PR DESCRIPTION
An attempt to access `option.value` within `itemToString` prop fails when `option` is `null` or `undefined`. An optional chaining operator + fallback value is added to resolve this behavior.

https://folio-org.atlassian.net/browse/UIU-3335