### PR TITLE
Fix user edit form redirect issue

### DIFF
--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -106,6 +106,9 @@ const withUserRoles = (WrappedComponent) => (props) => {
         // If user confirms, then changes will be copied over from mod-users to mod-users-keycloak.
         if (!isEqual(assignedRoleIds, initialAssignedRoleIds)) {
           setIsCreateKeycloakUserConfirmationOpen(true);
+        } else {
+          // No role changes, complete the edit process
+          onFinish();
         }
         break;
       default:


### PR DESCRIPTION
## Description
Fixes a bug where the user edit form was not redirecting to the preview page after saving user data. The form would successfully save changes but remain on the edit page instead of navigating to the expected preview URL.

## Root Cause
The issue was in the `withUserRoles` Higher-Order Component (HOC) in the `checkAndHandleKeycloakAuthUser` function. In the case where `KEYCLOAK_USER_EXISTANCE.nonExist` was true but no role changes were detected, the `onFinish` callback was not being called, which prevented the redirect from occurring.

## Solution
Added an `else` clause to ensure the `onFinish()` callback is called in all scenarios, not just when role changes are detected. This ensures that the redirect behavior works consistently regardless of whether user roles need to be updated.

## Changes Made
- **File**: `src/components/Wrappers/withUserRoles.js`
- **Change**: Added `else { onFinish(); }` clause in the Promise chain of `checkAndHandleKeycloakAuthUser` function

## Testing
- ✅ Verified the fix works by testing the complete user edit workflow
- ✅ Confirmed redirect from `/edit` to `/preview` page after saving
- ✅ Verified that user data is properly saved and displayed on preview page
- ✅ Tested with Playwright browser automation to ensure end-to-end functionality

## Impact
- Fixes the redirect issue for all user edit operations
- Maintains existing functionality for role management scenarios
- No breaking changes to existing behavior
- Improves user experience by ensuring proper navigation flow

## Files Changed
- `src/components/Wrappers/withUserRoles.js` - Fixed missing callback invocation