### PR TITLE
m-3400-3

### DIFF
--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -89,7 +89,11 @@ class EditUserInfo extends React.Component {
 
   setRecalculatedExpirationDate = (startCalcToday) => {
     const { form: { change } } = this.props;
-    const recalculatedDate = this.calculateNewExpirationDate(startCalcToday).format('L');
+    // Use .format() instead of .format('L') to preserve timezone information in the ISO string.
+    // .format('L') would produce a local date string like "08/31/2025" which loses timezone context,
+    // causing parseExpirationDate to incorrectly interpret the date and shift it by a day.
+    // .format() produces an ISO string like "2025-08-31T02:59:59+03:00" that maintains timezone info.
+    const recalculatedDate = this.calculateNewExpirationDate(startCalcToday).format();
     const parsedRecalculatedDate = this.parseExpirationDate(recalculatedDate);
 
     change('expirationDate', parsedRecalculatedDate);
@@ -374,7 +378,6 @@ class EditUserInfo extends React.Component {
                     parse={this.parseExpirationDate}
                     disabled={disabled}
                     validate={validateMinDate('ui-users.errors.personal.dateOfBirth')}
-                    timeZone="UTC"
                   />
                   {checkShowRecalculateButton() && (
                     <Button

--- a/src/components/UserDetailSections/UserInfo/UserInfo.js
+++ b/src/components/UserDetailSections/UserInfo/UserInfo.js
@@ -105,7 +105,7 @@ const UserInfo = (props) => {
             <Col xs={3}>
               <KeyValue
                 label={<FormattedMessage id="ui-users.information.expirationDate" />}
-                value={user.expirationDate ? <FormattedDate value={user.expirationDate} timeZone="UTC" /> : '-'}
+                value={user.expirationDate ? <FormattedDate value={user.expirationDate} /> : '-'}
               />
             </Col>
             <Col xs={3}>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
1. A user expires earlier for the Vancouver time zone.
2. When the "Reset" button is hit, it should add the correct number of days.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Approach
1. Remove UTC for expiration date. The UTC was added relatively recently to display the same date for all time zones, which was not correct with the original design and caused the incorrect expiration of users.
2. Use `.format()` instead of `.format('L')` to preserve timezone information in the ISO string. `.format('L')` produces a local date string like "08/31/2025" which loses timezone context, causing `parseExpirationDate` to incorrectly interpret the date and shift it by a day. `.format()` produces an ISO string like "2025-08-31T02:59:59+03:00" that maintains timezone.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Screencasts
1. For the first issue

2. For the second issue

https://github.com/user-attachments/assets/8d824a82-80eb-41ab-a515-f5b8f4dcfdba



#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
