### PR TITLE
UIU-3441: Revert migration of custom fields title from mod-configuration to mod-settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Remove empty lines in drop-down menus in Settings > Orders > Number generator options. Refs UIU-3424.
 * AccountDetailsContainer - Show loading while data is loading to prevent page crash when visiting the Fee/fines details page via URL. Fixes UIU-3428.
 * PermissionsModal to search in permissionName. Refs UIU-3436.
+* Revert migration of custom fields title from mod-configuration to mod-settings. Ref UIU-3441.
 
 ## [12.1.7] (https://github.com/folio-org/ui-users/tree/v12.1.7) (2025-06-03)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.6...v12.1.7)

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
           "configuration.entries.collection.get",
           "mod-settings.entries.collection.get",
           "mod-settings.entries.item.get",
-          "mod-settings.global.read.ui-users.custom-fields.manage",
           "user-settings.custom-fields.collection.get",
           "user-settings.custom-fields.item.get",
           "user-settings.custom-fields.item.stats.get",
@@ -420,7 +419,6 @@
           "settings.users.enabled",
           "mod-settings.entries.collection.get",
           "mod-settings.entries.item.get",
-          "mod-settings.global.read.ui-users.custom-fields.manage",
           "user-settings.custom-fields.collection.get",
           "user-settings.custom-fields.item.option.stats.get"
         ],
@@ -437,8 +435,7 @@
           "configuration.entries.item.post",
           "configuration.entries.item.put",
           "mod-settings.entries.item.post",
-          "mod-settings.entries.item.put",
-          "mod-settings.global.write.ui-users.custom-fields.manage"
+          "mod-settings.entries.item.put"
         ],
         "visible": true
       },
@@ -1205,16 +1202,6 @@
           "staging-users.collection.get"
         ],
         "visible": true
-      },
-      {
-        "permissionName": "mod-settings.global.read.ui-users.custom-fields.manage",
-        "displayName": "Settings (Users): Read the custom fields settings",
-        "visible": false
-      },
-      {
-        "permissionName": "mod-settings.global.write.ui-users.custom-fields.manage",
-        "displayName": "Settings (Users): Write the custom fields settings",
-        "visible": false
       }
     ]
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -409,8 +409,6 @@ export const NEW_FEE_FINE_FIELD_NAMES = {
   KEY_OF_ITEM_BARCODE: 'keyOfItemBarcode',
 };
 
-export const CUSTOM_FIELDS_SCOPE = 'ui-users.custom-fields.manage';
-
 // These fields will be validated on the BE side
 export const CUSTOM_FIELDS_SECTION = {
   CUSTOM_FIELDS: CUSTOM_FIELDS_SECTION_ID,

--- a/src/settings/CustomFieldsSettings.js
+++ b/src/settings/CustomFieldsSettings.js
@@ -7,7 +7,6 @@ import { useStripes, TitleManager } from '@folio/stripes/core';
 import { ViewCustomFieldsSettings, EditCustomFieldsSettings } from '@folio/stripes/smart-components';
 
 import {
-  CUSTOM_FIELDS_SCOPE,
   CUSTOM_FIELDS_SECTION,
 } from '../constants';
 
@@ -77,7 +76,6 @@ const CustomFieldsSettings = ({
             entityType={entityType}
             editRoute={`${base}/edit`}
             permissions={permissions}
-            scope={CUSTOM_FIELDS_SCOPE}
             hasDisplayInAccordionField
             displayInAccordionOptions={displayInAccordionOptions}
           />
@@ -88,7 +86,6 @@ const CustomFieldsSettings = ({
             entityType={entityType}
             viewRoute={base}
             permissions={permissions}
-            scope={CUSTOM_FIELDS_SCOPE}
             hasDisplayInAccordionField
             displayInAccordionOptions={displayInAccordionOptions}
           />

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -76,7 +76,6 @@ import ActionMenuDeleteButton from './components/ActionMenuDeleteButton';
 import OpenTransactionModal from './components/OpenTransactionModal';
 import DeleteUserModal from './components/DeleteUserModal';
 import ExportFeesFinesReportButton from './components';
-import { CUSTOM_FIELDS_SCOPE } from '../../constants';
 
 import css from './UserDetail.css';
 
@@ -816,7 +815,6 @@ class UserDetail extends React.Component {
                   customFieldsValues={customFields}
                   customFieldsLabel={<FormattedMessage id="ui-users.custom.customFields" />}
                   noCustomFieldsFoundLabel={<FormattedMessage id="ui-users.custom.noCustomFieldsFound" />}
-                  scope={CUSTOM_FIELDS_SCOPE}
                 />
                 {
                   displayReadingRoomAccessAccordion && (

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -27,7 +27,6 @@ import { EditCustomFieldsRecord } from '@folio/stripes/smart-components';
 import stripesFinalForm from '@folio/stripes/final-form';
 
 import {
-  CUSTOM_FIELDS_SCOPE,
   USER_TYPES,
 } from '../../constants';
 import {
@@ -447,7 +446,6 @@ class UserForm extends React.Component {
                     finalFormCustomFieldsValues={form.getState().values.customFields}
                     fieldComponent={Field}
                     changeFinalFormField={form.change}
-                    scope={CUSTOM_FIELDS_SCOPE}
                   />
                   {initialValues.id &&
                     <div>


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
Revert migration of custom fields __title__ from mod-configuration to mod-settings due to lack of data migration on the BE side for the Trillium release.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Issues
https://folio-org.atlassian.net/browse/UIU-3441

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
