### PR TITLE
UIU-3287: Remove `addressTypeId` prop from `EditContactInfo` and `UserForm` components to avoid address component issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Extended information - change order of fields, use MultiSelection for the departments field. Refs UIU-3123.
 * Display "Unknown user" instead of dash in proxy borrower field. Refs UIU-3373.
 * Make circulation-bff-loans dependency optional in folio_users UI module. Refs UIU-3409.
+* Remove addressTypeId prop from EditContactInfo and UserForm components to avoid address component issues. Refs UIU-3287.
 
 ## [12.1.7] (https://github.com/folio-org/ui-users/tree/v12.1.7) (2025-06-03)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.6...v12.1.7)

--- a/src/components/EditSections/EditContactInfo/EditContactInfo.js
+++ b/src/components/EditSections/EditContactInfo/EditContactInfo.js
@@ -27,7 +27,6 @@ const EditContactInfo = ({
   accordionId,
   addressTypes,
   preferredContactTypeId,
-  addressTypeId,
   intl,
   disabled,
   stripes,
@@ -50,7 +49,6 @@ const EditContactInfo = ({
         fullWidth: true,
         autoFocus: true,
         placeholder: intl.formatMessage({ id: 'ui-users.contact.selectAddressType' }),
-        defaultValue: addressTypeId,
       },
     },
   };
@@ -163,7 +161,6 @@ EditContactInfo.propTypes = {
   accordionId: PropTypes.string.isRequired,
   addressTypes: PropTypes.arrayOf(PropTypes.object),
   preferredContactTypeId: PropTypes.string,
-  addressTypeId: PropTypes.string,
   intl: PropTypes.object.isRequired,
   disabled: PropTypes.bool,
   stripes: PropTypes.object.isRequired,

--- a/src/components/EditSections/EditUserInfo/components/DeleteProfilePictureModal/DeleteProfilePictureModal.test.js
+++ b/src/components/EditSections/EditUserInfo/components/DeleteProfilePictureModal/DeleteProfilePictureModal.test.js
@@ -5,6 +5,7 @@ import DeleteProfilePictureModal from './DeleteProfilePictureModal';
 jest.unmock('react-intl');
 
 jest.mock('react-intl', () => ({
+  ...jest.requireActual('react-intl'),
   FormattedMessage: jest.fn(({ id, values }) => {
     if (values) {
       const valueStr = Object.values(values).join(',');

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -433,7 +433,6 @@ class UserForm extends React.Component {
                     accordionId="contactInfo"
                     addressTypes={formData.addressTypes}
                     preferredContactTypeId={initialValues.preferredContactTypeId}
-                    addressTypeId={initialValues.personal?.addresses[0]?.addressType}
                     disabled={isShadowUser}
                     stripes={stripes}
                   />

--- a/src/views/UserEdit/UserForm.test.js
+++ b/src/views/UserEdit/UserForm.test.js
@@ -1,7 +1,11 @@
+import { act } from 'react';
+
 import { FormattedMessage } from 'react-intl';
 import {
   screen,
+  within,
 } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import renderWithRouter from 'helpers/renderWithRouter';
 import { USER_TYPES } from '../../constants';
@@ -18,7 +22,7 @@ jest.mock('@folio/stripes/smart-components', () => ({
 jest.mock(
   '../../components/EditSections',
   () => ({
-    EditContactInfo: jest.fn(() => <div>EditContactInfo accordion</div>),
+    ...jest.requireActual('../../components/EditSections'),
     EditExtendedInfo: jest.fn(() => <div>EditExtendedInfo accordion</div>),
     EditProxy: jest.fn(() => <div>EditProxy accordion</div>),
     EditServicePoints: jest.fn(() => <div>EditServicePoints accordion</div>),
@@ -38,6 +42,11 @@ jest.mock(
   './TenantsPermissionsAccordion',
   () => jest.fn(() => <div>TenantsPermissionsAccordion accordion</div>),
 );
+
+jest.mock('@folio/service-interaction', () => () => <div>service-interaction</div>);
+
+const mockOnCancel = jest.fn();
+const mockOnSubmit = jest.fn();
 
 const STRIPES = {
   connect: (Component) => Component,
@@ -75,6 +84,60 @@ const STRIPES = {
   },
   withOkapi: true,
 };
+
+const formData = {
+  patronGroups: [],
+  addressTypes: [
+    {
+      addressType: 'Claim',
+      id: 'claim-id',
+    },
+    {
+      addressType: 'Home',
+      id: 'home-id',
+    },
+    {
+      addressType: 'Payment',
+      id: 'payment-id',
+    },
+  ],
+};
+
+const initialValues = {
+  id: 'id',
+  creds: {
+    password: 'password',
+  },
+  patronGroup: 'patronGroup',
+  personal: {
+    lastName: 'lastName',
+    preferredContactTypeId: 'preferredContactTypeId',
+    addresses: [
+      {
+        addressType: 'home-id',
+      },
+    ],
+  },
+  preferredServicePoint: 'preferredServicePoint',
+  servicePoints: ['a', 'b'],
+  username: 'username',
+};
+
+const renderUserForm = (props = {}) => renderWithRouter(
+  <UserForm
+    formData={formData}
+    initialValues={initialValues}
+    stripes={STRIPES}
+    uniquenessValidator={{
+      reset: jest.fn(),
+      GET: jest.fn(),
+    }}
+    profilePictureConfig={{}}
+    onCancel={mockOnCancel}
+    onSubmit={mockOnSubmit}
+    {...props}
+  />
+);
 
 describe('UserForm', () => {
   beforeEach(() => {
@@ -159,72 +222,73 @@ describe('UserForm', () => {
 
 
   describe('renders accordions and other values', () => {
-    const props = {
-      formData: {
-        patronGroups: [],
-      },
-      initialValues: {
-        id: 'id',
-        creds: {
-          password: 'password',
-        },
-        patronGroup: 'patronGroup',
-        personal: {
-          lastName: 'lastName',
-          preferredContactTypeId: 'preferredContactTypeId',
-          addresses: [
-            { addressType: 'addressType' },
-          ],
-        },
-        preferredServicePoint: 'preferredServicePoint',
-        servicePoints: ['a', 'b'],
-        username: 'username',
-      },
-      onCancel: jest.fn(),
-      onSubmit: jest.fn(),
-      stripes: STRIPES,
-      uniquenessValidator: {
-        reset: jest.fn(),
-        GET: jest.fn(),
-      }
-    };
-
     it('shows permissions accordion in legacy mode', async () => {
-      renderWithRouter(<UserForm {...props} />);
+      renderUserForm();
 
       expect(screen.getByText('TenantsPermissionsAccordion accordion')).toBeTruthy();
     });
 
     it('shows permissions accordion when "roles" interface is NOT present', async () => {
-      renderWithRouter(<UserForm {...props} />);
+      renderUserForm();
 
       expect(screen.queryByText('TenantsPermissionsAccordion accordion')).toBeInTheDocument();
     });
 
     it('show roles accordion when "roles" interface is present', async () => {
-      props.stripes.hasInterface = () => true;
-      renderWithRouter(<UserForm {...props} />);
+      renderUserForm({
+        stripes: {
+          ...STRIPES,
+          hasInterface: () => true,
+        },
+      });
 
       expect(screen.queryByText('EditUserRoles accordion')).toBeInTheDocument();
     });
 
     it('renders pronouns', () => {
-      renderWithRouter(
-        <UserForm
-          {...props}
-          initialValues={
-            {
-              ...props.initialValues,
-              personal: {
-                ...props.initialValues.personal,
-                pronouns: 'r2/d2',
-              },
-            }
-          }
-        />
-      );
+      renderUserForm({
+        initialValues: {
+          ...initialValues,
+          personal: {
+            ...initialValues.personal,
+            pronouns: 'r2/d2',
+          },
+        },
+      });
 
       expect(screen.getByText('(r2/d2)')).toBeInTheDocument();
+    });
+  });
+
+  describe('when adding a new address', () => {
+    beforeEach(async () => {
+      renderUserForm({
+        initialValues: {
+          ...initialValues,
+          personal: {
+            ...initialValues.personal,
+            addresses: [
+              {
+                addressType: 'payment-id',
+              },
+            ],
+          },
+        },
+      });
+
+      await act(() => userEvent.click(screen.getByText('stripes-smart-components.address.addAddress')));
+    });
+
+    it('should not change the address type of the previous address', async () => {
+      const addressTypeSelects = screen.getAllByRole('combobox', { name: 'stripes-smart-components.addressEdit.label.addressType' });
+
+      expect(within(addressTypeSelects[0]).getByText('Payment').selected).toBeTruthy();
+    });
+
+    it('should not have address type field selected for the new row', () => {
+      const addressTypeSelects = screen.getAllByRole('combobox', { name: 'stripes-smart-components.addressEdit.label.addressType' });
+
+      expect(within(addressTypeSelects[1]).getByText('ui-users.contact.selectAddressType').selected).toBeTruthy();
     });
   });
 

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -8,3 +8,4 @@ import './stripesSmartComponent.mock';
 import './stripesUtils.mock';
 import './currencyData.mock';
 import './resizeObserver.mock';
+import './matchMedia.mock';

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
   Accordion: jest.fn(({ children, ...rest }) => (
     <span {...rest}>{children}</span>
   )),
@@ -220,28 +221,6 @@ jest.mock('@folio/stripes/components', () => ({
       {...props}
     />
   )),
-  Select: jest.fn(({ children, dataOptions }) => {
-    const dummyData = [{
-      value: 'testValue',
-      id: 'testId',
-      label: 'TestLabel'
-    }];
-    const options = dataOptions && dataOptions.length > 0 ? dataOptions : dummyData;
-    return (
-      <div>
-        <select>
-          {options.forEach((option, i) => (
-            <option
-              value={option.value}
-              key={option.id || `option-${i}`}
-            >
-              {option.label}
-            </option>))}
-        </select>
-        {children}
-      </div>
-    );
-  }),
   TextArea: jest.fn((props) => (
     <div>
       <label htmlFor={props.label}>{props.label}</label>


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
When adding a new address:
1. It should not change the address type of the previous address.
2. It should not have address type field selected for the new row.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Approach
Remove `addressTypeId` prop from `EditContactInfo` and `UserForm` components. It is unnecessary for the create and edit pages.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Issues
https://folio-org.atlassian.net/browse/UIU-3287

## Screencasts

https://github.com/user-attachments/assets/9c999632-4637-456a-b4b4-4a4a6c35f5f0



#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
