### PR TITLE
users expire at midnight in tenant timezone instead of UTC

### DIFF
--- a/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
@@ -73,6 +73,22 @@ jest.mock('./components', () => ({
 
 const onSubmit = jest.fn();
 
+const getDayjsMock = (date) => {
+  const dayjsObj = jest.requireActual('@folio/stripes/components').dayjs(date);
+
+  return {
+    ...dayjsObj,
+    format: jest.fn().mockReturnValue('05/04/2027'),
+    add: jest.fn().mockReturnThis(),
+    tz: jest.fn().mockReturnThis(),
+    endOf: jest.fn().mockReturnThis(),
+    toISOString: jest.fn().mockReturnValue('2027-05-04T03:59:59.999Z'),
+    isSameOrBefore: jest.fn().mockReturnValue(false),
+    isBefore: jest.fn().mockReturnValue(true),
+    isAfter: jest.fn().mockReturnValue(true),
+  };
+};
+
 const arrayMutators = {
   concat: jest.fn(),
   move: jest.fn(),
@@ -169,17 +185,12 @@ const props = {
 
 describe('Render Edit User Information component', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     isConsortiumEnabled.mockClear().mockReturnValue(false);
 
-    dayjs.mockImplementation((date) => {
-      const dayjsObj = jest.requireActual('@folio/stripes/components').dayjs(date);
-
-      return {
-        ...dayjsObj,
-        format: jest.fn().mockReturnValue('05/04/2027'),
-        add: jest.fn().mockReturnThis(),
-      };
-    });
+    dayjs.mockImplementation(getDayjsMock);
+    dayjs.tz = jest.fn(getDayjsMock);
+    dayjs.utc = jest.fn(getDayjsMock);
   });
 
   it('Must be rendered', () => {
@@ -194,21 +205,11 @@ describe('Render Edit User Information component', () => {
 
   describe('when "Reset" (recalculate) button is clicked', () => {
     it('should change expiration date', async () => {
-      dayjs.mockImplementation((date) => {
-        const dayjsObj = jest.requireActual('@folio/stripes/components').dayjs(date);
-
-        return {
-          ...dayjsObj,
-          format: jest.fn().mockReturnValue('06/05/2025'),
-          add: jest.fn().mockReturnThis(),
-        };
-      });
-
       renderEditUserInfo(props);
 
       await act(() => userEvent.click(screen.getByText('ui-users.information.recalculate.expirationDate')));
 
-      expect(changeMock).toHaveBeenCalledWith('expirationDate', '2025-06-05T03:59:59.999Z');
+      expect(changeMock).toHaveBeenCalledWith('expirationDate', '2027-05-04T03:59:59.999Z');
     });
   });
 
@@ -345,6 +346,562 @@ describe('Render Edit User Information component', () => {
       };
       renderEditUserInfo(alteredProps);
       expect(screen.queryByText('Profile Picture')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('parseExpirationDate', () => {
+    describe('when recalculating expiration date by hitting the "Reset" button', () => {
+      it('should convert dates to UTC end-of-day ', async () => {
+        const mockUtcDayjs = {
+          ...getDayjsMock(),
+          endOf: jest.fn().mockReturnThis(),
+          toISOString: jest.fn().mockReturnValue('2025-07-31T23:59:59.999Z')
+        };
+
+        dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+
+        renderEditUserInfo(props);
+
+        await act(() => userEvent.click(screen.getByText('ui-users.information.recalculate.expirationDate')));
+        await userEvent.click(screen.getByText('ui-users.information.recalculate.modal.button'));
+
+        expect(dayjs.utc).toHaveBeenCalled();
+        expect(mockUtcDayjs.endOf).toHaveBeenCalledWith('day');
+        expect(mockUtcDayjs.toISOString).toHaveBeenCalled();
+      });
+
+      it('should process recalculated dates with correct format', async () => {
+        const mockCalculatedDate = {
+          ...getDayjsMock(),
+          format: jest.fn().mockReturnValue('2025-07-31'),
+          endOf: jest.fn().mockReturnThis(),
+          isSameOrBefore: jest.fn().mockReturnValue(false),
+        };
+
+        const mockUtcDayjs = {
+          ...getDayjsMock(),
+          endOf: jest.fn().mockReturnThis(),
+          toISOString: jest.fn().mockReturnValue('2025-07-31T23:59:59.999Z')
+        };
+
+        dayjs.mockImplementation(() => mockCalculatedDate);
+        dayjs.tz = jest.fn().mockReturnValue(mockCalculatedDate);
+        dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+
+        renderEditUserInfo(props);
+
+        await act(() => userEvent.click(screen.getByText('ui-users.information.recalculate.expirationDate')));
+        await userEvent.click(screen.getByText('ui-users.information.recalculate.modal.button'));
+
+        expect(mockCalculatedDate.format).toHaveBeenCalledWith('YYYY-MM-DD');
+        expect(dayjs.utc).toHaveBeenCalledWith('2025-07-31');
+        expect(mockUtcDayjs.endOf).toHaveBeenCalledWith('day');
+        expect(changeMock).toHaveBeenCalledWith('expirationDate', '2025-07-31T23:59:59.999Z');
+      });
+    });
+  });
+
+  describe('getNowAndExpirationEndOfDayInTenantTz', () => {
+    it('should handle timezone-aware expiration comparison for expired users', () => {
+      const expiredDate = '2023-01-15T23:59:59.999Z';
+
+      const mockUtcDayjs = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2023-01-15')
+      };
+
+      const mockExpirationEndOfDay = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(true),
+        isAfter: jest.fn().mockReturnValue(false),
+        endOf: jest.fn().mockReturnThis()
+      };
+
+      const mockNowInTz = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(false),
+        isAfter: jest.fn().mockReturnValue(true)
+      };
+
+      const mockDayjsBase = {
+        ...getDayjsMock(),
+        tz: jest.fn().mockReturnValue(mockNowInTz)
+      };
+
+      dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+      dayjs.tz = jest.fn().mockReturnValue(mockExpirationEndOfDay);
+      dayjs.mockReturnValue(mockDayjsBase);
+
+      const propsWithExpiredUser = {
+        ...props,
+        initialValues: {
+          ...props.initialValues,
+          expirationDate: expiredDate,
+        }
+      };
+
+      renderEditUserInfo(propsWithExpiredUser);
+
+      expect(dayjs.utc).toHaveBeenCalledWith(expiredDate);
+      expect(mockUtcDayjs.format).toHaveBeenCalledWith('YYYY-MM-DD');
+      expect(dayjs.tz).toHaveBeenCalledWith('2023-01-15', 'America/New_York');
+      expect(screen.getByText('ui-users.errors.userExpired')).toBeInTheDocument();
+    });
+
+    it('should handle timezone-aware expiration comparison for active users', () => {
+      const futureDate = '2026-12-31T23:59:59.999Z';
+
+      const mockUtcDayjs = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2026-12-31')
+      };
+
+      const mockExpirationEndOfDay = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(false),
+        isAfter: jest.fn().mockReturnValue(true),
+        endOf: jest.fn().mockReturnThis()
+      };
+
+      const mockNowInTz = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(true),
+        isAfter: jest.fn().mockReturnValue(false)
+      };
+
+      const mockDayjsBase = {
+        ...getDayjsMock(),
+        tz: jest.fn().mockReturnValue(mockNowInTz)
+      };
+
+      dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+      dayjs.tz = jest.fn().mockReturnValue(mockExpirationEndOfDay);
+      dayjs.mockReturnValue(mockDayjsBase);
+
+      const propsWithActiveUser = {
+        ...props,
+        initialValues: {
+          ...props.initialValues,
+          expirationDate: futureDate,
+        }
+      };
+
+      renderEditUserInfo(propsWithActiveUser);
+
+      expect(dayjs.utc).toHaveBeenCalledWith(futureDate);
+      expect(mockUtcDayjs.format).toHaveBeenCalledWith('YYYY-MM-DD');
+      expect(dayjs.tz).toHaveBeenCalledWith('2026-12-31', 'America/New_York');
+      expect(screen.queryByText('ui-users.errors.userExpired')).not.toBeInTheDocument();
+    });
+
+    it('should use tenant timezone', () => {
+      const timezone = 'America/Vancouver';
+
+      const mockUtcDayjs = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2025-07-15')
+      };
+
+      const mockTimezoneObj = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(false),
+        isAfter: jest.fn().mockReturnValue(true),
+        endOf: jest.fn().mockReturnThis()
+      };
+
+      const mockNowInTz = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(false),
+        isAfter: jest.fn().mockReturnValue(true)
+      };
+
+      const mockDayjsBase = {
+        ...getDayjsMock(),
+        tz: jest.fn().mockReturnValue(mockNowInTz)
+      };
+
+      dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+      dayjs.tz = jest.fn().mockReturnValue(mockTimezoneObj);
+      dayjs.mockReturnValue(mockDayjsBase);
+
+      const timezoneProps = {
+        ...props,
+        stripes: {
+          ...props.stripes,
+          timezone
+        },
+        initialValues: {
+          ...props.initialValues,
+          expirationDate: '2025-07-15T23:59:59.999Z'
+        }
+      };
+
+      renderEditUserInfo(timezoneProps);
+
+      expect(dayjs.tz).toHaveBeenCalledWith('2025-07-15', timezone);
+      expect(mockDayjsBase.tz).toHaveBeenCalledWith(timezone);
+    });
+
+    it('should extract date part correctly to avoid time inconsistencies', () => {
+      // Test with old data that might not be end-of-day
+      const inconsistentTimeData = '2025-06-15T14:30:22.123Z';
+
+      const mockUtcDayjs = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2025-06-15')
+      };
+
+      const mockTimezoneObj = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(false),
+        isAfter: jest.fn().mockReturnValue(true),
+        endOf: jest.fn().mockReturnThis()
+      };
+
+      const mockNowInTz = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(false),
+        isAfter: jest.fn().mockReturnValue(true)
+      };
+
+      const mockDayjsBase = {
+        ...getDayjsMock(),
+        tz: jest.fn().mockReturnValue(mockNowInTz)
+      };
+
+      dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+      dayjs.tz = jest.fn().mockReturnValue(mockTimezoneObj);
+      dayjs.mockReturnValue(mockDayjsBase);
+
+      const propsWithInconsistentTime = {
+        ...props,
+        initialValues: {
+          ...props.initialValues,
+          expirationDate: inconsistentTimeData,
+        }
+      };
+
+      renderEditUserInfo(propsWithInconsistentTime);
+
+      expect(dayjs.utc).toHaveBeenCalledWith(inconsistentTimeData);
+      expect(mockUtcDayjs.format).toHaveBeenCalledWith('YYYY-MM-DD');
+      expect(dayjs.tz).toHaveBeenCalledWith('2025-06-15', 'America/New_York');
+      expect(mockTimezoneObj.endOf).toHaveBeenCalledWith('day');
+    });
+
+    it('should handle UTC fallback when timezone is not specified', () => {
+      const mockUtcDayjs = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2025-08-01')
+      };
+
+      const mockTimezoneObj = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(false),
+        isAfter: jest.fn().mockReturnValue(true),
+        endOf: jest.fn().mockReturnThis()
+      };
+
+      const mockNowInTz = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(false),
+        isAfter: jest.fn().mockReturnValue(true)
+      };
+
+      const mockDayjsBase = {
+        ...getDayjsMock(),
+        tz: jest.fn().mockReturnValue(mockNowInTz)
+      };
+
+      dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+      dayjs.tz = jest.fn().mockReturnValue(mockTimezoneObj);
+      dayjs.mockReturnValue(mockDayjsBase);
+
+      const propsWithoutTimezone = {
+        ...props,
+        stripes: {
+          ...props.stripes,
+          timezone: undefined,
+        },
+        initialValues: {
+          ...props.initialValues,
+          expirationDate: '2025-08-01T23:59:59.999Z'
+        }
+      };
+
+      renderEditUserInfo(propsWithoutTimezone);
+
+      expect(dayjs.tz).toHaveBeenCalledWith('2025-08-01', 'UTC');
+      expect(mockDayjsBase.tz).toHaveBeenCalledWith('UTC');
+    });
+
+    it('should handle form field expiration date changes for willUserExtend logic', async () => {
+      const futureDate = '2026-01-01T23:59:59.999Z';
+      const expiredInitialDate = '2023-01-01T23:59:59.999Z';
+
+      const mockUtcDayjsForInitial = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2023-01-01'),
+      };
+
+      const mockUtcDayjsForFuture = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2026-01-01'),
+      };
+
+      const mockExpiredEndOfDay = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(true),
+        isAfter: jest.fn().mockReturnValue(false),
+        endOf: jest.fn().mockReturnThis()
+      };
+
+      const mockFutureEndOfDay = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(false),
+        isAfter: jest.fn().mockReturnValue(true),
+        endOf: jest.fn().mockReturnThis()
+      };
+
+      const mockNowInTz = {
+        ...getDayjsMock(),
+        isBefore: jest.fn().mockReturnValue(true),
+        isAfter: jest.fn().mockReturnValue(false)
+      };
+
+      const mockForm = {
+        ...props.form,
+        getFieldState: jest.fn().mockReturnValue({ value: futureDate })
+      };
+
+      const mockDayjsBase = {
+        ...getDayjsMock(),
+        tz: jest.fn().mockReturnValue(mockNowInTz)
+      };
+
+      dayjs.utc = jest.fn()
+        .mockImplementation((date) => {
+          if (date === expiredInitialDate) return mockUtcDayjsForInitial;
+          if (date === futureDate) return mockUtcDayjsForFuture;
+          return mockUtcDayjsForInitial;
+        });
+
+      dayjs.tz = jest.fn()
+        .mockImplementation((date) => {
+          if (date === '2023-01-01') return mockExpiredEndOfDay;
+          if (date === '2026-01-01') return mockFutureEndOfDay;
+          return mockExpiredEndOfDay;
+        });
+
+      dayjs.mockReturnValue(mockDayjsBase);
+
+      const propsWithExtendingUser = {
+        ...props,
+        form: mockForm,
+        initialValues: {
+          ...props.initialValues,
+          expirationDate: expiredInitialDate,
+        }
+      };
+
+      renderEditUserInfo(propsWithExtendingUser);
+
+      expect(screen.getByText('ui-users.information.recalculate.will.reactivate.user')).toBeInTheDocument();
+      expect(mockForm.getFieldState).toHaveBeenCalledWith('expirationDate');
+    });
+  });
+
+  describe('calculateNewExpirationDate', () => {
+    it('should calculate from today when startCalcToday is true', async () => {
+      const mockCalculatedDate = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2025-08-05'),
+        add: jest.fn().mockReturnThis(),
+        tz: jest.fn().mockReturnThis(),
+        isSameOrBefore: jest.fn().mockReturnValue(false),
+      };
+
+      const mockUtcDayjs = {
+        ...getDayjsMock(),
+        endOf: jest.fn().mockReturnThis(),
+        toISOString: jest.fn().mockReturnValue('2025-08-05T23:59:59.999Z')
+      };
+
+      dayjs.mockImplementation(() => mockCalculatedDate);
+      dayjs.tz = jest.fn().mockReturnValue(mockCalculatedDate);
+      dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+
+      renderEditUserInfo(props);
+
+      await act(() => userEvent.click(screen.getByText('ui-users.information.recalculate.expirationDate')));
+      await userEvent.click(screen.getByText('ui-users.information.recalculate.modal.button'));
+
+      expect(dayjs().tz).toHaveBeenCalledWith('America/New_York');
+      expect(mockCalculatedDate.add).toHaveBeenCalledWith(730, 'd');
+      expect(mockCalculatedDate.format).toHaveBeenCalledWith('YYYY-MM-DD');
+    });
+
+    it('should calculate from existing expiration date when startCalcToday is false and date is in future', async () => {
+      const futureDate = '2026-01-01T23:59:59.999Z';
+
+      const mockExistingDate = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2026-01-01'),
+        add: jest.fn().mockReturnThis(),
+        tz: jest.fn().mockReturnThis(),
+        isSameOrBefore: jest.fn().mockReturnValue(false),
+      };
+
+      const mockNowDate = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2025-08-05'),
+        add: jest.fn().mockReturnThis(),
+        tz: jest.fn().mockReturnThis(),
+        isSameOrBefore: jest.fn().mockReturnValue(true),
+      };
+
+      const mockUtcDayjs = {
+        ...getDayjsMock(),
+        endOf: jest.fn().mockReturnThis(),
+        toISOString: jest.fn().mockReturnValue('2026-01-01T23:59:59.999Z')
+      };
+
+      dayjs.mockImplementation(() => mockNowDate);
+      dayjs.tz = jest.fn()
+        .mockReturnValueOnce(mockExistingDate)
+        .mockReturnValue(mockExistingDate);
+      dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+
+      const propsWithFutureDate = {
+        ...props,
+        initialValues: {
+          ...props.initialValues,
+          expirationDate: futureDate,
+        }
+      };
+
+      renderEditUserInfo(propsWithFutureDate);
+
+      await userEvent.click(screen.getByText('ui-users.information.recalculate.expirationDate'));
+
+      expect(dayjs.tz).toHaveBeenCalledWith(futureDate, 'America/New_York');
+      expect(mockExistingDate.add).toHaveBeenCalledWith(730, 'd');
+    });
+
+    it('should fallback to today when existing expiration date is expired', async () => {
+      const expiredDate = '2023-01-01T23:59:59.999Z';
+
+      const mockExpiredDate = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2023-01-01'),
+        add: jest.fn().mockReturnThis(),
+        tz: jest.fn().mockReturnThis(),
+        isSameOrBefore: jest.fn().mockReturnValue(true),
+      };
+
+      const mockNowDate = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2025-08-05'),
+        add: jest.fn().mockReturnThis(),
+        tz: jest.fn().mockReturnThis(),
+        isSameOrBefore: jest.fn().mockReturnValue(false),
+      };
+
+      const mockUtcDayjs = {
+        ...getDayjsMock(),
+        endOf: jest.fn().mockReturnThis(),
+        toISOString: jest.fn().mockReturnValue('2025-08-05T23:59:59.999Z')
+      };
+
+      dayjs.mockImplementation(() => mockNowDate);
+      dayjs.tz = jest.fn()
+        .mockReturnValueOnce(mockExpiredDate)
+        .mockReturnValue(mockNowDate);
+      dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+
+      const propsWithExpiredDate = {
+        ...props,
+        initialValues: {
+          ...props.initialValues,
+          expirationDate: expiredDate,
+        }
+      };
+
+      renderEditUserInfo(propsWithExpiredDate);
+
+      await userEvent.click(screen.getByText('ui-users.information.recalculate.expirationDate'));
+
+      expect(mockNowDate.add).toHaveBeenCalledWith(730, 'd');
+    });
+
+    it('should handle undefined expiration date by using today', async () => {
+      const mockNowDate = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2025-08-05'),
+        add: jest.fn().mockReturnThis(),
+        tz: jest.fn().mockReturnThis(),
+        isSameOrBefore: jest.fn().mockReturnValue(false),
+      };
+
+      const mockUtcDayjs = {
+        ...getDayjsMock(),
+        endOf: jest.fn().mockReturnThis(),
+        toISOString: jest.fn().mockReturnValue('2025-08-05T23:59:59.999Z')
+      };
+
+      dayjs.mockImplementation(() => mockNowDate);
+      dayjs.tz = jest.fn().mockReturnValue(mockNowDate);
+      dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+
+      const propsWithoutDate = {
+        ...props,
+        initialValues: {
+          ...props.initialValues,
+          expirationDate: undefined,
+        }
+      };
+
+      renderEditUserInfo(propsWithoutDate);
+
+      await userEvent.click(screen.getByText('ui-users.information.recalculate.expirationDate'));
+
+      expect(mockNowDate.add).toHaveBeenCalledWith(730, 'd');
+    });
+
+    it('should use tenant timezone for calculations', async () => {
+      const timezone = 'Asia/Tokyo';
+
+      const mockCalculatedDate = {
+        ...getDayjsMock(),
+        format: jest.fn().mockReturnValue('2025-08-05'),
+        add: jest.fn().mockReturnThis(),
+        tz: jest.fn().mockReturnThis(),
+        isSameOrBefore: jest.fn().mockReturnValue(false),
+      };
+
+      const mockUtcDayjs = {
+        ...getDayjsMock(),
+        endOf: jest.fn().mockReturnThis(),
+        toISOString: jest.fn().mockReturnValue('2025-08-05T23:59:59.999Z')
+      };
+
+      dayjs.mockImplementation(() => mockCalculatedDate);
+      dayjs.tz = jest.fn().mockReturnValue(mockCalculatedDate);
+      dayjs.utc = jest.fn().mockReturnValue(mockUtcDayjs);
+
+      const timezoneProps = {
+        ...props,
+        stripes: {
+          ...props.stripes,
+          timezone,
+        },
+      };
+
+      renderEditUserInfo(timezoneProps);
+
+      userEvent.click(screen.getByText('ui-users.information.recalculate.expirationDate'));
+
+      expect(dayjs().tz).toHaveBeenCalledWith(timezone);
     });
   });
 });

