### PR TITLE
B12.1 patch [UIU-3426]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## [12.1.10] (https://github.com/folio-org/ui-users/tree/v12.1.10) (2025-08-20)
+[Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.9...v12.1.10)
+* Only show Keycloak user record confirmation when assigning roles to a non-Keycloak record. Refs UIU-3426.
+
 ## [12.1.9] (https://github.com/folio-org/ui-users/tree/v12.1.9) (2025-07-30)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.8...v12.1.9)
 * Add support for use circulation-bff for declare-item-lost. Refs UIU-3414.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [12.1.10] (https://github.com/folio-org/ui-users/tree/v12.1.10) (2025-08-20)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.9...v12.1.10)
 * Only show Keycloak user record confirmation when assigning roles to a non-Keycloak record. Refs UIU-3426.
+* Fix User Edit workflow for making edits to non-Keycloak user. Previously Edit screen remained open. Now it properly returns to User Detail page with updated data. Refs UIU-3426.
 
 ## [12.1.9] (https://github.com/folio-org/ui-users/tree/v12.1.9) (2025-07-30)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.8...v12.1.9)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/users",
-  "version": "12.1.9",
+  "version": "12.1.10",
   "description": "User management",
   "repository": "folio-org/ui-users",
   "publishConfig": {

--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -106,6 +106,8 @@ const withUserRoles = (WrappedComponent) => (props) => {
         // If user confirms, then changes will be copied over from mod-users to mod-users-keycloak.
         if (!isEqual(assignedRoleIds, initialAssignedRoleIds)) {
           setIsCreateKeycloakUserConfirmationOpen(true);
+        } else {
+          onFinish();
         }
         break;
       default:

--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -100,9 +100,13 @@ const withUserRoles = (WrappedComponent) => (props) => {
         break;
       case KEYCLOAK_USER_EXISTANCE.nonExist:
         // First, save changes to mod-users.
-        // If user decides to create a Keycloak user, then changes will be copied over from mod-users to mod-users-keycloak.
         await mutator.selUser.PUT(data);
-        setIsCreateKeycloakUserConfirmationOpen(true);
+
+        // Only prompt and create Keycloak user if assigning roles.
+        // If user confirms, then changes will be copied over from mod-users to mod-users-keycloak.
+        if (!isEqual(assignedRoleIds, initialAssignedRoleIds)) {
+          setIsCreateKeycloakUserConfirmationOpen(true);
+        }
         break;
       default:
         break;


### PR DESCRIPTION
- Cherry-picking work from [UIU-3426](https://folio-org.atlassian.net/browse/UIU-3426) into patch `12.1.10` so it can be included in `Sunflower R1 2025 Service Patch`.
- This includes both https://github.com/folio-org/ui-users/pull/2948 and https://github.com/folio-org/ui-users/pull/2950.