### PR TITLE
UIU-3449: Hide permissions and roles accordions on user create page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * Add support for use circulation-bff for claim-item-returned. Refs UIU-3413.
 * Pass `isCreateMode` prop to `EditCustomFieldsSection` components to ensure proper dirty and pristine form states. Refs UIU-3390.
 * Fix user search pagination and total count display beyond 1000 records. Refs UIU-3387.
+* Hide permissions and roles accordions on user create page. Refs UIU-3449.
 
 ## [12.1.8] (https://github.com/folio-org/ui-users/tree/v12.1.8) (2025-07-30)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.7...v12.1.8)

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -494,7 +494,7 @@ class UserForm extends React.Component {
                     accordionId={ACCORDION_ID.REQUESTS}
                     isCreateMode={!isEditing}
                   />
-                  {isEditing && this.showPermissionsAccordion() ?
+                  {isEditing && (this.showPermissionsAccordion() ?
                     <TenantsPermissionsAccordion
                       form={form}
                       initialValues={initialValues}
@@ -511,7 +511,7 @@ class UserForm extends React.Component {
                         accordionId={ACCORDION_ID.USER_ROLES}
                       />
                     </IfPermission>
-                  }
+                  )}
                   {isEditing && (
                     <EditServicePoints
                       accordionId={ACCORDION_ID.SERVICE_POINTS}

--- a/src/views/UserEdit/UserForm.test.js
+++ b/src/views/UserEdit/UserForm.test.js
@@ -266,6 +266,100 @@ describe('UserForm', () => {
     });
   });
 
+  describe('when creating a new user', () => {
+    const createModeInitialValues = {
+      // No id field means create mode (isEditing = false)
+      creds: {
+        password: 'password',
+      },
+      patronGroup: 'patronGroup',
+      personal: {
+        lastName: 'lastName',
+        preferredContactTypeId: 'preferredContactTypeId',
+        addresses: [
+          {
+            addressType: 'home-id',
+          },
+        ],
+      },
+      preferredServicePoint: 'preferredServicePoint',
+      servicePoints: ['a', 'b'],
+      username: 'username',
+    };
+
+    it('should not show permissions accordion in create mode', () => {
+      renderUserForm({
+        initialValues: createModeInitialValues,
+        stripes: {
+          ...STRIPES,
+          hasInterface: () => false, // roles interface is NOT present
+        },
+      });
+
+      expect(screen.queryByText('TenantsPermissionsAccordion accordion')).not.toBeInTheDocument();
+    });
+
+    it('should not show roles accordion in create mode', () => {
+      renderUserForm({
+        initialValues: createModeInitialValues,
+        stripes: {
+          ...STRIPES,
+          hasInterface: () => true, // roles interface is present
+        },
+      });
+
+      expect(screen.queryByText('EditUserRoles accordion')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when editing an existing user', () => {
+    const editModeInitialValues = {
+      id: 'existing-user-id', // ID present means edit mode (isEditing = true)
+      creds: {
+        password: 'password',
+      },
+      patronGroup: 'patronGroup',
+      personal: {
+        lastName: 'lastName',
+        preferredContactTypeId: 'preferredContactTypeId',
+        addresses: [
+          {
+            addressType: 'home-id',
+          },
+        ],
+      },
+      preferredServicePoint: 'preferredServicePoint',
+      servicePoints: ['a', 'b'],
+      username: 'username',
+    };
+
+    it('should show permissions accordion in edit mode when roles interface is NOT present', () => {
+      renderUserForm({
+        initialValues: editModeInitialValues,
+        stripes: {
+          ...STRIPES,
+          hasInterface: () => false, // roles interface is NOT present
+        },
+      });
+
+      expect(screen.queryByText('TenantsPermissionsAccordion accordion')).toBeInTheDocument();
+      expect(screen.queryByText('EditUserRoles accordion')).not.toBeInTheDocument();
+    });
+
+    it('should show roles accordion in edit mode when roles interface is present', () => {
+      renderUserForm({
+        initialValues: editModeInitialValues,
+        stripes: {
+          ...STRIPES,
+          hasInterface: () => true, // roles interface is present
+        },
+      });
+
+      expect(screen.queryByText('EditUserRoles accordion')).toBeInTheDocument();
+      expect(screen.queryByText('TenantsPermissionsAccordion accordion')).not.toBeInTheDocument();
+    });
+  });
+
   describe('when adding a new address', () => {
     beforeEach(async () => {
       renderUserForm({


### PR DESCRIPTION
## Purpose
Hide the `TenantsPermissionsAccordion` and `EditUserRoles` components from displaying on the user create page.

## Description
This PR addresses an issue where permissions and roles accordions were incorrectly displayed on the user create page, when they should only appear during user editing.

## Screencasts


https://github.com/user-attachments/assets/39b93200-667e-49cb-b034-b722a99c1c8c


## Issues
[UIU-3449](https://folio-org.atlassian.net/browse/UIU-3449)