### PR TITLE
[UIU-3465] Added null check to allow roles to be selected for user when list is emptied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Add permission for circulation-storage.request-preferences.collection.get to ui-users.view to display request preferences. Refs UIU-3445.
 * Avoid indirection through null item when loaned item is deleted. Fixes UIU-3457.
 * In the list of a user's open loans, the "Use at location" includes service-point and (when relevant) exipiry date. Fixes UIU-3418.
+* Added null check to allow roles to be selected for user when list is emptied. Fixes UIU-3465.
 
 ## [12.1.11] (https://github.com/folio-org/ui-users/tree/v12.1.11) (2025-08-27)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.10...v12.1.11)

--- a/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.js
+++ b/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.js
@@ -49,7 +49,7 @@ export default function UserRolesModal({ isOpen,
     if (assignedRoleIds[tenantId]?.includes(id)) {
       setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: assignedRoleIds[tenantId].filter(role => role !== id) });
     } else {
-      setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: assignedRoleIds[tenantId].concat(id) });
+      setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: assignedRoleIds[tenantId] ? assignedRoleIds[tenantId].concat(id) : [id] });
     }
   };
 


### PR DESCRIPTION
- Fixes [UIU-3465](https://folio-org.atlassian.net/browse/UIU-3465)
- Previously, if all user roles were deselected on User Edit screen, when trying to add new roles, the collection would be null and cause an exception. The code change adds a null check and initiates a new collection in this case.