### PR TITLE
m-3545

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 13.0.0 IN PROGRESS
 * Collect coverage from unit tests. Refs UIU-3356.
+* Fix HTTP 414 error when multi-selecting more than 80 patron groups – split CQL query into chunks and use chunked okapiKy requests for both record fetching and total count. Refs UIU-3545.
 * Modify translation string for search view: "User search -> Search & filter". Refs UIU-3231.
 * *BREAKING* Use number generator for barcode. Refs UIU-2729.
 * Change amount input type to number. Refs UIU-2836.

--- a/src/constants.js
+++ b/src/constants.js
@@ -72,6 +72,7 @@ export const statusFilter = [
  with hardcoded ids for now. */
 export const feeFineBalanceId = 'cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a';
 export const MAX_RECORDS = '10000';
+export const PATRON_GROUP_CHUNK_SIZE = 50;
 
 export const refundClaimReturned = {
   PAYMENT_STATUS: 'Suspended claim returned',

--- a/src/routes/UserSearchContainer.js
+++ b/src/routes/UserSearchContainer.js
@@ -18,12 +18,21 @@ import {
 } from '@folio/stripes/smart-components';
 
 import { UserSearch } from '../views';
-import { MAX_RECORDS } from '../constants';
+import { MAX_RECORDS, PATRON_GROUP_CHUNK_SIZE, USERS_API } from '../constants';
 import filterConfig from './filterConfig';
-import { buildFilterConfig } from './utils';
+import { buildFilterConfig, extractPatronGroupIds, stripPatronGroupFilters } from './utils';
 
-const INITIAL_RESULT_COUNT = 30;
-const RESULT_COUNT_INCREMENT = 30;
+const INITIAL_RESULT_COUNT = 100;
+const RESULT_COUNT_INCREMENT = 100;
+
+// Split a CQL query string at the last ' sortby ' keyword so we can wrap
+// the main part in parentheses before appending a patron-group clause.
+const splitCqlSort = (cql) => {
+  if (!cql) return { query: '', sortClause: '' };
+  const idx = cql.lastIndexOf(' sortby ');
+  if (idx === -1) return { query: cql, sortClause: '' };
+  return { query: cql.slice(0, idx), sortClause: cql.slice(idx) };
+};
 
 const searchFields = [
   'username="%{query}*"',
@@ -106,8 +115,15 @@ class UserSearchContainer extends React.Component {
       records: 'users',
       resultOffset: '%{resultOffset}',
       resultDensity: 'sparse',
-      perRequest: 100,
+      perRequest: RESULT_COUNT_INCREMENT,
       path: 'users',
+      // Disable the manifest fetch when too many patron groups are selected –
+      // the resulting CQL query would exceed URL length limits (HTTP 414).
+      // In that situation UserSearchContainer uses chunked okapiKy requests instead.
+      fetch: props => {
+        const filters = props.resources?.query?.filters || '';
+        return extractPatronGroupIds(filters).length <= PATRON_GROUP_CHUNK_SIZE;
+      },
       GET: {
         params: {
           query: buildQuery,
@@ -255,6 +271,9 @@ class UserSearchContainer extends React.Component {
   state = {
     actualTotalRecords: 0,
     hasLoadedActualTotalRecords: false,
+    // State for chunked-mode fetching (active when patron group count > PATRON_GROUP_CHUNK_SIZE)
+    chunkedUsers: [],
+    isChunkedFetching: false,
   }
 
   componentDidMount() {
@@ -269,6 +288,13 @@ class UserSearchContainer extends React.Component {
 
     if (resources.query?.query || resources.query?.filters) {
       this.fetchActualTotalRecords();
+    }
+
+    // Trigger initial chunked fetch when the page is loaded with 50+ patron groups
+    // already present in the URL (e.g. restored from a bookmark).
+    const patronGroupIds = extractPatronGroupIds(resources.query?.filters);
+    if (patronGroupIds.length > PATRON_GROUP_CHUNK_SIZE) {
+      this.fetchChunkedUsers();
     }
   }
 
@@ -288,16 +314,34 @@ class UserSearchContainer extends React.Component {
       }
     }
 
+    const queryChanged = resources.query.query !== prevProps.resources.query.query;
+    const filtersChanged = resources.query.filters !== prevProps.resources.query.filters;
+    const sortChanged = resources.query.sort !== prevProps.resources.query.sort;
+
+    const patronGroupIds = extractPatronGroupIds(resources.query?.filters);
+    const prevPatronGroupIds = extractPatronGroupIds(prevProps.resources.query?.filters);
+    const isChunkedMode = patronGroupIds.length > PATRON_GROUP_CHUNK_SIZE;
+    const wasChunkedMode = prevPatronGroupIds.length > PATRON_GROUP_CHUNK_SIZE;
+
     // Only fetch actual total records if the `query` or `filters` have changed
-    if ((resources.query.query !== prevProps.resources.query.query)
-      || (resources.query.filters !== prevProps.resources.query.filters)
-    ) {
+    if (queryChanged || filtersChanged || sortChanged) {
       if (resources.query?.query || resources.query?.filters) {
         this.fetchActualTotalRecords();
       } else {
         // Reset actual total records if both query and filters are empty and we previously had records
         this.resetActualTotalRecords();
       }
+    }
+
+    if (isChunkedMode) {
+      if (!wasChunkedMode || queryChanged || filtersChanged || sortChanged) {
+        // Entering chunked mode for the first time, or filters/query changed while in chunked mode
+        this.fetchChunkedUsers();
+      }
+    } else if (wasChunkedMode) {
+      // Leaving chunked mode – clear chunked state so normal manifest data takes over
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ chunkedUsers: [], isChunkedFetching: false });
     }
 
     this.source.update(this.props);
@@ -311,19 +355,33 @@ class UserSearchContainer extends React.Component {
   }
 
   fetchActualTotalRecords = async () => {
+    const { resources } = this.props;
+    const queryParams = { ...resources.query };
+    const patronGroupIds = extractPatronGroupIds(queryParams.filters);
+
+    if (patronGroupIds.length > PATRON_GROUP_CHUNK_SIZE) {
+      await this.fetchChunkedTotalRecords(patronGroupIds, queryParams);
+    } else {
+      await this.fetchSingleTotalRecords(queryParams);
+    }
+  }
+
+  fetchSingleTotalRecords = async (queryParams) => {
     const {
       okapiKy,
       resources,
     } = this.props;
-
-    const queryParams = { ...resources.query };
     const searchQuery = buildQuery(queryParams, {}, resources, this.logger, this.props);
 
     if (!searchQuery) return;
 
     try {
-      const response = await okapiKy(`users?limit=0&query=${searchQuery}`);
-      const data = await response.json();
+      const data = await okapiKy(USERS_API, {
+        searchParams: {
+          limit: 0,
+          query: searchQuery,
+        },
+      }).json();
 
       this.setState({
         actualTotalRecords: data.totalRecords,
@@ -333,6 +391,101 @@ class UserSearchContainer extends React.Component {
       // eslint-disable-next-line no-console
       console.error('Error fetching actual total records:', error);
     }
+  }
+
+  /**
+   * Build one CQL query string per chunk of patron group IDs.
+   * The sortby clause from the base query is stripped and re-appended after the
+   * combined (baseQuery) AND (pg chunk) expression so the CQL remains valid.
+   */
+  buildChunkedQueries = (patronGroupIds, queryParams) => {
+    const { resources } = this.props;
+    const filtersWithoutPG = stripPatronGroupFilters(queryParams.filters);
+    const baseQueryParams = { ...queryParams, filters: filtersWithoutPG };
+    const baseResourceData = { ...resources, query: { ...resources.query, filters: filtersWithoutPG } };
+
+    const fullBaseQuery = buildQuery(baseQueryParams, {}, baseResourceData, this.logger, this.props);
+    const query = buildQuery(queryParams, {}, resources, this.logger, this.props);
+    // Use original query (with patron group filters) to extract the sort clause,
+    // and the base query (without patron group filters) to extract the main query part,
+    // so that we can combine the main query with each chunk of patron group filters without losing the sort clause.
+    // Sort clause is empty if fullBaseQuery is empty, that's why we use the original query to extract it.
+    // fullBaseQuery can be empty when there no query and no filters (we strip patron group filters from the query,
+    // so if the only filters are patron groups, the resulting sort clause will be empty).
+    const { sortClause } = splitCqlSort(query);
+    const { query: baseQuery } = splitCqlSort(fullBaseQuery);
+
+    const queries = [];
+    for (let i = 0; i < patronGroupIds.length; i += PATRON_GROUP_CHUNK_SIZE) {
+      const chunk = patronGroupIds.slice(i, i + PATRON_GROUP_CHUNK_SIZE);
+      const pgCql = chunk.map(id => `patronGroup=="${id}"`).join(' OR ');
+      queries.push([baseQuery, `(${pgCql})`].filter(Boolean).join(' AND ') + sortClause);
+    }
+    return queries;
+  }
+
+  fetchChunkedTotalRecords = async (patronGroupIds, queryParams) => {
+    const { okapiKy } = this.props;
+    const queries = this.buildChunkedQueries(patronGroupIds, queryParams);
+
+    try {
+      const results = await Promise.all(
+        queries.map(q => okapiKy(USERS_API, { searchParams: { limit: 0, query: q } }).json())
+      );
+      const totalRecords = results.reduce((sum, r) => sum + (r.totalRecords ?? 0), 0);
+      this.setState({ actualTotalRecords: totalRecords, hasLoadedActualTotalRecords: true });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error fetching chunked total records:', error);
+    }
+  }
+
+  /**
+   * Fetch users across all patron-group chunks and merge results.
+   * Each chunk is fetched with the same limit and offset so that PREV/NEXT paging
+   * works correctly within each chunk. Results are concatenated and stored as a
+   * sparse array so MCL can detect page boundaries.
+   * Note: because chunks are fetched independently, global sort order across chunk
+   * boundaries is not guaranteed – each chunk returns server-sorted results.
+   */
+  fetchChunkedUsers = async (pageAmount = RESULT_COUNT_INCREMENT, pageIndex = 0) => {
+    const {
+      okapiKy,
+      resources,
+    } = this.props;
+
+    const queryParams = { ...resources.query };
+    const patronGroupIds = extractPatronGroupIds(queryParams.filters);
+    const queries = this.buildChunkedQueries(patronGroupIds, queryParams);
+
+    this.setState({ isChunkedFetching: true });
+
+    try {
+      const results = await Promise.all(
+        queries.map(q => okapiKy(USERS_API, {
+          searchParams: { limit: pageAmount, offset: pageIndex, query: q },
+        }).json())
+      );
+
+      const allUsers = results.flatMap(r => r.users ?? []);
+
+      this.setState({
+        // Prepend empty slots matching the offset so that MultiColumnList can
+        // determine when the end of the list is reached and disable Next correctly.
+        // This sets `isSparse` to true in MultiColumnList.
+        chunkedUsers: new Array(pageIndex).concat(allUsers.slice(0, pageAmount)),
+        isChunkedFetching: false,
+      });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error fetching chunked users:', error);
+      this.setState({ isChunkedFetching: false });
+    }
+  }
+
+  onNeedMoreDataChunked = (askAmount = RESULT_COUNT_INCREMENT, index = 0) => {
+    this.fetchActualTotalRecords();
+    this.fetchChunkedUsers(askAmount, index);
   }
 
   onNeedMoreData = (askAmount, index) => {
@@ -390,11 +543,46 @@ class UserSearchContainer extends React.Component {
     const {
       actualTotalRecords,
       hasLoadedActualTotalRecords,
+      chunkedUsers,
+      isChunkedFetching,
     } = this.state;
 
     if (this.source) {
       this.source.update(this.props);
     }
+
+    const patronGroupIds = extractPatronGroupIds(this.props.resources.query?.filters);
+    const isChunkedMode = patronGroupIds.length > PATRON_GROUP_CHUNK_SIZE;
+
+    // When chunked mode is active, supply a minimal source-adapter so that
+    // components that query source.totalCount() / source.pending() keep working.
+    const chunkedSource = isChunkedMode ? {
+      totalCount: () => actualTotalRecords,
+      pending: () => isChunkedFetching,
+      loaded: () => !isChunkedFetching,
+      records: () => chunkedUsers,
+      fetchMore: this.onNeedMoreDataChunked,
+      fetchOffset: this.onNeedMoreDataChunked,
+      failure: () => false,
+      failureMessage: () => null,
+    } : null;
+
+    // Override resources.records so UserSearch reads chunked data instead of the
+    // (disabled) manifest resource.
+    const chunkedResourcesOverride = isChunkedMode ? {
+      ...this.props.resources,
+      records: {
+        records: chunkedUsers,
+        isPending: isChunkedFetching,
+        hasLoaded: !isChunkedFetching,
+      },
+    } : null;
+
+    const chunkProps = isChunkedMode ? {
+      source: chunkedSource,
+      resources: chunkedResourcesOverride,
+      onNeedMoreData: this.onNeedMoreDataChunked,
+    } : {};
 
     return (
       <UserSearch
@@ -406,6 +594,7 @@ class UserSearchContainer extends React.Component {
         actualTotalRecords={actualTotalRecords}
         hasLoadedActualTotalRecords={hasLoadedActualTotalRecords}
         {...this.props}
+        {...chunkProps}
       >
         { this.props.children }
       </UserSearch>

--- a/src/routes/UserSearchContainer.test.js
+++ b/src/routes/UserSearchContainer.test.js
@@ -27,6 +27,13 @@ const mockOkapiKy = jest.fn().mockReturnValue({
   }),
 });
 
+const mockOkapiKyChunked = jest.fn().mockReturnValue({
+  json: jest.fn().mockResolvedValue({
+    users: [{ id: 'u1' }, { id: 'u2' }],
+    totalRecords: 10,
+  }),
+});
+
 const location = {
   pathname: '/users',
   search: '?sort=name',
@@ -112,6 +119,8 @@ const getUserSearchContainer = (_props = {}) => {
 
 const renderUserSearchContainer = (_props = {}) => render(getUserSearchContainer(_props));
 
+const makePatronGroupFilters = (count) => Array.from({ length: count }, (_, i) => `pg.pg-uuid-${i}`).join(',');
+
 describe('UserSearchContainer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -130,9 +139,15 @@ describe('UserSearchContainer', () => {
     }));
 
     expect(mockOkapiKy).toHaveBeenCalledTimes(1);
-    expect(mockOkapiKy).toHaveBeenCalledWith(expect.stringContaining(
-      'users?limit=0&query=((keywords="test*") and active=="true")'
-    ));
+    expect(mockOkapiKy).toHaveBeenCalledWith(
+      'users',
+      {
+        searchParams: {
+          limit: 0,
+          query: expect.stringContaining('((keywords="test*") and active=="true")'),
+        },
+      }
+    );
   });
 
   describe('when query and filters are not present', () => {
@@ -372,8 +387,176 @@ describe('UserSearchContainer', () => {
         },
       })));
 
-      expect(mockOkapiKy).toHaveBeenCalledWith(expect.stringContaining('users?limit=0&query=(keywords="foo*")'));
+      expect(mockOkapiKy).toHaveBeenCalledWith(
+        'users',
+        {
+          searchParams: {
+            limit: 0,
+            query: expect.stringContaining('(keywords="foo*")'),
+          },
+        }
+      );
       expect(getByText('1,200 records found')).toBeInTheDocument();
+    });
+  });
+
+  describe('chunked patron-group mode', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call okapiKy with chunked query params on mount with 51+ patron groups', async () => {
+      await act(async () => {
+        renderUserSearchContainer({
+          okapiKy: mockOkapiKyChunked,
+          resources: {
+            ...resources,
+            query: {
+              query: 'test',
+              filters: makePatronGroupFilters(51),
+              sort: 'name',
+            },
+          },
+        });
+      });
+
+      expect(mockOkapiKyChunked).toHaveBeenCalledWith(
+        'users',
+        expect.objectContaining({
+          searchParams: expect.objectContaining({
+            limit: 100,
+            offset: 0,
+            query: expect.stringContaining('patronGroup=='),
+          }),
+        })
+      );
+    });
+
+    it('should call okapiKy with limit 0 for each chunk when fetching total records', async () => {
+      await act(async () => {
+        renderUserSearchContainer({
+          okapiKy: mockOkapiKyChunked,
+          resources: {
+            ...resources,
+            query: {
+              query: 'test',
+              filters: makePatronGroupFilters(51),
+              sort: 'name',
+            },
+          },
+        });
+      });
+
+      const totalRecordsCalls = mockOkapiKyChunked.mock.calls.filter(
+        ([, options]) => options?.searchParams?.limit === 0
+      );
+      expect(totalRecordsCalls).toHaveLength(2);
+    });
+
+    it('should use single-mode fetch after leaving chunked mode', async () => {
+      const { rerender } = await act(async () => renderUserSearchContainer({
+        okapiKy: mockOkapiKyChunked,
+        resources: {
+          ...resources,
+          query: {
+            query: 'test',
+            filters: makePatronGroupFilters(51),
+            sort: 'name',
+          },
+        },
+      }));
+
+      jest.clearAllMocks();
+
+      await act(async () => rerender(getUserSearchContainer({
+        resources: {
+          ...resources,
+          query: {
+            query: 'test',
+            filters: 'active.active',
+            sort: 'name',
+          },
+        },
+      })));
+
+      expect(mockOkapiKy).toHaveBeenCalledWith(
+        'users',
+        expect.objectContaining({
+          searchParams: expect.objectContaining({
+            limit: 0,
+          }),
+        })
+      );
+    });
+
+    it('should call okapiKy with limit, offset, and patronGroup== query when fetching chunked users', async () => {
+      await act(async () => {
+        renderUserSearchContainer({
+          okapiKy: mockOkapiKyChunked,
+          resources: {
+            ...resources,
+            query: {
+              query: 'test',
+              filters: makePatronGroupFilters(51),
+              sort: 'name',
+            },
+          },
+        });
+      });
+
+      expect(mockOkapiKyChunked).toHaveBeenCalledWith(
+        'users',
+        expect.objectContaining({
+          searchParams: expect.objectContaining({
+            limit: expect.any(Number),
+            offset: expect.any(Number),
+            query: expect.stringContaining('patronGroup=='),
+          }),
+        })
+      );
+    });
+
+    it('should build 2 chunk queries for 51 patron groups', async () => {
+      await act(async () => {
+        renderUserSearchContainer({
+          okapiKy: mockOkapiKyChunked,
+          resources: {
+            ...resources,
+            query: {
+              query: 'test',
+              filters: makePatronGroupFilters(51),
+              sort: 'name',
+            },
+          },
+        });
+      });
+
+      const patronGroupDataCalls = mockOkapiKyChunked.mock.calls.filter(
+        ([, options]) => options?.searchParams?.query?.includes('patronGroup==')
+          && options?.searchParams?.limit !== 0
+      );
+      expect(patronGroupDataCalls).toHaveLength(2);
+    });
+
+    it('should include sortby clause in chunked queries when sort is specified', async () => {
+      await act(async () => {
+        renderUserSearchContainer({
+          okapiKy: mockOkapiKyChunked,
+          resources: {
+            ...resources,
+            query: {
+              query: 'test',
+              filters: makePatronGroupFilters(51),
+              sort: 'name',
+            },
+          },
+        });
+      });
+
+      const callsWithSort = mockOkapiKyChunked.mock.calls.filter(
+        ([, options]) => options?.searchParams?.query?.includes(' sortby ')
+      );
+      expect(callsWithSort.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/routes/utils.js
+++ b/src/routes/utils.js
@@ -2,6 +2,27 @@ import {
   parseFilters,
 } from '@folio/stripes/smart-components';
 
+/**
+ * Extracts patron group UUIDs from a comma-separated Stripes filter string.
+ * Patron group filter entries have the format "pg.<uuid>".
+ */
+export function extractPatronGroupIds(filters) {
+  if (!filters) return [];
+  return filters.split(',')
+    .filter(f => f.startsWith('pg.'))
+    .map(f => f.slice(3));
+}
+
+/**
+ * Returns a filters string with all patron group entries removed.
+ * Returns undefined when no entries remain so callers can detect "no filter".
+ */
+export function stripPatronGroupFilters(filters) {
+  if (!filters) return undefined;
+  const remaining = filters.split(',').filter(f => !f.startsWith('pg.')).join(',');
+  return remaining || undefined;
+}
+
 // Generates a filter config in a dynamic fashion for currently
 // registerd custom fields.
 // This function loops through all currently applied filters
@@ -9,7 +30,6 @@ import {
 // It then generates a custom config for each of them
 // replacing the name "customFields-fieldName"
 // with "customFields.fieldName" for CQL representation.
-// eslint-disable-next-line import/prefer-default-export
 export function buildFilterConfig(filters) {
   const customFilterConfig = [];
   const parsedFilters = parseFilters(filters);

--- a/src/routes/utils.test.js
+++ b/src/routes/utils.test.js
@@ -4,6 +4,8 @@ import {
 
 import {
   buildFilterConfig,
+  extractPatronGroupIds,
+  stripPatronGroupFilters,
 } from './utils';
 
 jest.mock('@folio/stripes/smart-components', () => ({
@@ -46,6 +48,62 @@ describe('Routes utils', () => {
       })));
 
       expect(buildFilterConfig(filters)).toEqual(expectedResult);
+    });
+  });
+
+  describe('extractPatronGroupIds', () => {
+    it('should return [] when called with undefined', () => {
+      expect(extractPatronGroupIds(undefined)).toEqual([]);
+    });
+
+    it('should return [] when called with null', () => {
+      expect(extractPatronGroupIds(null)).toEqual([]);
+    });
+
+    it('should return [] when called with empty string', () => {
+      expect(extractPatronGroupIds('')).toEqual([]);
+    });
+
+    it('should return [] when no pg. filters are present', () => {
+      expect(extractPatronGroupIds('active.active')).toEqual([]);
+    });
+
+    it('should return extracted UUID from a single pg. entry', () => {
+      expect(extractPatronGroupIds('pg.some-uuid')).toEqual(['some-uuid']);
+    });
+
+    it('should return multiple UUIDs from comma-separated pg. entries', () => {
+      expect(extractPatronGroupIds('pg.uuid1,pg.uuid2')).toEqual(['uuid1', 'uuid2']);
+    });
+
+    it('should ignore non-pg filters and return only pg UUIDs', () => {
+      expect(extractPatronGroupIds('active.active,pg.uuid1,tags.foo')).toEqual(['uuid1']);
+    });
+  });
+
+  describe('stripPatronGroupFilters', () => {
+    it('should return undefined for undefined input', () => {
+      expect(stripPatronGroupFilters(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined for null input', () => {
+      expect(stripPatronGroupFilters(null)).toBeUndefined();
+    });
+
+    it('should return undefined for empty string input', () => {
+      expect(stripPatronGroupFilters('')).toBeUndefined();
+    });
+
+    it('should return undefined when only pg. filters are present', () => {
+      expect(stripPatronGroupFilters('pg.uuid1,pg.uuid2')).toBeUndefined();
+    });
+
+    it('should remove pg filters and keep other filters', () => {
+      expect(stripPatronGroupFilters('active.active,pg.uuid1')).toBe('active.active');
+    });
+
+    it('should return undefined rather than empty string when result is empty', () => {
+      expect(stripPatronGroupFilters('pg.uuid1')).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION

## Purpose

Fix HTTP 414 (URI Too Long) error when multi-selecting more than 80 patron groups in the Users module search filters. When a large number of patron groups is selected, the resulting CQL query (each UUID ~36 chars, joined with `patronGroup=="..."` clauses) grows beyond typical URL length limits, causing the Okapi API call to fail.

Refs [UIU-3545](https://folio-org.atlassian.net/browse/UIU-3545).

## Approach

**Root cause**: The `records` stripesConnect manifest builds a CQL `patronGroup=="uuid1" OR patronGroup=="uuid2" OR ...` filter and appends it as a GET query parameter. With 80+ groups this exceeds ~8 KB, triggering HTTP 414.

**Fix**:

1. **Chunked mode detection** — a new `PATRON_GROUP_CHUNK_SIZE = 50` constant defines the threshold. When the number of selected patron groups exceeds it, the component enters "chunked mode".

2. **Manifest fetch guard** — the `records` manifest entry gains a `fetch: props => ...` guard that disables the stripesConnect GET request in chunked mode, preventing the 414 before it happens.

3. **Parallel chunked requests** — two new helpers in `src/routes/utils.js` (`extractPatronGroupIds`, `stripPatronGroupFilters`) split the patron group filter from the rest. `buildChunkedQueries` assembles one CQL string per chunk of ≤50 groups, re-appending the `sortby` clause so CQL remains valid. Both `fetchChunkedUsers` and `fetchChunkedTotalRecords` run these queries in parallel via `Promise.all` and merge results.

4. **Source adapter** — in chunked mode, a minimal `chunkedSource` object (implementing `totalCount`, `pending`, `loaded`, `records`, `fetchMore`, `fetchOffset`, `failure`, `failureMessage`) is passed as the `source` prop to `UserSearch`, keeping all downstream components compatible without modification.

5. **MCL pagination** — `fetchChunkedUsers` stores results as a sparse array (`new Array(pageIndex).concat(users)`) matching the `resultDensity: 'sparse'` pattern, so the MultiColumnList Next/Prev buttons work correctly across pages.

6. **Lifecycle** — `componentDidMount` triggers an initial chunked fetch when the page is loaded with 50+ patron groups already in the URL (e.g. from a bookmark). `componentDidUpdate` re-fetches on query/filter/sort changes and clears chunked state when leaving chunked mode.

#### TODOS and Open Questions


## Learning


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I&#39;ve added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project&#39;s PO and make sure they&#39;re aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it&#39;s helpful for reviewers to help identify potential problems, ensuring that it&#39;s safe to merge is ultimately the responsibility of the PR assignee.
