### PR TITLE
UIU-3586: Use the current tenant, not the selected affiliation tenant, for Keycloak auth-user existence and creation checks in user edit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add a Version history pane on the user detail view, gated on the mod-audit interface. Refs UIU-3388.
 * Send bulk override renewal requests sequentially to prevent race conditions. Refs UIU-3561.
 * Remove extra character from `Expired time` in Lost items requiring actual cost table. Refs UIU-3580.
+* Use the current tenant, not the selected affiliation tenant, for Keycloak auth-user existence and creation checks in user edit. Fixes UIU-3586.
 
 ## [13.0.0] (https://github.com/folio-org/ui-users/tree/v13.0.0) (2026-04-16)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.16...v13.0.0)

--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -30,14 +30,9 @@ const withUserRoles = (WrappedComponent) => (props) => {
   const callout = useCallout();
   const sendErrorCallout = error => showErrorCallout(error, callout.sendCallout);
 
-  const { mutateAsync: createKeycloakUser } = useCreateAuthUserKeycloak(sendErrorCallout, { tenantId });
+  const { mutateAsync: createKeycloakUser } = useCreateAuthUserKeycloak(sendErrorCallout);
 
   const ky = useOkapiKy();
-  const api = ky.extend({
-    hooks: {
-      beforeRequest: [(req) => req.headers.set('X-Okapi-Tenant', tenantId)]
-    }
-  });
 
   useEffect(() => {
     // No need to set roles if there are empty or loading
@@ -101,7 +96,11 @@ const withUserRoles = (WrappedComponent) => (props) => {
 
   const checkUserInKeycloak = async () => {
     try {
-      await api.get(`users-keycloak/auth-users/${userId}`);
+      // This endpoint is used to check if the user exists in Keycloak to determine whether to show the confirmation modal.
+      // The request must use the current tenant header and not the selected affiliation tenant to ensure the correct check.
+      // There is no need to check if the user exists in Keycloak in affiliated tenants, as they are automatically created
+      // in Keycloak after being assigned to the user.
+      await ky.get(`users-keycloak/auth-users/${userId}`);
       return KEYCLOAK_USER_EXISTANCE.exist;
     } catch (error) {
       if (error?.response?.status === 404) {

--- a/src/components/Wrappers/withUserRoles.test.js
+++ b/src/components/Wrappers/withUserRoles.test.js
@@ -4,7 +4,11 @@ import { cleanup, render, waitFor } from '@folio/jest-config-stripes/testing-lib
 import { useStripes, useOkapiKy, useCallout } from '@folio/stripes/core';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import withUserRoles from './withUserRoles';
-import { useAllRolesData, useUserAffiliationRoles } from '../../hooks';
+import {
+  useAllRolesData,
+  useCreateAuthUserKeycloak,
+  useUserAffiliationRoles,
+} from '../../hooks';
 
 jest.mock('react-query', () => ({
   useQueryClient: jest.fn(() => ({ invalidateQueries: jest.fn() })),
@@ -32,11 +36,6 @@ const mockStripes = {
   config: {
     maxUnpagedResourceCount: 1000,
   },
-  mutator: {
-    selUser: {
-      PUT: jest.fn().mockResolvedValue({ data: {} }),
-    },
-  }
 };
 
 const mockRolesData = {
@@ -57,53 +56,63 @@ const mockData = {
   username: 'testUser',
 };
 
-const mockApiPut = jest.fn(() => Promise.resolve({
-  json: () => Promise.resolve(),
-}));
+const mockApiPut = jest.fn().mockResolvedValue();
+const mockKyPut = jest.fn().mockResolvedValue();
 
-const mockKyPut = jest.fn();
+let ky;
 
-const mockKy = {
-  extend: () => ({
-    get: jest.fn().mockImplementationOnce(() => ({
-      json: () => Promise.resolve({ userRoles: [{ roleId: 'role1' }, { roleId: 'role2' }] }),
-    })).mockImplementationOnce(() => Promise.resolve(true)),
-    put: mockApiPut,
-  }),
-  put: mockKyPut,
+const mutator = {
+  selUser: {
+    PUT: jest.fn().mockResolvedValue({ data: {} }),
+  },
 };
 
-const WrappedComponent = ({ assignedRoleIds,
+const WrappedComponent = ({
+  assignedRoleIds,
   setAssignedRoleIds,
-  checkAndHandleKeycloakAuthUser, confirmCreateKeycloakUser }) => (
-    <div data-testid="assigned-role-ids">{assignedRoleIds.consortium?.join(', ')}
-      <button
-        type="submit"
-        data-testid="submit-form"
-        onClick={() => checkAndHandleKeycloakAuthUser(() => {}, mockData)}
-      >Submit
-      </button>
+  checkAndHandleKeycloakAuthUser,
+  confirmCreateKeycloakUser,
+  setTenantId,
+  tenantId,
+  isCreateKeycloakUserConfirmationOpen,
+}) => (
+  <div data-testid="assigned-role-ids">{assignedRoleIds.consortium?.join(', ')}
+    <button
+      type="submit"
+      data-testid="submit-form"
+      onClick={() => checkAndHandleKeycloakAuthUser(() => {}, mockData, mutator)}
+    >Submit
+    </button>
+    <button
+      type="button"
+      onClick={() => setAssignedRoleIds({
+        college: ['collegeRole1'],
+        consortium: ['role1', 'role2'],
+        university: ['universityRole1'],
+      })}
+      data-testid="assignRoles"
+    >
+      Assign roles
+    </button>
+    <button
+      type="button"
+      onClick={() => setTenantId('college')}
+      data-testid="switch-tenant"
+    >
+      Switch tenant
+    </button>
+    <div data-testid="selected-tenant">{tenantId}</div>
+    <div data-testid="keycloak-confirmation-open">{String(isCreateKeycloakUserConfirmationOpen)}</div>
+    <div data-testid="confirmation-dialog">
       <button
         type="button"
-        onClick={() => setAssignedRoleIds({
-          college: ['collegeRole1'],
-          consortium: ['role1', 'role2'],
-          university: ['universityRole1'],
+        data-testid="confirm-create-keycloak-user"
+        onClick={() => confirmCreateKeycloakUser(() => {
         })}
-        data-testid="assignRoles"
-      >
-        Assign roles
+      >Confirm
       </button>
-      <div data-testid="confirmation-dialog">
-        <button
-          type="button"
-          data-testid="confirm-create-keycloak-user"
-          onClick={() => confirmCreateKeycloakUser(() => {
-          })}
-        >Confirm
-        </button>
-      </div>
     </div>
+  </div>
 );
 
 const CompWithUserRoles = withUserRoles(WrappedComponent);
@@ -117,15 +126,29 @@ const renderComponent = (props = {}) => render(
 );
 
 describe('withUserRoles HOC', () => {
-  afterAll(() => {
+  afterEach(() => {
     jest.clearAllMocks();
     cleanup();
   });
+
   beforeEach(() => {
+    const roleKy = {
+      put: mockApiPut,
+    };
+
+    ky = {
+      get: jest.fn().mockResolvedValue(true),
+      put: mockKyPut,
+      extend: jest.fn(() => roleKy),
+    };
+
     useStripes.mockReturnValue(mockStripes);
     useAllRolesData.mockReturnValue(mockRolesData);
+    useCreateAuthUserKeycloak.mockReturnValue({
+      mutateAsync: jest.fn(),
+    });
     useUserAffiliationRoles.mockReturnValue(mockUserAffiliationRoles);
-    useOkapiKy.mockReturnValue(mockKy);
+    useOkapiKy.mockReturnValue(ky);
   });
 
   it('fetches and sets assigned role ids on mount and assignedRoleIds passed to wrapped component correctly', async () => {
@@ -134,10 +157,12 @@ describe('withUserRoles HOC', () => {
     await waitFor(() => expect(getByTestId('assigned-role-ids')).toHaveTextContent('role1, role2'));
   });
 
-  it('check keycloak user', async () => {
+  it('checks keycloak user with the current okapi client', async () => {
     const { getByTestId } = renderComponent();
 
     await userEvent.click(getByTestId('submit-form'));
+
+    expect(ky.get).toHaveBeenCalledWith('users-keycloak/auth-users/user1');
   });
 
   it('submit form changing user role ids', async () => {
@@ -148,16 +173,39 @@ describe('withUserRoles HOC', () => {
   });
 
   it('submit form after changing user role ids', async () => {
+    const mutateAsync = jest.fn().mockResolvedValue(undefined);
+
+    useCreateAuthUserKeycloak.mockReturnValue({ mutateAsync });
+
     const { getByTestId } = renderComponent();
 
     await act(() => userEvent.click(getByTestId('assignRoles')));
     await userEvent.click(getByTestId('confirm-create-keycloak-user'));
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith('user1');
+    });
+  });
+
+  it('opens keycloak confirmation for the current tenant after switching affiliation tenant', async () => {
+    const notFoundError = { response: { status: 404 } };
+    ky.get.mockRejectedValue(notFoundError);
+
+    const { getByTestId } = renderComponent();
+
+    await act(() => userEvent.click(getByTestId('assignRoles')));
+    await userEvent.click(getByTestId('switch-tenant'));
+    await waitFor(() => expect(getByTestId('selected-tenant')).toHaveTextContent('college'));
+    await userEvent.click(getByTestId('submit-form'));
+
+    expect(mutator.selUser.PUT).toHaveBeenCalledWith(mockData);
+    expect(getByTestId('keycloak-confirmation-open')).toHaveTextContent('true');
+    expect(mockKyPut).not.toHaveBeenCalled();
+    expect(useCreateAuthUserKeycloak).toHaveBeenLastCalledWith(expect.any(Function));
   });
 
   describe('when assigning roles for other tenants', () => {
     beforeEach(async () => {
-      jest.clearAllMocks();
-
       useUserAffiliationRoles.mockReturnValue({
         userRoleIds: {
           college: [],
@@ -229,13 +277,8 @@ describe('withUserRoles HOC', () => {
       capturedError = undefined;
 
       useCallout.mockReturnValue({ sendCallout: mockSendCallout });
-      useOkapiKy.mockReturnValue({
-        extend: () => ({
-          get: jest.fn(() => Promise.resolve()),
-          put: jest.fn(),
-        }),
-        put: jest.fn().mockRejectedValue(mockError),
-      });
+      ky.get.mockResolvedValue(true);
+      ky.put.mockRejectedValue(mockError);
     });
 
     it('should propagate the error to the caller instead of catching it', async () => {


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Description
When saving a user who doesn't have a Keycloak auth-user record, show a confirmation dialog.

The issue is that the request to check whether the edited user already has a Keycloak record is sent with the affiliation tenant currently selected in the "User roles" accordion, for example, "college" (x-okapi-tenant: college),  instead of the current tenant, for example, "consortium". Since the user has a Keycloak record for college, the check succeeds, and the confirmation dialog is not shown, even though the user doesn't yet have a Keycloak record for consortium.

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Issues
https://folio-org.atlassian.net/browse/UIU-3586

## Screencasts


https://github.com/user-attachments/assets/ada29e31-c737-4df5-9b45-7a6997665782



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
