### PR TITLE
UIU-3314: "Affiliations" select in Role/Permission accordion should not be displayed on patron user details pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Change amount input type to number. Refs UIU-2836.
 * Update jspdf(to v3.0.0) and jspdf-autotable(to v5.0.2) for security. Refs UIU-3347.
 * Prevent error toast from occurring when user doesn't have `ui-users.roles.view` capability. Refs UIU-3350.
+* "Affiliations" select in Role/Permission accordion should not be displayed on patron user details pane. Refs UIU-3314.
 
 ## [12.1.1] (https://github.com/folio-org/ui-users/tree/v12.1.1) (2025-03-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.0...v12.1.1)

--- a/src/components/RenderRoles/RenderRoles.js
+++ b/src/components/RenderRoles/RenderRoles.js
@@ -37,6 +37,7 @@ class RenderRoles extends React.Component {
         listInvisiblePerms: PropTypes.bool,
       }).isRequired,
     }).isRequired,
+    isAffiliationsVisible: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {
@@ -73,6 +74,7 @@ class RenderRoles extends React.Component {
       permToRead,
       selectedAffiliation,
       heading,
+      isAffiliationsVisible,
     } = this.props;
 
     if (!stripes.hasPerm(permToRead)) { return null; }
@@ -89,7 +91,7 @@ class RenderRoles extends React.Component {
       >
         <IfConsortium>
           <IfConsortiumPermission perm="consortia.user-tenants.collection.get">
-            {Boolean(affiliations?.length) && (
+            {Boolean(affiliations?.length) && isAffiliationsVisible && (
               <AffiliationsSelect
                 affiliations={affiliations}
                 onChange={onChangeAffiliation}

--- a/src/components/UserDetailSections/UserRoles/UserRoles.js
+++ b/src/components/UserDetailSections/UserRoles/UserRoles.js
@@ -31,6 +31,7 @@ const UserRoles = (props) => {
   } = useUserTenantRoles({ userId, tenantId });
 
   const isLoading = isAffiliationsFetching || isPermissionsFetching;
+  const isAffiliationsVisible = isAffiliationsEnabled(user);
 
   useEffect(() => {
     if (!affiliations.some(({ tenantId: assigned }) => tenantId === assigned)) {
@@ -46,6 +47,7 @@ const UserRoles = (props) => {
     selectedAffiliation={tenantId}
     isLoading={isLoading}
     onChangeAffiliation={setTenantId}
+    isAffiliationsVisible={isAffiliationsVisible}
     listedRoles={userRoles || []}
   />);
 };


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIU-3314

Here we fixed issue with `"Affiliations" select `with `Patron user type`