### PR TITLE
UICIRC-1232: Add missing users view sub-permission to view settings (users) patron blocks template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fix `Expiration date` field value when non-default locale is applied. Refs UIU-3318.
 * [Follow-up] Fix `Expiration date` field value when non-default locale is applied. Refs UIU-3318.
 * Add 'users.collection.get' permission to user settings. Fixes UIU-3189.
+* Add "users.collection.get" sub-permission for viewing settings (users) patron blocks template. Refs UICIRC-1232.
 
 ## [12.1.1] (https://github.com/folio-org/ui-users/tree/v12.1.1) (2025-03-26)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.0...v12.1.1)

--- a/package.json
+++ b/package.json
@@ -1119,7 +1119,8 @@
         "subPermissions": [
           "ui-users.settings.conditions.view",
           "ui-users.settings.limits.view",
-          "ui-users.settings.patron-block-templates.view"
+          "ui-users.settings.patron-block-templates.view",
+          "users.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
## Purpose
Requesting `GET /users` fails during viewing settings (users) patron blocks template

## Approach
Add missing `users.collection.get` sub-permission for `ui-users.settings.patron-blocks.view`

## Refs
[UICIRC-1232](https://folio-org.atlassian.net/browse/UICIRC-1232)