### PR TITLE
UIU-3356: Fix Jest coverage report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-users
 
 ## 12.2.0 IN PROGRESS
+* Collect coverage from unit tests. Refs UIU-3356.
 
 ## [12.1.0](https://github.com/folio-org/ui-users/tree/v12.1.0) (2025-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.0.0...v12.1.0)

--- a/package.json
+++ b/package.json
@@ -1176,7 +1176,7 @@
     "build": "stripes build",
     "lint": "eslint .",
     "test": "yarn run test:jest",
-    "test:jest": "jest",
+    "test:jest": "jest --coverage",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
     "formatjs-compile": "stripes translate compile"
   },


### PR DESCRIPTION
Add `--coverage` flag to jest script to collect unit test coverage.

https://folio-org.atlassian.net/browse/UIU-3356