### PR TITLE
UIU-3580: Remove extra character from Expired time in Lost items requiring actual cost table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add Settings > Users > Version history page to configure retention, anonymization, and excluded fields. Refs UIU-3385.
 * Add a Version history pane on the user detail view, gated on the mod-audit interface. Refs UIU-3388.
 * Send bulk override renewal requests sequentially to prevent race conditions. Refs UIU-3561.
+* Remove extra character from `Expired time` in Lost items requiring actual cost table. Refs UIU-3580.
 
 ## [13.0.0] (https://github.com/folio-org/ui-users/tree/v13.0.0) (2026-04-16)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.16...v13.0.0)

--- a/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RecordStatus/RecordStatus.js
+++ b/src/views/LostItems/LostItemsListContainer/components/LostItemsList/components/RecordStatus/RecordStatus.js
@@ -55,7 +55,7 @@ const RecordStatus = ({
           <>
             <br /><DateTimeFormatter value={actualCostRecord.expirationDate} />
           </>
-        )}c
+        )}
       </>
     );
   }


### PR DESCRIPTION
## Purpose
Remove extra character from Expired time in Lost items requiring actual cost table

## Refs
https://folio-org.atlassian.net/browse/UIU-3580