### PR TITLE
[UIU-3360] Ensure keycloak user updates are sent to `mod-users-keycloak` and non-keycloak user updates are sent to `mod-users`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@
 * "Affiliations" select in Role/Permission accordion should not be displayed on patron user details pane. Refs UIU-3314.
 * Fixed sponsor notification dropdown showing incorrect values for pristine forms. Refs UIU-3260.
 * Add the ability for staff to take a patron's profile picture photo using a webcam. Refs UIU-3266.
+* Ensure keycloak user updates are sent to `mod-users-keycloak` and non-keycloak user updates are sent to `mod-users`. Refs UIU-3360.
 
 ## [12.1.1] (https://github.com/folio-org/ui-users/tree/v12.1.1) (2025-03-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.0...v12.1.1)
 
-* Fetch all role records for each tenant in order to sort `assignedRoleIds` alphabetically by role name in UserEdit. Refs UIU-3355.   
+* Fetch all role records for each tenant in order to sort `assignedRoleIds` alphabetically by role name in UserEdit. Refs UIU-3355.
 
 ## [12.1.0](https://github.com/folio-org/ui-users/tree/v12.1.0) (2025-03-18)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.0.0...v12.1.0)

--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -89,13 +89,17 @@ const withUserRoles = (WrappedComponent) => (props) => {
     onFinish();
   };
 
-  const checkAndHandleKeycloakAuthUser = async (data, onFinish) => {
+  const checkAndHandleKeycloakAuthUser = async (data, mutator, onFinish) => {
     const userKeycloakStatus = await checkUserInKeycloak();
     switch (userKeycloakStatus) {
       case KEYCLOAK_USER_EXISTANCE.exist:
+        // Only save changes to mod-users-keycloak.
         await handleKeycloakUserExists(data, onFinish);
         break;
       case KEYCLOAK_USER_EXISTANCE.nonExist:
+        // First, save changes to mod-users.
+        // If user decides to create a Keycloak user, then changes will be copied over from mod-users to mod-users-keycloak.
+        await mutator.selUser.PUT(data);
         setIsCreateKeycloakUserConfirmationOpen(true);
         break;
       default:

--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -80,7 +80,7 @@ const withUserRoles = (WrappedComponent) => (props) => {
     await createKeycloakUser(userId);
   };
 
-  const handleKeycloakUserExists = async (data, onFinish) => {
+  const handleKeycloakUserExists = async (onFinish, data) => {
     await updateKeycloakUser(userId, data);
 
     if (!isEqual(assignedRoleIds, initialAssignedRoleIds)) {
@@ -89,12 +89,12 @@ const withUserRoles = (WrappedComponent) => (props) => {
     onFinish();
   };
 
-  const checkAndHandleKeycloakAuthUser = async (data, mutator, onFinish) => {
+  const checkAndHandleKeycloakAuthUser = async (onFinish, data, mutator) => {
     const userKeycloakStatus = await checkUserInKeycloak();
     switch (userKeycloakStatus) {
       case KEYCLOAK_USER_EXISTANCE.exist:
         // Only save changes to mod-users-keycloak.
-        await handleKeycloakUserExists(data, onFinish);
+        await handleKeycloakUserExists(onFinish, data);
         break;
       case KEYCLOAK_USER_EXISTANCE.nonExist:
         // First, save changes to mod-users.

--- a/src/components/Wrappers/withUserRoles.test.js
+++ b/src/components/Wrappers/withUserRoles.test.js
@@ -31,6 +31,11 @@ const mockStripes = {
   config: {
     maxUnpagedResourceCount: 1000,
   },
+  mutator: {
+    selUser: {
+      PUT: jest.fn().mockResolvedValue({ data: {} }),
+    },
+  }
 };
 
 const mockRolesData = {

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -333,14 +333,12 @@ class UserEdit extends React.Component {
   async updateUserData(data) {
     const { mutator, stripes } = this.props;
     try {
-      await mutator.selUser.PUT(data);
-
-      if (!stripes.hasInterface('users-keycloak')) {
+      if (stripes.hasInterface('users-keycloak')) {
+        await this.props.checkAndHandleKeycloakAuthUser(data, this.onCompleteEdit);
+      } else {
+        await mutator.selUser.PUT(data);
         this.onCompleteEdit();
-        return;
       }
-
-      await this.props.checkAndHandleKeycloakAuthUser(this.onCompleteEdit);
     } catch (e) {
       showErrorCallout(e, this.context.sendCallout);
     }

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -334,7 +334,7 @@ class UserEdit extends React.Component {
     const { mutator, stripes } = this.props;
     try {
       if (stripes.hasInterface('users-keycloak')) {
-        await this.props.checkAndHandleKeycloakAuthUser(data, mutator, this.onCompleteEdit);
+        await this.props.checkAndHandleKeycloakAuthUser(this.onCompleteEdit, data, mutator);
       } else {
         await mutator.selUser.PUT(data);
         this.onCompleteEdit();

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -334,7 +334,7 @@ class UserEdit extends React.Component {
     const { mutator, stripes } = this.props;
     try {
       if (stripes.hasInterface('users-keycloak')) {
-        await this.props.checkAndHandleKeycloakAuthUser(data, this.onCompleteEdit);
+        await this.props.checkAndHandleKeycloakAuthUser(data, mutator, this.onCompleteEdit);
       } else {
         await mutator.selUser.PUT(data);
         this.onCompleteEdit();


### PR DESCRIPTION
- Fulfills [UIU-3360](https://folio-org.atlassian.net/browse/UIU-3360).
- Previously, when updating a Keycloak user record (a User record created in Eureka, or converted when updating in Eureka), the backend call went to `mod-users`, but the source of truth is now `mod-users-keycloak`. 
- The new code sends updated fields to `mod-users-keycloak` if it is a Keycloak record, otherwise, updates are sent to `mod-users`.
- If a user decides to convert the user record to a Keycloak user (by clicking Yes on a prompt when saving) the update happens in `mod-users` first and then when the user is created in `mod-users-keycloak` all data is copied via back-end logic.