### PR TITLE
[UIU-3420] use-at-location action translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * In the list of a user's open loans, the "Use at location" includes service-point and (when relevant) exipiry date. Fixes UIU-3418.
 * Added null check to allow roles to be selected for user when list is emptied. Fixes UIU-3465.
 * Remove UTC timezone from expiration date formatting in `UserInfo` and `EditUserInfo` components so that expiration is correct. Use `.format()` instead of `.format('L')` in `recalculatedDate` to preserve timezone information. Fixes UIU-3400.
+* Add translations for use-at-location actions for history list in loan detail pages. Fixes UIU-3420.
 
 ## [12.1.13] (https://github.com/folio-org/ui-users/tree/v12.1.13) (2025-09-16)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.12...v12.1.13)

--- a/src/components/data/static/loanActionMap.js
+++ b/src/components/data/static/loanActionMap.js
@@ -19,4 +19,6 @@ export default {
   'staffInfoAdded': 'ui-users.data.loanActionMap.staffInfo',
   'unknownAction': 'ui-users.data.loanActionMap.unknownAction',
   'reminderFee': 'ui-users.data.loanActionMap.reminderFee',
+  'heldForUseAtLocation': 'ui-users.data.loanActionMap.heldForUseAtLocation',
+  'pickedUpForUseAtLocation': 'ui-users.data.loanActionMap.pickedUpForUseAtLocation',
 };

--- a/src/components/data/static/loanActionMap.test.js
+++ b/src/components/data/static/loanActionMap.test.js
@@ -2,7 +2,7 @@ import loanActionMap from './loanActionMap';
 
 describe('loan action map', () => {
   test('checking the number of types', () => {
-    expect(Object.keys(loanActionMap).length).toEqual(20);
+    expect(Object.keys(loanActionMap).length).toEqual(22);
   });
   test('checking the type with values', () => {
     expect(Object.values(loanActionMap)[0]).toBe('ui-users.data.loanActionMap.checkedOut');

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -62,6 +62,8 @@
   "data.loanActionMap.staffInfo.superseded": "Staff info (SUPERSEDED)",
   "data.loanActionMap.unknownAction": "Unknown action",
   "data.loanActionMap.reminderFee": "Reminder fee",
+  "data.loanActionMap.heldForUseAtLocation": "Held for use at location",
+  "data.loanActionMap.pickedUpForUseAtLocation": "Picked up for use at location",
   "user.unknown": "Unknown user",
   "action": "Action",
   "actionMenu.lostItems": "Lost items requiring actual cost",


### PR DESCRIPTION
Add translations for use-at-location actions (Held for use at location, Picked up for use at location), which appear in the history of actions in the detail page for one of a user's loans.