### PR TITLE
UIU-3122: ExtendedInfo - display the departments field if at least one department is added in Settings (follow-up).

### DIFF
--- a/src/components/UserDetailSections/ExtendedInfo/ExtendedInfo.js
+++ b/src/components/UserDetailSections/ExtendedInfo/ExtendedInfo.js
@@ -24,6 +24,7 @@ const ExtendedInfo = (props) => {
     defaultServicePointName,
     defaultDeliveryAddressTypeName,
     departments,
+    userDepartments,
   } = props;
 
   return (
@@ -60,13 +61,18 @@ const ExtendedInfo = (props) => {
         defaultServicePointName={defaultServicePointName}
         defaultDeliveryAddressTypeName={defaultDeliveryAddressTypeName}
       />
-      <Row>
-        <Col xs={12} md={6}>
-          <KeyValue label={<FormattedMessage id="ui-users.extended.department.name" />}>
-            {departments.join(', ')}
-          </KeyValue>
-        </Col>
-      </Row>
+      {departments.length && (
+        <Row>
+          <Col xs={12} md={6}>
+            <KeyValue
+              label={<FormattedMessage id="ui-users.extended.department.name" />}
+              data-testid="department-names"
+            >
+              {userDepartments.join(', ')}
+            </KeyValue>
+          </Col>
+        </Row>
+      )}
       <Row>
         <Col xs={12} md={6}>
           <KeyValue label={<FormattedMessage id="ui-users.information.username" />}>
@@ -83,6 +89,7 @@ ExtendedInfo.propTypes = {
   expanded: PropTypes.bool,
   onToggle: PropTypes.func,
   user: PropTypes.object,
+  userDepartments: PropTypes.arrayOf(PropTypes.string).isRequired,
   defaultServicePointName: PropTypes.string,
   requestPreferences: requestPreferencesShape,
   defaultDeliveryAddressTypeName: PropTypes.string.isRequired,

--- a/src/components/UserDetailSections/ExtendedInfo/ExtendedInfo.test.js
+++ b/src/components/UserDetailSections/ExtendedInfo/ExtendedInfo.test.js
@@ -1,0 +1,143 @@
+
+import {
+  screen,
+  within,
+} from '@folio/jest-config-stripes/testing-library/react';
+
+import renderWithRouter from 'helpers/renderWithRouter';
+import ExtendedInfo from './ExtendedInfo';
+
+jest.unmock('@folio/stripes/components');
+
+const mockUser = {
+  id: 'user-id',
+  enrollmentDate: '2022-01-01T00:00:00.000Z',
+  externalSystemId: 'EXT-123',
+  personal: {
+    dateOfBirth: '1990-01-01T00:00:00.000Z',
+  },
+  username: 'testuser',
+};
+
+const mockRequestPreferences = {
+  defaultServicePointId: 'sp-1',
+  defaultDeliveryAddressTypeId: 'addr-1',
+  fulfillment: 'Hold Shelf',
+};
+
+describe('ExtendedInfo', () => {
+  const renderComponent = (props = {}) => {
+    return renderWithRouter(
+      <ExtendedInfo
+        accordionId="extendedInfoAccordion"
+        expanded
+        onToggle={() => {}}
+        user={mockUser}
+        requestPreferences={mockRequestPreferences}
+        defaultServicePointName="Main Library"
+        defaultDeliveryAddressTypeName="Home Address"
+        departments={['department-1', 'department-2']}
+        userDepartments={['department-2']}
+        {...props}
+      />
+    );
+  };
+
+  it('displays enrollment date when available', () => {
+    renderComponent();
+    expect(screen.getByText(/ui-users.extended.dateEnrolled/i)).toBeInTheDocument();
+    expect(screen.getByText('2022-01-01T00:00:00.000Z')).toBeInTheDocument();
+  });
+
+  it('displays external system ID when available', () => {
+    renderComponent();
+    expect(screen.getByText(/ui-users.extended.externalSystemId/i)).toBeInTheDocument();
+    expect(screen.getByText('EXT-123')).toBeInTheDocument();
+  });
+
+  it('displays birth date when available', () => {
+    renderComponent();
+    expect(screen.getByText(/ui-users.extended.birthDate/i)).toBeInTheDocument();
+    expect(screen.getByText('1990-01-01T00:00:00.000Z')).toBeInTheDocument();
+  });
+
+  it('displays FOLIO number from user ID', () => {
+    renderComponent();
+    expect(screen.getByText(/ui-users.extended.folioNumber/i)).toBeInTheDocument();
+    expect(screen.getByText('user-id')).toBeInTheDocument();
+  });
+
+  describe('RequestPreferencesView', () => {
+    it('displays request preferences', () => {
+      renderComponent();
+      expect(screen.getByText('ui-users.requests.preferences')).toBeInTheDocument();
+      expect(screen.getByText('ui-users.requests.holdShelf')).toBeInTheDocument();
+      expect(screen.getByText('ui-users.requests.delivery')).toBeInTheDocument();
+    });
+
+    it('displays default service point', () => {
+      renderComponent();
+      expect(screen.getByText('ui-users.requests.defaultPickupServicePoint')).toBeInTheDocument();
+      expect(screen.getByText('Main Library')).toBeInTheDocument();
+    });
+
+    it('displays fulfilment', () => {
+      renderComponent();
+      expect(screen.getByText('ui-users.requests.fulfillmentPreference')).toBeInTheDocument();
+      expect(screen.getByText('Hold Shelf')).toBeInTheDocument();
+    });
+
+    it('displays default delivery address', () => {
+      renderComponent();
+      expect(screen.getByText('ui-users.requests.defaultDeliveryAddress')).toBeInTheDocument();
+      expect(screen.getByText('Home Address')).toBeInTheDocument();
+    });
+  });
+
+  describe('Departments', () => {
+    describe('when there are departments in Settings', () => {
+      describe('and there is a department selected in user data', () => {
+        it('displays user departments', () => {
+          renderComponent({
+            departments: ['department-1', 'department-2'],
+            userDepartments: ['department-1', 'department-2'],
+          });
+
+          expect(screen.getByText(/ui-users.extended.department.name/i)).toBeInTheDocument();
+          expect(screen.getByText('department-1, department-2')).toBeInTheDocument();
+        });
+      });
+
+      describe('and there are no departments selected in user data', () => {
+        it('displays empty string for user departments', () => {
+          renderComponent({
+            departments: ['department-1', 'department-2'],
+            userDepartments: [],
+          });
+
+          const departmentNames = screen.getByTestId('department-names');
+
+          expect(screen.getByText(/ui-users.extended.department.name/i)).toBeInTheDocument();
+          expect(within(departmentNames).getByText('stripes-components.noValue.noValueSet')).toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('when there are no departments in Settings', () => {
+      it('does not display departments section', () => {
+        renderComponent({
+          departments: [],
+          userDepartments: [],
+        });
+
+        expect(screen.queryByText(/ui-users.extended.department.name/i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  it('displays username when available', () => {
+    renderComponent();
+    expect(screen.getByText(/ui-users.information.username/i)).toBeInTheDocument();
+    expect(screen.getByText('testuser')).toBeInTheDocument();
+  });
+});

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -794,7 +794,8 @@ class UserDetail extends React.Component {
                   defaultServicePointName={defaultServicePointName}
                   defaultDeliveryAddressTypeName={defaultDeliveryAddressTypeName}
                   onToggle={this.handleSectionToggle}
-                  departments={userDepartments}
+                  departments={departments}
+                  userDepartments={userDepartments}
                 />
                 <ContactInfo
                   accordionId="contactInfoSection"


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
Display the departments field if at least one department is added in Settings (follow-up PR).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Issues
https://folio-org.atlassian.net/browse/UIU-3122

## Screenshots
With the "department name" field
![image](https://github.com/user-attachments/assets/264fa3ed-3688-4bb9-8f4f-19a621319f5d)

Without it
![image](https://github.com/user-attachments/assets/900a9e6a-db07-4650-bae6-fabe6d851f42)



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
