### PR TITLE
UIU-3548 Implement "select all" as "select visible"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * Fix problem with missing loan policy. Refs UIU-3512.
 * Handle non-404 4xx errors in UserDetail. Refs UIU-3057.
 * Update the `index.all` translation. Refs UIU-1027.
+* Select user roles' modal's "Select all" button selects all *visible* records, following convention. Refs UIU-3548.
 
 ## [12.1.16] (https://github.com/folio-org/ui-users/tree/v12.1.16) (2025-12-29)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.15...v12.1.16)

--- a/src/components/EditSections/EditUserRoles/components/UserRolesList/UserRolesList.js
+++ b/src/components/EditSections/EditUserRoles/components/UserRolesList/UserRolesList.js
@@ -10,11 +10,13 @@ const visibleColumns = ['selected', 'roleName', 'status'];
 const UserRolesList = ({ assignedUserRoleIds,
   filteredRoles,
   toggleRole,
-  toggleAllRoles,
+  toggleRoleList,
   tenantId }) => {
   const allChecked = filteredRoles.every(filteredRole => assignedUserRoleIds[tenantId]?.includes(filteredRole.id));
 
-  const handleToggleAllRoles = (event) => toggleAllRoles(event.target.checked);
+  const handleToggleRoleList = (event) => {
+    toggleRoleList(event.target.checked, filteredRoles);
+  };
 
   return (
     <div data-test-user-roles-list>
@@ -27,16 +29,16 @@ const UserRolesList = ({ assignedUserRoleIds,
         contentData={filteredRoles}
         columnMapping={{
           selected:
-          (
-            <div data-test-select-all-user-roles>
-              <CheckboxColumn
-                roleName="select-all"
-                value="selectAll"
-                checked={allChecked}
-                onChange={handleToggleAllRoles}
-              />
-            </div>
-          ),
+            (
+              <div data-test-select-all-user-roles>
+                <CheckboxColumn
+                  roleName="select-all"
+                  value="selectAll"
+                  checked={allChecked}
+                  onChange={handleToggleRoleList}
+                />
+              </div>
+            ),
           roleName: <FormattedMessage id="ui-users.information.name" />,
           status: <FormattedMessage id="ui-users.information.status" />,
         }}
@@ -57,13 +59,10 @@ const UserRolesList = ({ assignedUserRoleIds,
             </div>
           ),
           status: role => {
-            const statusText = `ui-users.roles.modal.${
-              // eslint-disable-next-line react/prop-types
-              assignedUserRoleIds[tenantId]?.includes(role.id)
-                ? 'assigned'
-                : 'unassigned'
-            }`;
-
+            const status = assignedUserRoleIds[tenantId]?.includes(role.id)
+              ? 'assigned'
+              : 'unassigned';
+            const statusText = `ui-users.roles.modal.${status}`;
             return <div data-test-role-status><FormattedMessage id={statusText} /></div>;
           }
         }}
@@ -81,7 +80,7 @@ UserRolesList.propTypes = {
     })
   ).isRequired,
   toggleRole: PropTypes.func.isRequired,
-  toggleAllRoles: PropTypes.func.isRequired,
+  toggleRoleList: PropTypes.func.isRequired,
   tenantId: PropTypes.string.isRequired
 };
 

--- a/src/components/EditSections/EditUserRoles/components/UserRolesList/UserRolesList.test.js
+++ b/src/components/EditSections/EditUserRoles/components/UserRolesList/UserRolesList.test.js
@@ -14,7 +14,7 @@ const renderComponent = (props) => render(<UserRolesList {...props} />);
 
 describe('UserRolesList', () => {
   beforeEach(() => {
-    renderComponent({ assignedUserRoleIds, filteredRoles, toggleRole:mockToggleRole, toggleAllRoles:mockToggleAllRoles, tenantId });
+    renderComponent({ assignedUserRoleIds, filteredRoles, toggleRole: mockToggleRole, toggleRoleList: mockToggleAllRoles, tenantId });
   });
   afterAll(() => {
     cleanup();
@@ -31,7 +31,7 @@ describe('UserRolesList', () => {
 
     await userEvent.click(selectAllCheckbox);
 
-    expect(mockToggleAllRoles).toHaveBeenCalledWith(false);
+    expect(mockToggleAllRoles).toHaveBeenCalledWith(false, filteredRoles);
   });
 
   it('toggle select role', async () => {

--- a/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.js
+++ b/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.js
@@ -55,9 +55,13 @@ export default function UserRolesModal({ isOpen,
 
   const toggleRoleList = (checked, roleList) => {
     if (checked) {
-      setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: roleList?.map(role => role.id) });
+      const currentIds = assignedRoleIds[tenantId] || [];
+      const currentPlusFiltered = new Set([...currentIds, ...roleList.map(role => role.id)]);
+      setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: Array.from(currentPlusFiltered) });
     } else {
-      setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: [] });
+      const idsToUnassign = roleList.map(role => role.id);
+      const remainingIds = (assignedRoleIds[tenantId] || []).filter(id => !idsToUnassign.includes(id));
+      setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: remainingIds });
     }
   };
 

