### PR TITLE
UIU-3400: Use `dayjs(expirationDate).tz(timezone)` instead of `dayjs.tz(expirationDate, timezone)` to properly handle timezone conversion. (follow-up).

### DIFF
--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -102,13 +102,18 @@ class EditUserInfo extends React.Component {
   }
 
   calculateNewExpirationDate = (startCalcToday) => {
-    const { initialValues } = this.props;
-    const now = Date.now();
-    const expirationDate = initialValues.expirationDate ? new Date(initialValues.expirationDate) : now;
+    const { 
+      initialValues,
+      stripes: { 
+        timezone,
+      },
+    } = this.props;
+    const now = dayjs().tz(timezone);
+    const expirationDate = initialValues.expirationDate ? dayjs(initialValues.expirationDate).tz(timezone) : now;
     const offsetOfSelectedPatronGroup = this.state.selectedPatronGroup ? this.getPatronGroupOffset() : '';
 
-    const shouldRecalculateFromToday = startCalcToday || initialValues.expirationDate === undefined || expirationDate <= now;
-    const baseDate = shouldRecalculateFromToday ? dayjs() : dayjs(expirationDate);
+    const shouldRecalculateFromToday = startCalcToday || initialValues.expirationDate === undefined || expirationDate.isSameOrBefore(now);
+    const baseDate = shouldRecalculateFromToday ? now : expirationDate;
 
     return baseDate.add(offsetOfSelectedPatronGroup, 'd');
   }
@@ -126,7 +131,7 @@ class EditUserInfo extends React.Component {
     } = this.props;
 
     return expirationDate
-      ? dayjs.tz(expirationDate, timezone).endOf('day').toISOString()
+      ? dayjs(expirationDate).tz(timezone).endOf('day').toISOString()
       : expirationDate;
   };
 

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -102,18 +102,13 @@ class EditUserInfo extends React.Component {
   }
 
   calculateNewExpirationDate = (startCalcToday) => {
-    const { 
-      initialValues,
-      stripes: { 
-        timezone,
-      },
-    } = this.props;
-    const now = dayjs().tz(timezone);
-    const expirationDate = initialValues.expirationDate ? dayjs(initialValues.expirationDate).tz(timezone) : now;
+    const { initialValues } = this.props;
+    const now = Date.now();
+    const expirationDate = initialValues.expirationDate ? new Date(initialValues.expirationDate) : now;
     const offsetOfSelectedPatronGroup = this.state.selectedPatronGroup ? this.getPatronGroupOffset() : '';
 
-    const shouldRecalculateFromToday = startCalcToday || initialValues.expirationDate === undefined || expirationDate.isSameOrBefore(now);
-    const baseDate = shouldRecalculateFromToday ? now : expirationDate;
+    const shouldRecalculateFromToday = startCalcToday || initialValues.expirationDate === undefined || expirationDate <= now;
+    const baseDate = shouldRecalculateFromToday ? dayjs() : dayjs(expirationDate);
 
     return baseDate.add(offsetOfSelectedPatronGroup, 'd');
   }

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
@@ -347,4 +347,34 @@ describe('Render Edit User Information component', () => {
       expect(screen.queryByText('Profile Picture')).not.toBeInTheDocument();
     });
   });
+
+  describe('parseExpirationDate function', () => {
+    it('should use dayjs(expirationDate).tz(timezone) instead of dayjs.tz(expirationDate, timezone)', async () => {
+      const mockTz = jest.fn().mockReturnThis();
+      const mockEndOf = jest.fn().mockReturnThis();
+      const mockToISOString = jest.fn().mockReturnValue('2027-05-04T03:59:59.999Z');
+
+      const mockDayjsInstance = {
+        tz: mockTz,
+        endOf: mockEndOf,
+        toISOString: mockToISOString,
+        format: jest.fn().mockReturnValue('05/04/2027'),
+        add: jest.fn().mockReturnThis(),
+        isSameOrBefore: jest.fn().mockReturnValue(false),
+        isBefore: jest.fn().mockReturnValue(true),
+        isAfter: jest.fn().mockReturnValue(true),
+      };
+
+      dayjs.mockImplementation(() => mockDayjsInstance);
+
+      renderEditUserInfo(props);
+
+      await act(() => userEvent.click(screen.getByText('ui-users.information.recalculate.expirationDate')));
+
+      expect(dayjs).toHaveBeenCalled();
+      expect(mockTz).toHaveBeenCalledWith('America/New_York');
+      expect(mockEndOf).toHaveBeenCalledWith('day');
+      expect(mockToISOString).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
Use the Pacific/Honolulu and UTC time zones, and make sure Honolulu is one day behind the UTC time zone.
When adding 365 days to the expiration date by clicking the "Reset" button, the only _year_ should be changed: 09/**18**/202**8**  -> 09/**18**/202**9**.
If the year is a leap year, the _day_ should be decreased by 1 and the _year_ should be increased by 1: 09/**18**/202**7** -> 09/**17**/202**8**

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Description
The difference between `dayjs.tz(expirationDate, timezone).endOf('day').toISOString()` and `dayjs(expirationDate).tz(timezone).endOf('day').toISOString()` is how dayjs handles timezone conversions.

**dayjs.tz(expirationDate, timezone)** - Parse in timezone
* This parses the date string as if it were already in the specified timezone
* If expirationDate is `2028-09-18T09:59:59.999Z` (UTC), this treats it as if it were `2028-09-18T09:59:59.999` in Pacific/Honolulu time
* This effectively ignores the UTC timezone indicator and reinterprets the date/time values in the target timezone

**dayjs(expirationDate).tz(timezone)** - Convert to timezone
* This first parses the date string correctly (respecting the UTC timezone)
* Then converts that moment in time to the specified timezone
* This preserves the actual moment in time but displays it in the target timezone

**Example:**
Input: `2028-09-18T09:59:59.999Z` (September 18, 2028 at 09:59:59 UTC)

**Method 1**: `dayjs.tz(expirationDate, "Pacific/Honolulu")`
* Treats this as September 18, 2028 at 09:59:59 in Pacific/Honolulu time
* When we call `.endOf('day')`, it becomes September 18, 2028 at 23:59:59 in Pacific/Honolulu
* Converting back to UTC: September 19, 2028 at 09:59:59 UTC

**Method 2**: `dayjs(expirationDate).tz("Pacific/Honolulu")`
* Correctly parses as September 18, 2028 at 09:59:59 UTC
* Converts to Pacific/Honolulu: September 17, 2028 at 23:59:59 (because Pacific/Honolulu is UTC-10)
* When we call `.endOf('day')`, it becomes September 17, 2028 at 23:59:59 in Pacific/Honolulu
* Converting back to UTC: September 18, 2028 at 09:59:59 UTC

The key insight is that UI is displaying the date as it appears in the user's timezone. When the stored UTC date is 2028-09-18T09:59:59.999Z, it represents:
* September 18 in UTC
* September 17 in Pacific/Honolulu (UTC-10)

## Approach
Use `dayjs(expirationDate).tz(timezone).endOf('day').toISOString()` instead of `dayjs.tz(expirationDate, timezone).endOf('day').toISOString()`.


## Issues
https://folio-org.atlassian.net/browse/UIU-3400

## Screencasts

https://github.com/user-attachments/assets/4e892312-1361-4ca4-9035-0bfd3bf6f2b4




