### PR TITLE
[UIU-3426] Fix User Edit workflow for making edits to non-Keycloak user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Only show Keycloak user record confirmation when assigning roles to a non-Keycloak record. Refs UIU-3426.
 * Add 'Minor' column to Patrons Pre-Registration List. Refs UIU-3425.
 * *BREAKING* Update the user record view page to display custom fields under the Fees/fines, Loans, or Requests accordions as configured in settings. Refs UIU-3130.
+* Fix User Edit workflow for making edits to non-Keycloak user. Previously Edit screen remained open. Now it properly returns to User Detail page with updated data. Refs UIU-3426.
 
 ## [12.1.7] (https://github.com/folio-org/ui-users/tree/v12.1.7) (2025-06-03)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.6...v12.1.7)

--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -106,6 +106,8 @@ const withUserRoles = (WrappedComponent) => (props) => {
         // If user confirms, then changes will be copied over from mod-users to mod-users-keycloak.
         if (!isEqual(assignedRoleIds, initialAssignedRoleIds)) {
           setIsCreateKeycloakUserConfirmationOpen(true);
+        } else {
+          onFinish();
         }
         break;
       default:


### PR DESCRIPTION
- Addressing comment made by QA in [UIU-3426](https://folio-org.atlassian.net/browse/UIU-3426?focusedCommentId=272678)
- Previously Edit screen remained open. Now it properly returns to User Detail page with updated data by calling `onFinish()`. This is only explicitly called when not assigning roles since `setIsCreateKeycloakUserConfirmationOpen()` calls `onFinish()` when dismissing the dialog.