### PR TITLE
UIU-2466: Fix pagination for user search results beyond 1000 records

### DIFF
--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
 import {
   cloneDeep,
   get,
   template,
+  flowRight,
 } from 'lodash';
 
-import { stripesConnect } from '@folio/stripes/core';
+import { 
+  stripesConnect,
+  withOkapiKy,
+} from '@folio/stripes/core';
 import {
   makeQueryFunction,
   StripesConnectedSource,
@@ -105,7 +110,14 @@ class UserSearchContainer extends React.Component {
       perRequest: 100,
       path: 'users',
       GET: {
-        params: { query: buildQuery },
+        params: { 
+          query: buildQuery,
+          // Setting `resultOffset` to the `offset` parameter is required to fetch results further than the 10th page (offset > 1000).
+          // BE returns `totalRecords` as 1000 even though there are more (this is how it works https://folio-org.atlassian.net/browse/RMB-673) 
+          // and stripes-connect requests 1000 in the `offset` parameter even when `resultOffset` is more then 1000 as it uses `totalRecords` value. 
+          // We can get around this by setting `offset` to the `resultOffset` value.
+          offset: '%{resultOffset}',
+      },
         staticFallback: { params: {} },
       },
       shouldRefresh: (resource, action, refresh) => {
@@ -236,14 +248,32 @@ class UserSearchContainer extends React.Component {
     this.searchField = React.createRef();
   }
 
+  state = {
+    actualTotalRecords: 0,
+    hasLoadedActualTotalRecords: false,
+  }
+
   componentDidMount() {
+    const {
+      resources,
+    } = this.props;
+
     this.source = new StripesConnectedSource(this.props, this.logger);
     if (this.searchField.current) {
       this.searchField.current.focus();
     }
+
+    if (resources.query?.query || resources.query?.filters) {
+      this.fetchActualTotalRecords();
+    }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    const {
+      resources,
+    } = this.props;
+    
+    // Process patron groups
     const pg = (this?.props?.resources?.patronGroups || {})?.records || [];
     if (pg.length) {
       const pgFilterConfig = filterConfig.find(group => group.name === 'pg');
@@ -253,11 +283,55 @@ class UserSearchContainer extends React.Component {
         this.props.mutator.initializedFilterConfig.replace(true); // triggers refresh of users
       }
     }
+
+    // Only fetch actual total records if the `query` or `filters` have changed
+    if (resources.query.query && resources.query.query !== prevProps.resources.query.query 
+      || resources.query.filters && resources.query.filters !== prevProps.resources.query.filters
+    ) {
+      this.fetchActualTotalRecords();
+    }
+
     this.source.update(this.props);
+  }
+
+  resetActualTotalRecords = () => {
+    this.setState({ 
+      actualTotalRecords: 0,
+      hasLoadedActualTotalRecords: false,
+    });
+  }
+
+  fetchActualTotalRecords = async () => {
+    const { 
+      okapiKy,
+      resources,
+    } = this.props;
+
+    const queryParams = { ...resources.query };
+    const searchQuery = buildQuery(queryParams, {}, resources, this.logger, this.props);
+
+    if (!searchQuery) return;
+
+    try {
+      console.log('111')
+      const response = await okapiKy(`users?limit=0&query=${searchQuery}`);
+      const data = await response.json();
+
+      console.log('2222')
+
+      this.setState({ 
+        actualTotalRecords: data.totalRecords,
+        hasLoadedActualTotalRecords: true,
+      });
+    } catch (error) {
+      this.log('Error fetching actual total records:', error);
+    }
   }
 
   onNeedMoreData = (askAmount, index) => {
     const { resultOffset } = this.props.mutator;
+
+    this.fetchActualTotalRecords();
 
     if (this.source) {
       if (resultOffset && index >= 0) {
@@ -287,9 +361,7 @@ class UserSearchContainer extends React.Component {
       location = { ...locationProp, pathname };
     }
 
-    // reset offset when sort values change
-    // https://issues.folio.org/browse/UIU-2466
-    if (state.sortChanged) {
+    if (resultOffset) {
       resultOffset.replace(0);
     }
 
@@ -308,9 +380,16 @@ class UserSearchContainer extends React.Component {
   }
 
   render() {
+    const {
+      actualTotalRecords,
+      hasLoadedActualTotalRecords,
+    } = this.state;
+
     if (this.source) {
       this.source.update(this.props);
     }
+
+    console.log('this.props', this.props.resources.resultOffset)
 
     return (
       <UserSearch
@@ -319,6 +398,9 @@ class UserSearchContainer extends React.Component {
         onNeedMoreData={this.onNeedMoreData}
         queryGetter={this.queryGetter}
         querySetter={this.querySetter}
+        actualTotalRecords={actualTotalRecords}
+        hasLoadedActualTotalRecords={hasLoadedActualTotalRecords}
+        onResetActualTotalRecords={this.resetActualTotalRecords}
         {...this.props}
       >
         { this.props.children }
@@ -327,4 +409,6 @@ class UserSearchContainer extends React.Component {
   }
 }
 
-export default stripesConnect(UserSearchContainer);
+export default flowRight(
+  withOkapiKy,
+)(stripesConnect(UserSearchContainer));

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -160,6 +160,12 @@ class UserSearch extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
+    const { 
+      resources, 
+      source,
+      history,
+    } = this.props;
+
     if (
       this.state.searchPending &&
       prevProps.resources.records &&
@@ -168,7 +174,6 @@ class UserSearch extends React.Component {
       this.onSearchComplete(this.props.resources.records);
     }
 
-    const { resources, source, history } = this.props;
     // Open the detail view when there's a single hit
     if (resources.records.records[0] !== prevProps.resources.records.records[0] &&
       source.totalCount() === 1) {
@@ -197,11 +202,14 @@ class UserSearch extends React.Component {
     };
   }
 
-  onSearchComplete = records => {
-    const { intl } = this.props;
+  onSearchComplete = () => {
+    const { 
+      intl,
+      actualTotalRecords,
+    } = this.props;
+
     const headerEl = this.resultsPaneTitleRef.current;
-    const resultsCount = get(records, 'other.totalRecords', 0);
-    const hasResults = !!resultsCount;
+    const hasResults = !!actualTotalRecords;
 
     this.setState({ searchPending: false });
 
@@ -209,7 +217,7 @@ class UserSearch extends React.Component {
     this.SRStatusRef.current.sendMessage(intl.formatMessage({
       id: 'ui-users.resultCount',
     }, {
-      count: resultsCount
+      count: actualTotalRecords,
     }));
 
     // Focus the pane header if we have results to minimize tabbing distance
@@ -646,6 +654,9 @@ class UserSearch extends React.Component {
       stripes: { timezone },
       okapi: { currentUser },
       intl: { formatMessage },
+      actualTotalRecords,
+      hasLoadedActualTotalRecords,
+      onResetActualTotalRecords,
     } = this.props;
     const {
       filterPaneIsVisible,
@@ -670,7 +681,6 @@ class UserSearch extends React.Component {
     const servicePoints = currentUser.servicePoints;
     const patronGroups = (resources.patronGroups || {}).records || [];
     const query = queryGetter ? queryGetter() || {} : {};
-    const count = source ? source.totalCount() : 0;
     const sortOrder = query.sort || '';
     const initialCashDrawerReportValues = {
       format: 'both'
@@ -686,8 +696,9 @@ class UserSearch extends React.Component {
       </div>) : 'no source yet';
 
     let resultPaneSub = <FormattedMessage id="stripes-smart-components.searchCriteria" />;
-    if (source && source.loaded()) {
-      resultPaneSub = <FormattedMessage id="stripes-smart-components.searchResultsCountHeader" values={{ count }} />;
+
+    if (hasLoadedActualTotalRecords) {
+      resultPaneSub = <FormattedMessage id="stripes-smart-components.searchResultsCountHeader" values={{ count: actualTotalRecords }} />;
     }
 
     const resultsFormatter = {
@@ -730,6 +741,11 @@ class UserSearch extends React.Component {
                 searchChanged,
                 resetAll,
               }) => {
+                const handleResetAll = () => {
+                  onResetActualTotalRecords();
+                  resetAll();
+                };
+
                 return (
                   <Paneset id={`${idPrefix}-paneset`}>
                     {filterPaneIsVisible &&
@@ -789,7 +805,7 @@ class UserSearch extends React.Component {
                               id="clickable-reset-all"
                               disabled={!(filterChanged || searchChanged)}
                               fullWidth
-                              onClick={resetAll}
+                              onClick={handleResetAll}
                             >
                               <Icon icon="times-circle-solid">
                                 <FormattedMessage id="stripes-smart-components.resetAll" />
@@ -827,7 +843,7 @@ class UserSearch extends React.Component {
                             visibleColumns={visibleColumns}
                             rowUpdater={this.rowUpdater}
                             contentData={users}
-                            totalCount={count}
+                            totalCount={actualTotalRecords}
                             columnMapping={columnMapping}
                             formatter={resultsFormatter}
                             onNeedMoreData={onNeedMoreData}


### PR DESCRIPTION
## Purpose
Fix pagination issues when user search results exceed 1000 records by implementing proper handling of actual total record counts.

## Description
This PR addresses the pagination limitation where stripes-connect only returns a maximum of 1000 records in `totalRecords`, even when more records exist. The changes include:

- **UserSearchContainer.js**: Added functionality to fetch actual total record counts using a separate API call with `limit=0`
- **UserSearch.js**: Updated to use the actual total records count instead of the limited count from stripes-connect
- **Filters.js**: Added debug logging for filter change tracking

Key changes:
- Added `fetchActualTotalRecords()` method to get true record count
- Implemented state management for `actualTotalRecords` and `hasLoadedActualTotalRecords`
- Updated pagination logic to use actual counts instead of capped values
- Added `resultOffset` parameter handling to enable pagination beyond page 10
- Enhanced reset functionality to clear actual total records state

## Issues
https://folio-org.atlassian.net/browse/UIU-2466