--- a/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
+++ b/src/components/Loans/OpenLoans/components/ActionsDropdown/ActionsDropdown.js
@@ -57,12 +57,15 @@ class ActionsDropdown extends React.Component {
       patronGroup,
       history,
     } = this.props;
+    const {
+      timezone = 'UTC',
+    } = stripes;
 
     const itemStatusName = loan?.item?.status?.name;
     const itemDetailsLink = `/inventory/view/${loan.item?.instanceId}/${loan.item?.holdingsRecordId}/${loan.itemId}`;
     const loanPolicyLink = `/settings/circulation/loan-policies/${loan.loanPolicyId}`;
     const buttonDisabled = !stripes.hasPerm('ui-users.feesfines.actions.all');
-    const isUserActive = checkUserActive(user);
+    const isUserActive = checkUserActive(user, timezone);
     const isVirtualUser = isDcbUser(user);
     const isVirtualItem = isDcbItem(loan?.item);
     const isItemAbsent = !loan?.item;

--- a/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
+++ b/src/components/Loans/OpenLoans/components/OpenLoansSubHeader/OpenLoansSubHeader.js
@@ -6,7 +6,10 @@ import {
 } from 'lodash';
 import { useIntl } from 'react-intl';
 
-import { IfPermission } from '@folio/stripes/core';
+import {
+  IfPermission,
+  useStripes,
+} from '@folio/stripes/core';
 import {
   Button,
   Dropdown,
@@ -54,8 +57,13 @@ const OpenLoansSubHeader = ({
   patronGroup
 }) => {
   const intl = useIntl();
+  const stripes = useStripes();
 
   const [toggleDropdownState, setToggleDropdownState] = useState(false);
+
+  const {
+    timezone = 'UTC',
+  } = stripes;
 
   const headers = [
     'action',
@@ -124,7 +132,7 @@ const OpenLoansSubHeader = ({
   const countRenews = getRenewalPatronBlocksFromPatronBlocks(patronBlocks);
   const onlyClaimedReturnedItemsSelected = hasEveryLoanItemStatus(checkedLoans, itemStatuses.CLAIMED_RETURNED);
   const onlyLostyItemsSelected = hasAnyLoanItemStatus(checkedLoans, lostItemStatuses);
-  const isUserActive = checkUserActive(user);
+  const isUserActive = checkUserActive(user, timezone);
   const isVirtualUser = isDcbUser(user);
   const checkedLoansArray = Object.values(checkedLoans);
 

--- a/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.js
+++ b/src/components/ProxyGroup/ProxyEditItem/ProxyEditItem.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Field } from 'react-final-form';
 import { OnChange } from 'react-final-form-listeners';
+import { withStripes } from '@folio/stripes/core';
 import {
   Row,
   Col,
@@ -35,6 +36,9 @@ class ProxyEditItem extends React.Component {
     onDelete: PropTypes.func,
     change: PropTypes.func.isRequired,
     formValues: PropTypes.object,
+    stripes: PropTypes.shape({
+      timezone: PropTypes.string,
+    }).isRequired,
   };
 
   constructor() {
@@ -96,11 +100,15 @@ class ProxyEditItem extends React.Component {
     const {
       index,
       namespace,
+      stripes,
     } = this.props;
+    const {
+      timezone = 'UTC',
+    } = stripes;
 
     const formValues = this.state.formValues;
 
-    this.toggleStatus(!getWarning(formValues, namespace, index));
+    this.toggleStatus(!getWarning(formValues, namespace, index, timezone));
   }
 
   optionsFor = (list) => {
@@ -244,4 +252,4 @@ class ProxyEditItem extends React.Component {
   }
 }
 
-export default ProxyEditItem;
+export default withStripes(ProxyEditItem);

--- a/src/components/util/getProxySponsorWarning.js
+++ b/src/components/util/getProxySponsorWarning.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import moment from 'moment';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
+
+import { dayjs } from '@folio/stripes/components';
 
 /**
  * getProxySponsorWarning
@@ -26,24 +27,24 @@ import { get } from 'lodash';
  *
  * @return empty string indicates no warnings; a string contains a warning message.
  */
-export default function getProxySponsorWarning(values, namespace, index) {
+export default function getProxySponsorWarning(values, namespace, index, timezone = 'UTC') {
   const proxyRel = values[namespace][index] || {};
-  const today = moment().endOf('day');
+  const today = dayjs().tz(timezone).endOf('day');
   let warning = '';
 
   // proxy/sponsor user expired
-  if (get(proxyRel, 'user.expirationDate') && moment(proxyRel.user.expirationDate).isSameOrBefore(today, 'day')) {
+  if (get(proxyRel, 'user.expirationDate') && dayjs.tz(proxyRel.user.expirationDate, timezone).isSameOrBefore(today, 'day')) {
     warning = <FormattedMessage id={`ui-users.errors.${namespace}.expired`} />;
   }
 
   // current user expired
-  if (values.expirationDate && moment(values.expirationDate).isSameOrBefore(today, 'day')) {
+  if (values.expirationDate && dayjs.tz(values.expirationDate, timezone).isSameOrBefore(today, 'day')) {
     warning = <FormattedMessage id="ui-users.errors.currentUser.expired" />;
   }
 
   // proxy relationship expired
   if (get(proxyRel, 'proxy.expirationDate') &&
-    moment(proxyRel.proxy.expirationDate).isSameOrBefore(today, 'day')) {
+    dayjs.tz(proxyRel.proxy.expirationDate, timezone).isSameOrBefore(today, 'day')) {
     warning = <FormattedMessage id="ui-users.errors.proxyrelationship.expired" />;
   }
 

--- a/src/components/util/getProxySponsorWarning.test.js
+++ b/src/components/util/getProxySponsorWarning.test.js
@@ -3,6 +3,8 @@ import getProxySponsorWarning from './getProxySponsorWarning';
 
 describe('Proxy Sponsor component', () => {
   it('getProxySponsorWarning', async () => {
+    const timezone = 'Pacific/Fakaofo';
+
     const values = {
       proxies: [
         {
@@ -23,7 +25,7 @@ describe('Proxy Sponsor component', () => {
       expirationDate: '2022-05-30T03:22:53.897+00:00',
     };
 
-    const data = getProxySponsorWarning(values, 'proxies', 0);
+    const data = getProxySponsorWarning(values, 'proxies', 0, timezone);
     expect(data).toBeTruthy();
   });
 });

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -3,7 +3,10 @@ import { FormattedMessage } from 'react-intl';
 import { every, orderBy } from 'lodash';
 import queryString from 'query-string';
 
-import { NoValue } from '@folio/stripes/components';
+import {
+  dayjs,
+  NoValue,
+} from '@folio/stripes/components';
 
 import {
   USER_TYPES,
@@ -176,11 +179,9 @@ export function getValue(value) {
   return value || '';
 }
 
-// Given a user record, test whether the user is active. Checking the `active` property ought to
-// be sufficient, but test the expiration date as well just to be sure.
-export function checkUserActive(user) {
+export function checkUserActive(user = {}, timezone = 'UTC') {
   if (user.expirationDate == null || user.expirationDate === undefined) return user.active;
-  return user.active && (new Date(user.expirationDate) >= new Date());
+  return user.active && (dayjs.tz(user.expirationDate, timezone).isAfter(dayjs().tz(timezone), 'day'));
 }
 
 export const getContributors = (account, instance) => {

--- a/src/views/LoanDetails/LoanDetails.js
+++ b/src/views/LoanDetails/LoanDetails.js
@@ -422,6 +422,9 @@ class LoanDetails extends React.Component {
       isLoading,
       showErrorCallout,
     } = this.props;
+    const {
+      timezone = 'UTC',
+    } = stripes;
 
     const {
       patronBlockedModal,
@@ -528,7 +531,7 @@ class LoanDetails extends React.Component {
       </p>
     );
     const patronBlocksForModal = getRenewalPatronBlocksFromPatronBlocks(patronBlocks);
-    const isUserActive = user ? checkUserActive(user) : false;
+    const isUserActive = user ? checkUserActive(user, timezone) : false;
     const borrower = user ? getFullName(user) : <FormattedMessage id="ui-users.user.unknown" />;
     const isVirtualPatron = isDcbUser(user);
 

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
 import { FormattedMessage } from 'react-intl';
 
@@ -12,7 +11,10 @@ import {
   get,
 } from 'lodash';
 
-import { LoadingView } from '@folio/stripes/components';
+import {
+  dayjs,
+  LoadingView,
+} from '@folio/stripes/components';
 import {
   CalloutContext,
   withOkapiKy,
@@ -286,6 +288,9 @@ class UserEdit extends React.Component {
       resources,
       stripes,
     } = this.props;
+    const {
+      timezone = 'UTC',
+    } = stripes;
 
     const propertiesToOmit = ['creds', 'proxies', 'sponsors', 'permissions', 'servicePoints', 'preferredServicePoint', 'assignedRoleIds', 'initialAssignedRoleIds', 'tenantId'];
     const user = cloneDeep(userFormData);
@@ -329,7 +334,7 @@ class UserEdit extends React.Component {
     }
 
     const data = omit(user, propertiesToOmit);
-    const today = moment().endOf('day');
+    const today = dayjs().tz(timezone).endOf('day');
     const curActive = user.active;
     const prevActive = prevUser.active;
     const formattedCustomFieldsPayload = this.formatCustomFieldsPayload(data.customFields);
@@ -341,7 +346,7 @@ class UserEdit extends React.Component {
     if (curActive !== prevActive || !user.expirationDate) {
       data.active = curActive;
     } else {
-      data.active = (moment(user.expirationDate).endOf('day').isSameOrAfter(today));
+      data.active = dayjs.tz(user.expirationDate, timezone).endOf('day').isSameOrAfter(today);
     }
 
     this.updateUserData(data, user);

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -357,6 +357,10 @@ class UserForm extends React.Component {
       isCreateKeycloakUserConfirmationOpen,
       onCancelKeycloakConfirmation
     } = this.props;
+    const {
+      timezone = 'UTC',
+    } = stripes;
+
     const isEditing = !!initialValues.id;
     const selectedPatronGroup = form.getFieldState('patronGroup')?.value;
     const firstMenu = this.getAddFirstMenu();
@@ -527,7 +531,7 @@ class UserForm extends React.Component {
               ['sponsors', 'proxies'].forEach(namespace => {
                 if (values[namespace]) {
                   values[namespace].forEach((_, index) => {
-                    const warning = getProxySponsorWarning(values, namespace, index);
+                    const warning = getProxySponsorWarning(values, namespace, index, timezone);
 
                     if (warning) {
                       mutators.setFieldData(`${namespace}[${index}].proxy.status`, { warning });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

# Fix expiration date issues.

## Problems
1. ~~The expiration date field shows one day ahead for the timezone, which is _already_ the next day (Pacific/Fakaofo). This happens because the expiration date is not saved at the end of the day, it is saved with a time shift based on your timezone (e.g. 2025-08-07T**20**:**59**:59.999Z). The expiration date must display the same date for all timezones ([UIU-3352](https://folio-org.atlassian.net/browse/UIU-3352)).~~
2. User accounts expire at 5PM instead of midnight in Vancouver (UTC-7). Users must expire at the end of the day ([UIU-3400](https://folio-org.atlassian.net/browse/UIU-3400), [UIU-2182](https://folio-org.atlassian.net/browse/UIU-2182)). This happens because the expiration date is saved with a time offset based on the time zone (e.g., for a user in UTC+3 it will be 2025-08-06T**20**:**59**:59.999+00:00). If the person who created a user was in UTC+3, but the user who opened the record was in UTC-7, the expiration date will be 1:59:59.999 PM.
3. When a user is created and then Edit page is opened in the timezone, which is _already_ the next day (Pacific/Fakaofo), then selecting a patron group with a 1-day offset, the modal window shows up with the correct day, but after hitting "Set", the one day earlier is inserted to the expiration date field. - 1-day offset must be added.

## Approach
1). **Store dates in UTC** - so "07/28/2025" becomes "2025-07-28T23:59:59.999Z" (end of day UTC)
2). **Display dates without timezone conversion** - so every timezone sees "07/28/2025"
3). **Apply timezone logic only for expiration checking** - convert UTC stored date to local timezone for comparison

1. ~~Save dates as UTC end of day using `dayjs.utc` (e.g. 2025-08-07T**23**:59:59.999Z), so that the expiration date field will display the same year, month, and day for all timezones (implemented in the `parseExpirationDate` function).~~
2. Most likely, the user records were created in the UTC timezone (default setting), and then patrons from Vancouver (UTC-7) got time shifting (24 - 7 = 17 PM). Or the user records were created in the Vancouver (UTC-7) timezone (setting set to Vancouver), but patron computers were not located in UTC-7.
- Save dates as UTC (end of day) using `dayjs.utc` (e.g. 2025-08-07T**23**:**59**:59.999Z), so that the expiration date field will display the same year, month, and day for all timezones (implemented in the `parseExpirationDate`). 
- When checking for expiration (in `isUserExpired`), also use `dayjs.utc` to avoid time shifting. This will allow having the correct year, month, and day. 
- Then extract just the date part (YYYY-MM-DD), as time may not match the end of the day for some existing data. 
- Then shift the day to the end. 
- Consider the tenant's timezone when forming the current time (`now`), since without `.tz(...)`, the timezone selected in the settings will not be taken into account, instead the local system/browser timezone will be taken into account. 
- Then compare the expiration date with `now`.
4. Change from `.format('L')` to `.format('YYYY-MM-DD')` in the `setRecalculatedExpirationDate`.
5. Migrate `moment` to `dayjs` everywhere for the expiration date functionality.

## Description
Based on the conversation summary and the current state of the files, I can describe what was accomplished in this comprehensive timezone bug fix:

What Was Done
1. **Fixed Core Timezone Bug**
* Problem: Users in non-UTC timezones (like Vancouver, UTC-8) were expiring at 5:00 PM instead of midnight due to incorrect timezone handling
* Solution: Implemented timezone-aware expiration logic where users expire at midnight in their tenant's configured timezone, not UTC midnight
6. **Complete Library Migration (moment.js → dayjs)**
* Migrated EditUserInfo.js: Replaced all moment.js usage with dayjs for better performance and consistency
* Migrated [getProxySponsorWarning.js](vscode-file://vscode-app/c:/Users/Dmytro_Melnyshyn/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Recently completed the migration by replacing the remaining moment(proxyRel.proxy.expirationDate) call with [dayjs.tz()](vscode-file://vscode-app/c:/Users/Dmytro_Melnyshyn/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and removing the unused moment import
* Updated ProxyEditItem.js: Uses timezone parameter from stripes for consistent date operations
7. **Architectural Design Decisions**
* **UTC Storage Pattern**: Dates are stored as UTC start-of-day (e.g., "2025-07-31T00:00:00.000Z") for consistent database storage
* **Timezone-Aware Business Logic**: All expiration comparisons use the tenant's timezone to determine when users actually expire (midnight in their local time)
Consistent Display: FormattedDate components use timeZone="UTC" to show the same date across all timezones
8. **Key Functions Implemented**
**In EditUserInfo.js:**
* `parseExpirationDate()`: Converts input dates to UTC ISO strings for storage
* `calculateNewExpirationDate()`: Performs date arithmetic in tenant timezone
* `getNowAndExpirationEndOfDayInTenantTz()`: Creates timezone-aware comparison objects
* `isUserExpired()` / `willUserExtend()`: Timezone-aware expiration checks
**In getProxySponsorWarning.js:**
* Updated all date comparisons to use [dayjs.tz(expirationDate, timezone)](vscode-file://vscode-app/c:/Users/Dmytro_Melnyshyn/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for consistent timezone context
* Ensures proxy/sponsor expiration warnings are accurate across timezones
9. **Error Resolution**
* **Fixed Runtime Errors** after reloading the page: Resolved "Invalid time value" RangeError by adding timezone fallbacks
* **Fixed Date Display Issues**: Changed from `.format('L')` to `.format('YYYY-MM-DD')` to prevent ambiguous date parsing that caused wrong dates to display
10. Ensured all changes work correctly in edge-case timezones like Pacific/Fakaofo (UTC+13)

**Why This Approach Was Chosen**
**UTC Storage + Timezone-Aware Logic Pattern**
This hybrid approach provides:

* Database Consistency: UTC storage prevents timezone-related data corruption
* User Experience: Expiration happens at midnight in the user's actual timezone
* Display Consistency: The same date appears the same way for all users

**Example of the Fix in Action**
For a Vancouver user (UTC-8) with expiration date "2025-07-29":

* **Before**: User expired at 5:00 PM Pacific Time (when UTC hit midnight)
* **After**: User expires at 11:59:59 PM Pacific Time (proper midnight in their timezone)
* **Storage**: Still stored as "2025-07-29T00:00:00.000Z" (UTC start-of-day)
* **Logic**: Compares against "2025-07-30T07:59:59.999Z" (end of July 29 in Pacific time)

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
