### PR TITLE
[UIU-3521] Update IfPerm in user edit form from `ui-users-roles.view` to `ui-authorization-roles.users.settings.view`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-users
 
+## 13.1.0 IN PROGRESS
+
+* Update IfPerm in user edit form from `ui-users-roles.view` to `ui-authorization-roles.users.settings.view` since `ui-users-roles.view` includes extraneous subpermissions. Refs UIU-3521.
+
 ## [13.0.0] (https://github.com/folio-org/ui-users/tree/v13.0.0) (2026-04-16)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.16...v13.0.0)
 * Collect coverage from unit tests. Refs UIU-3356.
@@ -81,7 +85,6 @@
 * Handle non-404 4xx errors in UserDetail. Refs UIU-3057.
 * Update the `index.all` translation. Refs UIU-1027.
 * Select user roles' modal's "Select all" button selects all *visible* records, following convention. Refs UIU-3548.
-* Update IfPerm in user edit form from `ui-users-roles.view` to `ui-authorization-roles.users.settings.view` since `ui-users-roles.view` includes extraneous subpermissions. Refs UIU-3521.
 
 ## [12.1.16] (https://github.com/folio-org/ui-users/tree/v12.1.16) (2025-12-29)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.15...v12.1.16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 * Handle non-404 4xx errors in UserDetail. Refs UIU-3057.
 * Update the `index.all` translation. Refs UIU-1027.
 * Select user roles' modal's "Select all" button selects all *visible* records, following convention. Refs UIU-3548.
+* Update IfPerm in user edit form from `ui-users-roles.view` to `ui-authorization-roles.users.settings.view` since `ui-users-roles.view` includes extraneous subpermissions. Refs UIU-3521.
 
 ## [12.1.16] (https://github.com/folio-org/ui-users/tree/v12.1.16) (2025-12-29)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.15...v12.1.16)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/users",
-  "version": "13.0.0",
+  "version": "13.1.0",
   "description": "User management",
   "repository": "folio-org/ui-users",
   "publishConfig": {

--- a/src/hooks/useUserAffiliationRoles/useUserAffiliationRoles.js
+++ b/src/hooks/useUserAffiliationRoles/useUserAffiliationRoles.js
@@ -13,7 +13,7 @@ function useUserAffiliationRoles(userId, tenantId) {
   const [namespace] = useNamespace({ key: USER_AFFILIATION_ROLES_CACHE_KEY });
   const ky = useOkapiKy({ tenant: tenantId });
 
-  const hasViewRolesPermission = stripes.hasPerm('ui-users.roles.view');
+  const hasViewRolesPermission = stripes.hasPerm('ui-authorization-roles.users.settings.view');
 
   // Since `roles/users` return doesn't include names (only ids) for the roles, and we need them sorted by role name,
   // we need to retrieve all the records for roles and use them to determine the sequence of ids.

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -943,7 +943,7 @@ class UserDetail extends React.Component {
                 }
 
                 { !this.showPermissionsAccordion() &&
-                  <IfPermission perm="ui-users.roles.view">
+                  <IfPermission perm="ui-authorization-roles.users.settings.view">
                     <UserRoles
                       expanded={sections[ACCORDION_ID.ROLES]}
                       onToggle={this.handleSectionToggle}

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -500,7 +500,7 @@ class UserForm extends React.Component {
                       initialValues={initialValues}
                       setButtonRef={this.setButtonRef}
                     /> :
-                    <IfPermission perm="ui-users.roles.view">
+                    <IfPermission perm="ui-authorization-roles.users.settings.view">
                       <EditUserRoles
                         form={form}
                         user={initialValues}

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -134,6 +134,8 @@ jest.mock('@folio/stripes/core', () => {
     IfPermission: jest.fn(({ perm, children }) => {
       if (perm === 'permission') {
         return children;
+      } else if (perm.startsWith('ui-authorization')) {
+        return children;
       } else if (perm.startsWith('ui-users')) {
         return children;
       } else if (perm.startsWith('perms')) {


### PR DESCRIPTION
- Fulfills [UIU-3521](https://folio-org.atlassian.net/browse/UIU-3521).
- Switching IfPerm checks for roles to be more specific using `ui-authorization-roles.users.settings.view` per ticket. The previously used perm `ui-users-roles.view` includes `ui-authorization-roles.users.settings.view` as a subpermission so accounts that rely on `ui-users-roles.view` will be unaffected. 
- Accounts that just have `ui-authorization-roles.users.settings.view` will benefit as they expect to see Roles in Settings and Users modules. 