### PR TITLE
UIU-3387: Reset total records on query and filters removal (follow-up PR).

### DIFF
--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -289,10 +289,15 @@ class UserSearchContainer extends React.Component {
     }
 
     // Only fetch actual total records if the `query` or `filters` have changed
-    if ((resources.query.query && resources.query.query !== prevProps.resources.query.query)
-      || (resources.query.filters && resources.query.filters !== prevProps.resources.query.filters)
+    if ((resources.query.query !== prevProps.resources.query.query)
+      || (resources.query.filters !== prevProps.resources.query.filters)
     ) {
-      this.fetchActualTotalRecords();
+      if (resources.query?.query || resources.query?.filters) {
+        this.fetchActualTotalRecords();
+      } else {
+        // Reset actual total records if both query and filters are empty and we previously had records
+        this.resetActualTotalRecords();
+      }
     }
 
     this.source.update(this.props);
@@ -400,7 +405,6 @@ class UserSearchContainer extends React.Component {
         querySetter={this.querySetter}
         actualTotalRecords={actualTotalRecords}
         hasLoadedActualTotalRecords={hasLoadedActualTotalRecords}
-        onResetActualTotalRecords={this.resetActualTotalRecords}
         {...this.props}
       >
         { this.props.children }

--- a/src/views/UserSearch/UserSearch.js
+++ b/src/views/UserSearch/UserSearch.js
@@ -78,7 +78,6 @@ class UserSearch extends React.Component {
     match: PropTypes.object.isRequired,
     onComponentWillUnmount: PropTypes.func,
     onNeedMoreData: PropTypes.func.isRequired,
-    onResetActualTotalRecords: PropTypes.func.isRequired,
     queryGetter: PropTypes.func,
     querySetter: PropTypes.func,
     resources: PropTypes.shape({
@@ -642,13 +641,6 @@ class UserSearch extends React.Component {
     }
   }
 
-  handleResetAll = (resetAll) => () => {
-    const { onResetActualTotalRecords } = this.props;
-
-    onResetActualTotalRecords();
-    resetAll();
-  }
-
   render() {
     const {
       onComponentWillUnmount,
@@ -809,7 +801,7 @@ class UserSearch extends React.Component {
                               id="clickable-reset-all"
                               disabled={!(filterChanged || searchChanged)}
                               fullWidth
-                              onClick={this.handleResetAll(resetAll)}
+                              onClick={resetAll}
                             >
                               <Icon icon="times-circle-solid">
                                 <FormattedMessage id="stripes-smart-components.resetAll" />


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
1. Remove the total records display in the results list when the query and filters are empty.
2. Fetch actual total records when there is a query and selected filter, and then a user unselects the filter.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Issues
[UIU-3387](https://folio-org.atlassian.net/browse/UIU-3387)

## Approach
1. Call the `this.resetActualTotalRecords();` in the `componentDidUpdate` when `query` or `filters` have changed and they are both empty.
2. Remove the `resources.query.query` and `resources.query.filters` from `componentDidUpdate`.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Screencasts

https://github.com/user-attachments/assets/1da82d05-0fcb-4687-a74e-6cc538a67dab




#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
