### PR TITLE
UIU-3057: Handle non-404 4xx errors in UserDetail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-users
 
 ## 13.0.0 IN PROGRESS
+* Handle non-404 4xx errors in UserDetail. Refs UIU-3057.
 * Collect coverage from unit tests. Refs UIU-3356.
 * Modify translation string for search view: "User search -> Search & filter". Refs UIU-3231.
 * *BREAKING* Use number generator for barcode. Refs UIU-2729.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change history for ui-users
 
 ## 13.0.0 IN PROGRESS
-* Handle non-404 4xx errors in UserDetail. Refs UIU-3057.
 * Collect coverage from unit tests. Refs UIU-3356.
 * Modify translation string for search view: "User search -> Search & filter". Refs UIU-3231.
 * *BREAKING* Use number generator for barcode. Refs UIU-2729.
@@ -77,6 +76,7 @@
 * Replace the `ui-requests.all` permission with `ui-requests.create` to display the "New request" buttons. Refs UIU-3211.
 * *BREAKING* Change `users/settings/entries` to `user/settings`. Update `users.settings` interface version to 2.0. Refs UIU-3506.
 * Refactor `withServicePoints` to update service points and current service point in a single call of `updateUser` to prevent the second call overwriting the first call's updates. Prevent redirection when a service point modal appears while saving an updated user record. Fixes UIU-3541.
+* Handle non-404 4xx errors in UserDetail. Refs UIU-3057.
 
 ## [12.1.16] (https://github.com/folio-org/ui-users/tree/v12.1.16) (2025-12-29)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.15...v12.1.16)

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -589,6 +589,31 @@ class UserDetail extends React.Component {
     return this.props.resources?.selUser?.failed?.httpStatus === 404;
   }
 
+  selUserFailed = () => {
+    const { failed } = this.props.resources?.selUser ?? {};
+    return failed && failed.httpStatus !== 404;
+  }
+
+  renderErrorPane = ({
+    id,
+    paneTitle,
+    errorMessage,
+  }) => {
+    const { paneWidth } = this.props;
+
+    return (
+      <ErrorPane
+        id={id}
+        defaultWidth={paneWidth}
+        paneTitle={paneTitle}
+        dismissible
+        onClose={this.onClose}
+      >
+        {errorMessage}
+      </ErrorPane>
+    );
+  }
+
   loadPatronBlocks() {
     const {
       mutator: {
@@ -695,19 +720,22 @@ class UserDetail extends React.Component {
 
     const displayReadingRoomAccessAccordion = isPatronUser(user) || isStaffUser(user);
     const readingRoomPermissions = resources?.userReadingRoomPermissions;
+    const paneTitle = intl.formatMessage({ id: 'ui-users.information.userDetails' });
 
     if (this.userNotFound()) {
-      return (
-        <ErrorPane
-          id="pane-user-not-found"
-          defaultWidth={paneWidth}
-          paneTitle={<FormattedMessage id="ui-users.information.userDetails" />}
-          dismissible
-          onClose={this.onClose}
-        >
-          <FormattedMessage id="ui-users.errors.userNotFound" />
-        </ErrorPane>
-      );
+      return this.renderErrorPane({
+        id: "pane-user-not-found",
+        paneTitle,
+        errorMessage: intl.formatMessage({ id: 'ui-users.errors.userNotFound' }),
+      });
+    }
+
+    if (this.selUserFailed()) {
+      return this.renderErrorPane({
+        id: "pane-user-request-failed",
+        paneTitle,
+        errorMessage: intl.formatMessage({ id: 'ui-users.errors.userRequestFailed' }),
+      });
     }
 
     // Don't display loading if `resources.selUser.isPending` is true`, because creating a new tag in the 4th pane
@@ -719,7 +747,7 @@ class UserDetail extends React.Component {
         <LoadingPane
           id="pane-userdetails"
           defaultWidth={paneWidth}
-          paneTitle={<FormattedMessage id="ui-users.information.userDetails" />}
+          paneTitle={paneTitle}
           dismissible
           onClose={onClose}
         />

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -7,7 +7,7 @@ import {
   concat,
   orderBy,
 } from 'lodash';
-import { injectIntl, FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 
 import {
   AppIcon,
@@ -724,7 +724,7 @@ class UserDetail extends React.Component {
 
     if (this.userNotFound()) {
       return this.renderErrorPane({
-        id: "pane-user-not-found",
+        id: 'pane-user-not-found',
         paneTitle,
         errorMessage: intl.formatMessage({ id: 'ui-users.errors.userNotFound' }),
       });
@@ -732,7 +732,7 @@ class UserDetail extends React.Component {
 
     if (this.selUserFailed()) {
       return this.renderErrorPane({
-        id: "pane-user-request-failed",
+        id: 'pane-user-request-failed',
         paneTitle,
         errorMessage: intl.formatMessage({ id: 'ui-users.errors.userRequestFailed' }),
       });

--- a/src/views/UserDetail/UserDetail.test.js
+++ b/src/views/UserDetail/UserDetail.test.js
@@ -424,6 +424,21 @@ describe('UserDetail', () => {
     });
   });
 
+  describe('when selUser request fails with a non-404 error', () => {
+    const failedUserResources = {
+      ...resources,
+      selUser: {
+        failed: {
+          httpStatus: 403
+        }
+      }
+    };
+    it('should render request-failed error pane', () => {
+      renderUserDetail(stripes, { resources: failedUserResources });
+      expect(screen.getByText('ui-users.errors.userRequestFailed')).toBeDefined();
+    });
+  });
+
   describe('when user information is not available', () => {
     const resourcesWithoutUserInfo = Object.keys(resources).reduce((acc, prop) => {
       if (prop !== 'selUser') {

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -426,6 +426,7 @@
   "errors.reviewBeforeRenewal": "{message} Please review {policyName} before retrying renewal.",
   "errors.loanNotRenewedReason": "Loan cannot be renewed because: {message}.",
   "errors.userNotFound": "User not found",
+  "errors.userRequestFailed": "Unable to retrieve user details",
   "errors.proxyBorrowerNotFound": "Proxy borrower not found",
   "errors.permissionChangeFailed": "Permissions were not changed",
   "errors.permissionsLoadFailed": "Permissions loading for user <b>{user}</b> in <b>{tenantId}</b> tenant was failed.",


### PR DESCRIPTION
## Purpose

The UserDetail pane displayed a perpetual loading spinner when the `selUser` API request failed with a non-404 4xx response. The `userNotFound()` check only handled 404 responses, leaving other error statuses unhandled.

## Description

- Added `selUserFailed()` method to detect non-404 failures from the `selUser` resource
- Extracted `renderErrorPane()` helper to avoid duplicating the ErrorPane render logic
- Added a new error pane render path for non-404 failures with the message "Unable to retrieve user details"
- Added translation key `errors.userRequestFailed`
- Added a test case for the new error path

## Issues

[UIU-3057](https://folio-org.atlassian.net/browse/UIU-3057)