### PR TITLE
UIU-3411: Migrate custom fields from mod-configuration to mod-settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Display "Unknown user" instead of dash in proxy borrower field. Refs UIU-3373.
 * Make circulation-bff-loans dependency optional in folio_users UI module. Refs UIU-3409.
 * Escape the `username` and `barcode` fields. Fixes UIU-2882.
+* Migrate custom fields from mod-configuration to mod-settings. Refs UIU-3411.
 
 ## [12.1.7] (https://github.com/folio-org/ui-users/tree/v12.1.7) (2025-06-03)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.6...v12.1.7)

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
           "users-keycloak.item.get",
           "usergroups.collection.get",
           "configuration.entries.collection.get",
+          "mod-settings.entries.collection.get",
+          "mod-settings.entries.item.get",
+          "mod-settings.global.read.ui-users.custom-fields.manage",
           "user-settings.custom-fields.collection.get",
           "user-settings.custom-fields.item.get",
           "user-settings.custom-fields.item.stats.get",
@@ -415,7 +418,9 @@
         "displayName": "Settings (Users): Can view custom fields",
         "subPermissions": [
           "settings.users.enabled",
-          "configuration.entries.collection.get",
+          "mod-settings.entries.collection.get",
+          "mod-settings.entries.item.get",
+          "mod-settings.global.read.ui-users.custom-fields.manage",
           "user-settings.custom-fields.collection.get",
           "user-settings.custom-fields.item.option.stats.get"
         ],
@@ -430,7 +435,10 @@
           "user-settings.custom-fields.item.post",
           "user-settings.custom-fields.item.put",
           "configuration.entries.item.post",
-          "configuration.entries.item.put"
+          "configuration.entries.item.put",
+          "mod-settings.entries.item.post",
+          "mod-settings.entries.item.put",
+          "mod-settings.global.write.ui-users.custom-fields.manage"
         ],
         "visible": true
       },
@@ -1196,6 +1204,16 @@
           "staging-users.collection.get"
         ],
         "visible": true
+      },
+      {
+        "permissionName": "mod-settings.global.read.ui-users.custom-fields.manage",
+        "displayName": "Settings (Users): Read the custom fields settings",
+        "visible": false
+      },
+      {
+        "permissionName": "mod-settings.global.write.ui-users.custom-fields.manage",
+        "displayName": "Settings (Users): Write the custom fields settings",
+        "visible": false
       }
     ]
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -406,3 +406,5 @@ export const NEW_FEE_FINE_FIELD_NAMES = {
   ITEM_BARCODE: 'itemBarcode',
   KEY_OF_ITEM_BARCODE: 'keyOfItemBarcode',
 };
+
+export const CUSTOM_FIELDS_SCOPE = 'ui-users.custom-fields.manage';

--- a/src/settings/CustomFieldsSettings.js
+++ b/src/settings/CustomFieldsSettings.js
@@ -6,6 +6,8 @@ import { useIntl } from 'react-intl';
 import { useStripes, TitleManager } from '@folio/stripes/core';
 import { ViewCustomFieldsSettings, EditCustomFieldsSettings } from '@folio/stripes/smart-components';
 
+import { CUSTOM_FIELDS_SCOPE } from '../constants';
+
 const propTypes = {
   history: PropTypes.shape({
     push: PropTypes.func.isRequired,
@@ -45,6 +47,7 @@ const CustomFieldsSettings = ({
             entityType={entityType}
             editRoute={`${base}/edit`}
             permissions={permissions}
+            scope={CUSTOM_FIELDS_SCOPE}
           />
         </Route>
         <Route exact path={`${base}/edit`}>
@@ -53,6 +56,7 @@ const CustomFieldsSettings = ({
             entityType={entityType}
             viewRoute={base}
             permissions={permissions}
+            scope={CUSTOM_FIELDS_SCOPE}
           />
         </Route>
       </Switch>

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -76,6 +76,7 @@ import ActionMenuDeleteButton from './components/ActionMenuDeleteButton';
 import OpenTransactionModal from './components/OpenTransactionModal';
 import DeleteUserModal from './components/DeleteUserModal';
 import ExportFeesFinesReportButton from './components';
+import { CUSTOM_FIELDS_SCOPE } from '../../constants';
 
 import css from './UserDetail.css';
 
@@ -815,6 +816,7 @@ class UserDetail extends React.Component {
                   customFieldsValues={customFields}
                   customFieldsLabel={<FormattedMessage id="ui-users.custom.customFields" />}
                   noCustomFieldsFoundLabel={<FormattedMessage id="ui-users.custom.noCustomFieldsFound" />}
+                  scope={CUSTOM_FIELDS_SCOPE}
                 />
                 {
                   displayReadingRoomAccessAccordion && (

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -26,7 +26,10 @@ import {
 import { EditCustomFieldsRecord } from '@folio/stripes/smart-components';
 import stripesFinalForm from '@folio/stripes/final-form';
 
-import { USER_TYPES } from '../../constants';
+import {
+  CUSTOM_FIELDS_SCOPE,
+  USER_TYPES,
+} from '../../constants';
 import {
   EditUserInfo,
   EditExtendedInfo,
@@ -445,6 +448,7 @@ class UserForm extends React.Component {
                     finalFormCustomFieldsValues={form.getState().values.customFields}
                     fieldComponent={Field}
                     changeFinalFormField={form.change}
+                    scope={CUSTOM_FIELDS_SCOPE}
                   />
                   {initialValues.id &&
                     <div>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Description
Custom field components in stripes-smart-components have already been migrated to mod-settings. It is just necessary to pass the `scope` property and create the permissions.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1586

## Issues
[UIU-3411](https://folio-org.atlassian.net/browse/UIU-3411)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