--- a/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.js
+++ b/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.js
@@ -55,8 +55,8 @@ export default function UserRolesModal({ isOpen,
 
   const toggleRoleList = (checked, roleList) => {
     if (checked) {
-      const currentIds = assignedRoleIds[tenantId] || [];
-      const currentPlusFiltered = new Set([...currentIds, ...roleList.map(role => role.id)]);
+      const currentAssignedIds = assignedRoleIds[tenantId] || [];
+      const currentPlusFiltered = new Set([...currentAssignedIds, ...roleList.map(role => role.id)]);
       setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: Array.from(currentPlusFiltered) });
     } else {
       const idsToUnassign = roleList.map(role => role.id);

--- a/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.js
+++ b/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.js
@@ -53,9 +53,9 @@ export default function UserRolesModal({ isOpen,
     }
   };
 
-  const toggleAllRoles = (checked) => {
+  const toggleRoleList = (checked, roleList) => {
     if (checked) {
-      setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: allRolesData?.roles.map(role => role.id) });
+      setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: roleList?.map(role => role.id) });
     } else {
       setAssignedRoleIds({ ...assignedRoleIds, [tenantId]: [] });
     }
@@ -172,7 +172,7 @@ export default function UserRolesModal({ isOpen,
               assignedUserRoleIds={assignedRoleIds}
               filteredRoles={filteredRoles}
               toggleRole={toggleRole}
-              toggleAllRoles={toggleAllRoles}
+              toggleRoleList={toggleRoleList}
               tenantId={tenantId}
             />
           </Pane>

--- a/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.test.js
+++ b/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.test.js
@@ -6,12 +6,12 @@ jest.mock('../../../../../hooks', () => {
   const mockAllRolesData = {
     data: {
       roles: [{ id: '1', name: 'testRole' },
-      { id: '4', name: 'AAtestRole4' },
-      { id: '3', name: 'testRole3' }]
+        { id: '4', name: 'AAtestRole4' },
+        { id: '3', name: 'testRole3' }]
     },
     allRolesMapStructure: new Map([['1', { id: '1', name: 'testRole' }],
-    ['4', { id: '4', name: 'AAtestRole4' }],
-    ['3', { id: '3', name: 'testRole3' }]])
+      ['4', { id: '4', name: 'AAtestRole4' }],
+      ['3', { id: '3', name: 'testRole3' }]])
   };
 
   return {

--- a/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.test.js
+++ b/src/components/EditSections/EditUserRoles/components/UserRolesModal/UserRolesModal.test.js
@@ -3,15 +3,21 @@ import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import UserRolesModal from './UserRolesModal';
 
 jest.mock('../../../../../hooks', () => {
-  const mockAllRolesData = { data:{ roles: [{ id: '1', name: 'testRole' },
-    { id: '4', name: 'AAtestRole4' },
-    { id: '3', name: 'testRole3' }] },
-  allRolesMapStructure: new Map([['1', { id: '1', name: 'testRole' }],
+  const mockAllRolesData = {
+    data: {
+      roles: [{ id: '1', name: 'testRole' },
+      { id: '4', name: 'AAtestRole4' },
+      { id: '3', name: 'testRole3' }]
+    },
+    allRolesMapStructure: new Map([['1', { id: '1', name: 'testRole' }],
     ['4', { id: '4', name: 'AAtestRole4' }],
-    ['3', { id: '3', name: 'testRole3' }]]) };
+    ['3', { id: '3', name: 'testRole3' }]])
+  };
 
-  return { ...jest.requireActual('../../../../../hooks'),
-    useAllRolesData: jest.fn().mockReturnValue(mockAllRolesData) };
+  return {
+    ...jest.requireActual('../../../../../hooks'),
+    useAllRolesData: jest.fn().mockReturnValue(mockAllRolesData)
+  };
 });
 jest.unmock('@folio/stripes/components');
 
@@ -28,7 +34,7 @@ describe('UserRoleModal', () => {
     jest.clearAllMocks();
   });
   it('renders user roles modal', async () => {
-    const { getByText } = await waitFor(() => renderComponent({ isOpen: true, onClose: mockOnClose, assignedRoles: mockAssignedRoles, initialRoleIds, setAssignedRolesIds:jest.fn(), tenantId }));
+    const { getByText } = await waitFor(() => renderComponent({ isOpen: true, onClose: mockOnClose, assignedRoles: mockAssignedRoles, initialRoleIds, setAssignedRolesIds: jest.fn(), tenantId }));
 
     expect(getByText('testRole')).toBeInTheDocument();
     expect(getByText('AAtestRole4')).toBeInTheDocument();
@@ -36,18 +42,20 @@ describe('UserRoleModal', () => {
   });
 
   it('should call onClose function', async () => {
-    await waitFor(() => renderComponent({ isOpen: true, onClose: mockOnClose, assignedRoles: mockAssignedRoles, initialRoleIds, setAssignedRolesIds:jest.fn(), tenantId }));
+    await waitFor(() => renderComponent({ isOpen: true, onClose: mockOnClose, assignedRoles: mockAssignedRoles, initialRoleIds, setAssignedRolesIds: jest.fn(), tenantId }));
     await userEvent.click(document.getElementById('user-roles-modal-close-button'));
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it('should select/unselect all roles, and ', async () => {
-    renderComponent({ isOpen: true,
+    renderComponent({
+      isOpen: true,
       onClose: mockOnClose,
       initialRoleIds,
-      changeUserRoles:jest.fn(),
-      tenantId });
+      changeUserRoles: jest.fn(),
+      tenantId
+    });
 
     const selectAllButton = document.querySelector('[name="selected-selectAll"]');
     await userEvent.click(selectAllButton);
@@ -62,13 +70,65 @@ describe('UserRoleModal', () => {
     expect(roleCheckbox.checked).toBe(false);
   });
 
+  it('should select all only for filtered roles and keep unfiltered assigned roles', async () => {
+    const mockChangeUserRoles = jest.fn();
+
+    renderComponent({
+      isOpen: true,
+      onClose: mockOnClose,
+      initialRoleIds: { consortium: ['1', '4'] },
+      changeUserRoles: mockChangeUserRoles,
+      tenantId,
+    });
+
+    await userEvent.type(document.querySelector('[name="query"]'), 'testRole3');
+    await userEvent.click(document.querySelector('[data-test-submit-button]'));
+
+    const selectAllButton = document.querySelector('[name="selected-selectAll"]');
+    expect(selectAllButton.checked).toBe(false);
+
+    await userEvent.click(selectAllButton);
+
+    const submitButton = document.querySelector('#clickable-permissions-modal-save');
+    await userEvent.click(submitButton);
+
+    expect(mockChangeUserRoles).toHaveBeenCalledWith(['4', '1', '3']);
+  });
+
+  it('should deselect all only for filtered roles and keep other assigned roles', async () => {
+    const mockChangeUserRoles = jest.fn();
+
+    renderComponent({
+      isOpen: true,
+      onClose: mockOnClose,
+      initialRoleIds: { consortium: ['1', '3'] },
+      changeUserRoles: mockChangeUserRoles,
+      tenantId,
+    });
+
+    await userEvent.type(document.querySelector('[name="query"]'), 'testRole3');
+    await userEvent.click(document.querySelector('[data-test-submit-button]'));
+
+    const selectAllButton = document.querySelector('[name="selected-selectAll"]');
+    expect(selectAllButton.checked).toBe(true);
+
+    await userEvent.click(selectAllButton);
+
+    const submitButton = document.querySelector('#clickable-permissions-modal-save');
+    await userEvent.click(submitButton);
+
+    expect(mockChangeUserRoles).toHaveBeenCalledWith(['1']);
+  });
+
 
   it('should show assigned roles only', async () => {
-    const { queryByText } = renderComponent({ isOpen: true,
+    const { queryByText } = renderComponent({
+      isOpen: true,
       onClose: mockOnClose,
       initialRoleIds: ['1'],
-      changeUserRoles:jest.fn(),
-      tenantId });
+      changeUserRoles: jest.fn(),
+      tenantId
+    });
 
     const assignedFilterCheckbox = document.querySelector('[name="status.assigned"]');
     await userEvent.click(assignedFilterCheckbox);
@@ -79,11 +139,13 @@ describe('UserRoleModal', () => {
   });
 
   it('should show unassigned roles only', async () => {
-    const { getAllByRole } = renderComponent({ isOpen: true,
+    const { getAllByRole } = renderComponent({
+      isOpen: true,
       onClose: mockOnClose,
       initialRoleIds,
-      changeUserRoles:jest.fn(),
-      tenantId });
+      changeUserRoles: jest.fn(),
+      tenantId
+    });
 
     const unassignedFilterCheckbox = document.querySelector('[name="status.unassigned"]');
     await userEvent.click(unassignedFilterCheckbox);
@@ -99,13 +161,15 @@ describe('UserRoleModal', () => {
   it('should reset all filters', async () => {
     const actual = jest.requireActual('./useRolesModalFilters');
     const mockFunction = jest.spyOn(actual, 'default');
-    mockFunction.mockReturnValue({ filters: {}, onChangeFilter: jest.fn(), onClearFilter: jest.fn(), resetFilters:jest.fn() });
+    mockFunction.mockReturnValue({ filters: {}, onChangeFilter: jest.fn(), onClearFilter: jest.fn(), resetFilters: jest.fn() });
 
-    renderComponent({ isOpen: true,
+    renderComponent({
+      isOpen: true,
       onClose: mockOnClose,
       initialRoleIds,
-      changeUserRoles:jest.fn(),
-      tenantId });
+      changeUserRoles: jest.fn(),
+      tenantId
+    });
 
     await userEvent.click(document.querySelector('[data-test-reset-all-button="true"]'));
 
@@ -113,11 +177,13 @@ describe('UserRoleModal', () => {
   });
 
   it('should toggle filters pane', async () => {
-    const { getByText } = renderComponent({ isOpen: true,
+    const { getByText } = renderComponent({
+      isOpen: true,
       onClose: mockOnClose,
       initialRoleIds,
-      changeUserRoles:jest.fn(),
-      tenantId });
+      changeUserRoles: jest.fn(),
+      tenantId
+    });
 
     const collapseButton = document.querySelector('[data-test-collapse-filter-pane-button="true"]');
     await userEvent.click(collapseButton);
@@ -130,11 +196,13 @@ describe('UserRoleModal', () => {
 
   it('should sort objects alphabetically, extract ids after sorting and call changeUserRoles function with that ids', async () => {
     const mockChangeUserRoles = jest.fn();
-    const { getByRole } = renderComponent({ isOpen: true,
+    const { getByRole } = renderComponent({
+      isOpen: true,
       onClose: mockOnClose,
       initialRoleIds: { 'consortium': ['1', '4'] },
-      changeUserRoles:mockChangeUserRoles,
-      tenantId });
+      changeUserRoles: mockChangeUserRoles,
+      tenantId
+    });
     const submitButton = getByRole('button', { name: 'stripes-components.saveAndClose' });
     await userEvent.click(submitButton);
     expect(mockChangeUserRoles).toHaveBeenCalledWith(['4', '1']);


### PR DESCRIPTION
In the "Select user roles" SAS modal, ticking the "Select all" checkbox in the first column header must follow existing conventions, select only the rows that are visible in the results pane, not all rows.

Previously, conducting a search that returned, say, 10 rows and then ticking the column-header's box would select all rows rather than only the 10 returned by the search. This was misleading and inconsistent with other implementations where "select all" is implemented "select all that are visible".

Refs [UIU-3548](https://folio-org.atlassian.net/browse/UIU-3548)


https://github.com/user-attachments/assets/4a8a6b76-0ebc-4967-b16d-9b7e124ef7e1

