### PR TITLE
UIU-3436: PermissionsModal to search in permissionName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * UIU-3414* Add support for use circulation-bff for declare-item-lost. Refs UIU-3414.
 * Remove empty lines in drop-down menus in Settings > Orders > Number generator options. Refs UIU-3424.
 * AccountDetailsContainer - Show loading while data is loading to prevent page crash when visiting the Fee/fines details page via URL. Fixes UIU-3428.
+* PermissionsModal to search in permissionName. Refs UIU-3436.
 
 ## [12.1.7] (https://github.com/folio-org/ui-users/tree/v12.1.7) (2025-06-03)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.6...v12.1.7)

--- a/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
+++ b/src/components/PermissionsAccordion/components/PermissionsModal/PermissionsModal.js
@@ -191,9 +191,9 @@ class PermissionsModal extends React.Component {
     // Need a bit of extra work to search for terms that might appear only in a translated label
     const translationResults = this.getMatchedTranslations(searchText, permissions);
 
-    // Search in permission display names or permission names
+    // Search in permission display names and permission names
     const filteredPermissions = permissions.filter(({ displayName, permissionName }) => {
-      const permissionText = displayName || permissionName;
+      const permissionText = [displayName, permissionName].join('|');
       return permissionText.toLowerCase().includes(searchText.toLowerCase());
     });
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIU-3436

## Purpose
Allows to use a permissionsName to find a permission.

## Approach
Search in both displayName and permissionName.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - n/a If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.