### PR TITLE
UIU-3444: Add support for use circulation-bff for mark-as-missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Pass `isCreateMode` prop to `EditCustomFieldsSection` components to ensure proper dirty and pristine form states. Refs UIU-3390.
 * Fix user search pagination and total count display beyond 1000 records. Refs UIU-3387.
 * Hide permissions and roles accordions on user create page. Refs UIU-3449.
+* Add support for use circulation-bff for mark-as-missing.  Refs UIU-3444.
 
 ## [12.1.8] (https://github.com/folio-org/ui-users/tree/v12.1.8) (2025-07-30)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.7...v12.1.8)

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "request-storage": "2.5 3.0 4.0 5.0 6.0",
       "reading-room-patron-permission": "1.0",
       "roles": "1.0",
-      "circulation-bff-loans": "1.4",
+      "circulation-bff-loans": "1.6",
       "users-keycloak": "1.0"
     },
     "permissionSets": [
@@ -823,6 +823,7 @@
         "replaces": ["ui-users.loans.declare-claimed-returned-item-as-missing"],
         "subPermissions": [
           "circulation.loans.declare-claimed-returned-item-as-missing.post",
+          "circulation-bff.loans.declare-claimed-returned-item-as-missing.execute",
           "circulation-storage.loans.item.get",
           "inventory-storage.items.item.get",
           "inventory-storage.holdings.item.get",

--- a/src/components/ModalContent/ModalContent.js
+++ b/src/components/ModalContent/ModalContent.js
@@ -32,14 +32,17 @@ import css from './ModalContent.css';
 export const getMutatorFunction = (stripes, mutator, loanAction) => {
   const isDeclareLostAction = loanAction === loanActionMutators.DECLARE_LOST;
   const isClaimedReturnedAction = loanAction === loanActionMutators.CLAIMED_RETURNED;
+  const isMarkAsMissingAction = loanAction === loanActionMutators.MARK_AS_MISSING;
 
-  if (stripes?.config?.enableEcsRequests && (isDeclareLostAction || isClaimedReturnedAction)) {
+  if (stripes?.config?.enableEcsRequests && (isDeclareLostAction || isClaimedReturnedAction || isMarkAsMissingAction)) {
     const isCorrectCirculationBFFLoansInterface = stripes.hasInterface(CIRCULATION_BFF_LOANS_INTERFACE_NAME, CIRCULATION_BFF_LOANS_INTERFACE_VERSION);
 
     if (isCorrectCirculationBFFLoansInterface && isDeclareLostAction) {
       return mutator.declareLostBFF.POST;
     } else if (isCorrectCirculationBFFLoansInterface && isClaimedReturnedAction) {
       return mutator.claimReturnedBFF.POST;
+    } else if (isCorrectCirculationBFFLoansInterface && isMarkAsMissingAction) {
+      return mutator.markAsMissingBFF.POST;
     } else {
       throw new Error(CIRCULATION_BFF_LOANS_INTERFACE_ERROR);
     }
@@ -88,6 +91,13 @@ class ModalContent extends React.Component {
         path: 'circulation/loans/!{loan.id}/declare-claimed-returned-item-as-missing',
       },
     },
+    markAsMissingBFF: {
+      type: 'okapi',
+      fetch: false,
+      POST: {
+        path: 'circulation-bff/loans/!{loan.id}/declare-claimed-returned-item-as-missing',
+      },
+    },
     patronInfo: {
       type: 'okapi',
       fetch: false,
@@ -133,6 +143,9 @@ class ModalContent extends React.Component {
         POST: PropTypes.func.isRequired,
       }).isRequired,
       markAsMissing: PropTypes.shape({
+        POST: PropTypes.func.isRequired,
+      }).isRequired,
+      markAsMissingBFF: PropTypes.shape({
         POST: PropTypes.func.isRequired,
       }).isRequired,
       patronInfo: PropTypes.shape({

--- a/src/components/ModalContent/ModalContent.test.js
+++ b/src/components/ModalContent/ModalContent.test.js
@@ -8,6 +8,10 @@ import ModalContent, {
   getMutatorFunction,
 } from './ModalContent';
 
+import {
+  CIRCULATION_BFF_LOANS_INTERFACE_ERROR,
+} from '../../constants';
+
 jest.unmock('@folio/stripes/components');
 
 const resources = (records = {}) => {
@@ -496,6 +500,12 @@ describe('Modal Content', () => {
       claimReturned: {
         POST: 'claimReturned',
       },
+      markAsMissingBFF: {
+        POST: 'markAsMissingBFF',
+      },
+      markAsMissing: {
+        POST: 'markAsMissing',
+      },
       notDeclareLost: {
         POST: 'notDeclareLost',
       },
@@ -510,13 +520,17 @@ describe('Modal Content', () => {
       expect(getMutatorFunction(stripes, mutatorFunction, 'claimReturned')).toEqual('claimReturnedBFF');
     });
 
+    it('should return mutator POST value for markAsMissingBFF action', () => {
+      expect(getMutatorFunction(stripes, mutatorFunction, 'markAsMissing')).toEqual('markAsMissingBFF');
+    });
+
     it('should return required okapi interfaces error', () => {
       const stripesWithOutCirculationBffLoans = {
         ...stripes,
         hasInterface: () => false,
       };
 
-      expect(() => { getMutatorFunction(stripesWithOutCirculationBffLoans, mutatorFunction, loanAction); }).toThrow('Required okapi interfaces circulation-bff-loans v1.4');
+      expect(() => { getMutatorFunction(stripesWithOutCirculationBffLoans, mutatorFunction, loanAction); }).toThrow(CIRCULATION_BFF_LOANS_INTERFACE_ERROR);
     });
 
     it('should return mutator POST value for declareLost action', () => {
@@ -529,6 +543,12 @@ describe('Modal Content', () => {
       const stripesWithOutEnableEcsRequests = {};
 
       expect(getMutatorFunction(stripesWithOutEnableEcsRequests, mutatorFunction, 'claimReturned')).toEqual('claimReturned');
+    });
+
+    it('should return mutator POST value for markAsMissing action', () => {
+      const stripesWithOutEnableEcsRequests = {};
+
+      expect(getMutatorFunction(stripesWithOutEnableEcsRequests, mutatorFunction, 'markAsMissing')).toEqual('markAsMissing');
     });
 
     it('should return mutator POST value for passed action', () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -47,7 +47,7 @@ export const loanActionMutators = {
 };
 
 export const CIRCULATION_BFF_LOANS_INTERFACE_NAME = 'circulation-bff-loans';
-export const CIRCULATION_BFF_LOANS_INTERFACE_VERSION = '1.4';
+export const CIRCULATION_BFF_LOANS_INTERFACE_VERSION = '1.6';
 export const CIRCULATION_BFF_LOANS_INTERFACE_ERROR = `Required okapi interfaces ${CIRCULATION_BFF_LOANS_INTERFACE_NAME} v${CIRCULATION_BFF_LOANS_INTERFACE_VERSION}`;
 
 export const deliveryFulfillmentValues = {


### PR DESCRIPTION
## Purpose
Add support for use circulation-bff for mark-as-missing

## Refs
https://folio-org.atlassian.net/browse/UIU-3444