### PR TITLE
UIU-3400: Remove UTC timezone from expiration date formatting in `UserInfo` and `EditUserInfo` components so that expiration is correct. Use `.format()` instead of `.format('L')` in `recalculatedDate` to preserve timezone information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Avoid indirection through null item when loaned item is deleted. Fixes UIU-3457.
 * In the list of a user's open loans, the "Use at location" includes service-point and (when relevant) exipiry date. Fixes UIU-3418.
 * Added null check to allow roles to be selected for user when list is emptied. Fixes UIU-3465.
+* Remove UTC timezone from expiration date formatting in `UserInfo` and `EditUserInfo` components so that expiration is correct. Use `.format()` instead of `.format('L')` in `recalculatedDate` to preserve timezone information. Fixes UIU-3400.
 
 ## [12.1.12] (https://github.com/folio-org/ui-users/tree/v12.1.12) (2025-09-12)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.11...v12.1.12)

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -89,7 +89,7 @@ class EditUserInfo extends React.Component {
 
   setRecalculatedExpirationDate = (startCalcToday) => {
     const { form: { change } } = this.props;
-    const recalculatedDate = this.calculateNewExpirationDate(startCalcToday).format('L');
+    const recalculatedDate = this.calculateNewExpirationDate(startCalcToday).format();
     const parsedRecalculatedDate = this.parseExpirationDate(recalculatedDate);
 
     change('expirationDate', parsedRecalculatedDate);
@@ -374,7 +374,6 @@ class EditUserInfo extends React.Component {
                     parse={this.parseExpirationDate}
                     disabled={disabled}
                     validate={validateMinDate('ui-users.errors.personal.dateOfBirth')}
-                    timeZone="UTC"
                   />
                   {checkShowRecalculateButton() && (
                     <Button

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -1,5 +1,4 @@
 import get from 'lodash/get';
-import moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Field } from 'react-final-form';
@@ -127,7 +126,7 @@ class EditUserInfo extends React.Component {
     } = this.props;
 
     return expirationDate
-      ? moment.tz(expirationDate, timezone).endOf('day').toDate().toISOString()
+      ? dayjs.tz(expirationDate, timezone).endOf('day').toISOString()
       : expirationDate;
   };
 

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
@@ -73,6 +73,22 @@ jest.mock('./components', () => ({
 
 const onSubmit = jest.fn();
 
+const getDayjsMock = (date) => {
+  const dayjsObj = jest.requireActual('@folio/stripes/components').dayjs(date);
+
+  return {
+    ...dayjsObj,
+    format: jest.fn().mockReturnValue('05/04/2027'),
+    add: jest.fn().mockReturnThis(),
+    tz: jest.fn().mockReturnThis(),
+    endOf: jest.fn().mockReturnThis(),
+    toISOString: jest.fn().mockReturnValue('2027-05-04T03:59:59.999Z'),
+    isSameOrBefore: jest.fn().mockReturnValue(false),
+    isBefore: jest.fn().mockReturnValue(true),
+    isAfter: jest.fn().mockReturnValue(true),
+  };
+};
+
 const arrayMutators = {
   concat: jest.fn(),
   move: jest.fn(),
@@ -169,17 +185,11 @@ const props = {
 
 describe('Render Edit User Information component', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     isConsortiumEnabled.mockClear().mockReturnValue(false);
 
-    dayjs.mockImplementation((date) => {
-      const dayjsObj = jest.requireActual('@folio/stripes/components').dayjs(date);
-
-      return {
-        ...dayjsObj,
-        format: jest.fn().mockReturnValue('05/04/2027'),
-        add: jest.fn().mockReturnThis(),
-      };
-    });
+    dayjs.mockImplementation(getDayjsMock);
+    dayjs.tz = jest.fn(getDayjsMock);
   });
 
   it('Must be rendered', () => {
@@ -194,21 +204,11 @@ describe('Render Edit User Information component', () => {
 
   describe('when "Reset" (recalculate) button is clicked', () => {
     it('should change expiration date', async () => {
-      dayjs.mockImplementation((date) => {
-        const dayjsObj = jest.requireActual('@folio/stripes/components').dayjs(date);
-
-        return {
-          ...dayjsObj,
-          format: jest.fn().mockReturnValue('06/05/2025'),
-          add: jest.fn().mockReturnThis(),
-        };
-      });
-
       renderEditUserInfo(props);
 
       await act(() => userEvent.click(screen.getByText('ui-users.information.recalculate.expirationDate')));
 
-      expect(changeMock).toHaveBeenCalledWith('expirationDate', '2025-06-05T03:59:59.999Z');
+      expect(changeMock).toHaveBeenCalledWith('expirationDate', '2027-05-04T03:59:59.999Z');
     });
   });
 

--- a/src/components/UserDetailSections/UserInfo/UserInfo.js
+++ b/src/components/UserDetailSections/UserInfo/UserInfo.js
@@ -105,7 +105,14 @@ const UserInfo = (props) => {
             <Col xs={3}>
               <KeyValue
                 label={<FormattedMessage id="ui-users.information.expirationDate" />}
-                value={user.expirationDate ? <FormattedDate value={user.expirationDate} /> : '-'}
+                value={user.expirationDate
+                  ? (
+                    <FormattedDate
+                      value={user.expirationDate}
+                      data-testid="formatted-date-expirationDate"
+                    />
+                  )
+                  : <NoValue />}
               />
             </Col>
             <Col xs={3}>

--- a/src/components/UserDetailSections/UserInfo/UserInfo.js
+++ b/src/components/UserDetailSections/UserInfo/UserInfo.js
@@ -105,7 +105,7 @@ const UserInfo = (props) => {
             <Col xs={3}>
               <KeyValue
                 label={<FormattedMessage id="ui-users.information.expirationDate" />}
-                value={user.expirationDate ? <FormattedDate value={user.expirationDate} timeZone="UTC" /> : '-'}
+                value={user.expirationDate ? <FormattedDate value={user.expirationDate} /> : '-'}
               />
             </Col>
             <Col xs={3}>

--- a/src/components/UserDetailSections/UserInfo/UserInfo.test.js
+++ b/src/components/UserDetailSections/UserInfo/UserInfo.test.js
@@ -31,6 +31,7 @@ const props = {
     updatedDate: '2022-05-10T02:00:49.576+00:00',
     username: 'acq-admin'
   },
+  customFields: [],
   settings: [{ enabled: true }]
 };
 
@@ -70,5 +71,23 @@ describe('Render userInfo component', () => {
   it('should display ViewCustomFieldsRecord', () => {
     renderUserInfo(props);
     expect(screen.getByText('ViewCustomFieldsRecord')).toBeInTheDocument();
+  });
+
+  it('should not include UTC or any other timezone in FormattedDate for expiration date', () => {
+    const propsWithExpirationDate = {
+      ...props,
+      user: {
+        ...props.user,
+        expirationDate: '2023-12-31T23:59:59.000Z'
+      }
+    };
+
+    renderUserInfo(propsWithExpirationDate);
+
+    const formattedDateElement = screen.getByTestId('formatted-date-expirationDate');
+    expect(formattedDateElement).toBeInTheDocument();
+
+    expect(formattedDateElement).not.toHaveAttribute('data-timezone', 'UTC');
+    expect(formattedDateElement).not.toHaveAttribute('data-timezone');
   });
 });

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -62,12 +62,19 @@ jest.mock('@folio/stripes/components', () => ({
 
     return value;
   }),
-  FormattedDate: jest.fn(({ value, children }) => {
+  FormattedDate: jest.fn(({ value, children, timeZone, 'data-testid': dataTestId }) => {
     if (children) {
       return children([value]);
     }
 
-    return value;
+    return (
+      <span
+        data-timezone={timeZone}
+        data-testid={dataTestId}
+      >
+        {value}
+      </span>
+    );
   }),
   HasCommand: jest.fn(({ children }) => (
     <span>{children}</span>


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
1. A user expires earlier for the Vancouver time zone. 
3. When the "Reset" button is hit, it should add the correct number of days.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Description
1. This happens because the expiration date is saved in UTC, not in the current tenant's time zone, but the expiration is checked in the tenant's time zone in both FE and BE (`active` flag), so the expiration date is being saved one day earlier. 
For instance, if we want to set one day for the expiration day (to the end of the day), and if the current date is 2025-09-17 and the time zone is Vancouver (UTC-7), the current implementation saves 2025-09-**18**T06:59:59.999Z, 18th is incorrect, because 17th + 1 day + end of the day + 7 hours = 19th (2025-09-19T06:59:59.999Z).
This year the `timeZone="UTC"` was added to fix a bug [UIU-3352](https://folio-org.atlassian.net/browse/UIU-3352) that sayes that date should be displayed the same for all time zones, but this is not a bug, the date can be different in different time zones because of the original design, which is to have the same instance in time (expiration occurs at the exact same moment globally, users in different time zones see different local dates/times, end-of-day expiration applies only to the time zone where it was set, prevents a user with an expired account from regaining access by switching time zones). 
([more info](https://folio-org.atlassian.net/browse/UIU-3400?focusedCommentId=272695))


## Approach
1. Remove UTC for expiration date. The UTC was added relatively recently to display the same date for all time zones, which was _not_ correct with the original design and caused the incorrect expiration of users.
4. Use `.format()` instead of `.format('L')` to preserve timezone information in the ISO string. `.format('L')` produces a local date string like "08/31/2025" which loses timezone context, causing `parseExpirationDate` to incorrectly interpret the date and shift it by a day. `.format()` produces an ISO string like `2025-08-31T02:59:59+03:00` that maintains timezone.
5. Migrate from `moment` to `dayjs` (it doesn't fix anything, it's only done so that QA will check the ticket with dayjs)
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Screencasts
1. For the first issue


https://github.com/user-attachments/assets/3b4961ea-1a0c-4029-805a-fbd3757b463f




3. For the second issue

https://github.com/user-attachments/assets/8d824a82-80eb-41ab-a515-f5b8f4dcfdba



#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
