### PR TITLE
UIU-3355: Assigned roles are not sorted in user edit view when roles assigned via roles UI or via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Change amount input type to number. Refs UIU-2836.
 * Update jspdf(to v3.0.0) and jspdf-autotable(to v5.0.2) for security. Refs UIU-3347.
 
+## [12.1.1] IN PROGRESS
+* Fetch all role records for each tenant in order to sort `assignedRoleIds` alphabetically by role name in UserEdit. Refs UIU-3355.   
+
 ## [12.1.0](https://github.com/folio-org/ui-users/tree/v12.1.0) (2025-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.0.0...v12.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * Change amount input type to number. Refs UIU-2836.
 * Update jspdf(to v3.0.0) and jspdf-autotable(to v5.0.2) for security. Refs UIU-3347.
 
-## [12.1.1] IN PROGRESS
+## [12.1.1] (https://github.com/folio-org/ui-users/tree/v12.1.1) (2025-03-26)
+[Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.0...v12.1.1)
+
 * Fetch all role records for each tenant in order to sort `assignedRoleIds` alphabetically by role name in UserEdit. Refs UIU-3355.   
 
 ## [12.1.0](https://github.com/folio-org/ui-users/tree/v12.1.0) (2025-03-18)

--- a/src/hooks/useUserAffiliationRoles/useUserAffiliationRoles.js
+++ b/src/hooks/useUserAffiliationRoles/useUserAffiliationRoles.js
@@ -9,7 +9,7 @@ function useUserAffiliationRoles(userId) {
     query: `userId==${userId}`,
   };
 
-  // To unify in case if consortium or non-consortium
+  // To unify in case if consortium of non-consortium
   const tenants = stripes.user.user?.tenants || [{ id: stripes.okapi.tenant }];
   const ky = useOkapiKy();
 
@@ -57,7 +57,7 @@ function useUserAffiliationRoles(userId) {
       const found = tenantRolesQueries[index].data?.roles.find(r => r.id === roleId);
       if (found) assignedRoles.push(found);
     });
-    acc[tenant.id] = assignedRoles.sort((a, b) => a.name.localeCompare(b.name)).map(({ id }) => id);
+    acc[tenant.id] = [...assignedRoles].sort((a, b) => a.name.localeCompare(b.name)).map(({ id }) => id);
     return acc;
   }, {});
 }

--- a/src/hooks/useUserAffiliationRoles/useUserAffiliationRoles.js
+++ b/src/hooks/useUserAffiliationRoles/useUserAffiliationRoles.js
@@ -9,11 +9,11 @@ function useUserAffiliationRoles(userId) {
     query: `userId==${userId}`,
   };
 
-  // To unify in case if consortium of non-consortium
+  // To unify in case if consortium or non-consortium
   const tenants = stripes.user.user?.tenants || [{ id: stripes.okapi.tenant }];
   const ky = useOkapiKy();
 
-  const queries = useQueries(
+  const userTenantRolesQueries = useQueries(
     tenants.map(({ id }) => {
       return {
         queryKey:['userTenantRoles', id],
@@ -30,10 +30,34 @@ function useUserAffiliationRoles(userId) {
     })
   );
 
-  // result from useQueries doesn’t provide information about the tenants.
+  // Since `roles/users` return doesn't include names (only ids) for the roles, and we need them sorted by role name,
+  // we need to retrieve all the records for roles and use them to determine the sequence of ids.
+  const tenantRolesQueries = useQueries(
+    tenants.map(({ id }) => {
+      return {
+        queryKey:['tenantRolesAllRecords', id],
+        queryFn:() => {
+          const api = ky.extend({
+            hooks: {
+              beforeRequest: [(req) => req.headers.set('X-Okapi-Tenant', id)]
+            }
+          });
+          return api.get(`roles?limit=${stripes.config.maxUnpagedResourceCount}&query=cql.allRecords=1 sortby name`).json();
+        },
+      };
+    })
+  );
+
+  // result from useQueries doesn’t provide information about the tenants, reach appropriate tenant using index
   // useQueries guarantees that the results come in the same order as provided [queryFns]
-  return tenants.reduce((acc, value, index) => {
-    acc[value.id] = queries[index].data?.userRoles.flatMap(d => d.roleId) || [];
+  return tenants.reduce((acc, tenant, index) => {
+    const roleIds = userTenantRolesQueries[index].data?.userRoles.map(d => d.roleId) || [];
+    const assignedRoles = [];
+    roleIds.forEach(roleId => {
+      const found = tenantRolesQueries[index].data?.roles.find(r => r.id === roleId);
+      if (found) assignedRoles.push(found);
+    });
+    acc[tenant.id] = assignedRoles.sort((a, b) => a.name.localeCompare(b.name)).map(({ id }) => id);
     return acc;
   }, {});
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
Refs [UIU-3355](https://folio-org.atlassian.net/browse/UIU-3355) 
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Approach
We retrieve `assignedRoleIds` by calling `users/roles`, but it returns only ids. To sort them correctly, we need a way to get the names of the roles.
Just retrieve all roles for each tenant, find the names of the assigned role ids, and sort roles alphabetically. 

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
