### PR TITLE
UIU-3586: Fix keycloak confirmation dialog not showing when assigning roles/affiliations to non-home tenants in ECS, and add the same dialog when creating a new user on a member tenant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add a Version history pane on the user detail view, gated on the mod-audit interface. Refs UIU-3388.
 * Send bulk override renewal requests sequentially to prevent race conditions. Refs UIU-3561.
 * Remove extra character from `Expired time` in Lost items requiring actual cost table. Refs UIU-3580.
+* Fix keycloak confirmation dialog not showing when assigning roles/affiliations to non-home tenants in ECS. Refs UIU-3586.
 
 ## [13.0.0] (https://github.com/folio-org/ui-users/tree/v13.0.0) (2026-04-16)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.16...v13.0.0)

--- a/src/components/UserDetailSections/UserAffiliations/UserAffiliations.js
+++ b/src/components/UserDetailSections/UserAffiliations/UserAffiliations.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 
 import {
   useCallout,
@@ -24,6 +24,7 @@ import {
 import AffiliationsManager from '../../AffiliationsManager';
 import IfConsortiumPermission from '../../IfConsortiumPermission';
 import { KEYCLOAK_USER_EXISTENCE } from '../../../constants';
+import { getFullName } from '../../util';
 
 import css from './UserAffiliations.css';
 import { createErrorMessage } from './util';
@@ -38,9 +39,11 @@ const UserAffiliations = ({
   onToggle,
   userId,
   userName,
+  user,
 }) => {
   const callout = useCallout();
   const stripes = useStripes();
+  const intl = useIntl();
   const [isKeycloakConfirmationOpen, setIsKeycloakConfirmationOpen] = useState(false);
   const [keycloakMissingTenantNames, setKeycloakMissingTenantNames] = useState('');
   const [keycloakMissingTenantCount, setKeycloakMissingTenantCount] = useState(0);
@@ -60,6 +63,7 @@ const UserAffiliations = ({
     isLoading: isAffiliationsMutating,
   } = useUserAffiliationsMutation();
 
+  const userFullName = getFullName(user);
   const isLoading = isFetching || isAffiliationsMutating;
 
   const processAssignment = useCallback(async ({ added, removed }) => {
@@ -192,12 +196,16 @@ const UserAffiliations = ({
       </Accordion>
       <ConfirmationModal
         id="affiliations-keycloak-confirmation"
-        heading={<FormattedMessage id="ui-users.keycloak.modal.confirmationHeading" />}
-        message={<FormattedMessage id="ui-users.keycloak.modal.creation" values={{ user: userName, tenants: keycloakMissingTenantNames, count: keycloakMissingTenantCount }} />}
+        heading={intl.formatMessage({ id: 'ui-users.keycloak.modal.confirmationHeading' })}
+        message={intl.formatMessage({ id: 'ui-users.keycloak.modal.creationMessage' }, {
+          user: userFullName,
+          tenants: keycloakMissingTenantNames,
+          count: keycloakMissingTenantCount,
+        })}
         onConfirm={handleConfirmKeycloakCreation}
         onCancel={handleCancelKeycloakCreation}
         open={isKeycloakConfirmationOpen}
-        confirmLabel={<FormattedMessage id="stripes-core.button.confirm" />}
+        confirmLabel={intl.formatMessage({ id: 'stripes-core.button.confirm' })}
       />
     </>
   );
@@ -214,6 +222,7 @@ UserAffiliations.propTypes = {
   onToggle: PropTypes.func.isRequired,
   userId: PropTypes.string,
   userName: PropTypes.string,
+  user: PropTypes.object,
 };
 
 export default UserAffiliations;

--- a/src/components/UserDetailSections/UserAffiliations/UserAffiliations.js
+++ b/src/components/UserDetailSections/UserAffiliations/UserAffiliations.js
@@ -1,13 +1,15 @@
 import PropTypes from 'prop-types';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import {
-  useCallout
+  useCallout,
+  useStripes,
 } from '@folio/stripes/core';
 import {
   Accordion,
   Badge,
+  ConfirmationModal,
   Headline,
   Icon,
   List,
@@ -17,9 +19,11 @@ import {
 import {
   useUserAffiliations,
   useUserAffiliationsMutation,
+  useCheckUserInKeycloak,
 } from '../../../hooks';
 import AffiliationsManager from '../../AffiliationsManager';
 import IfConsortiumPermission from '../../IfConsortiumPermission';
+import { KEYCLOAK_USER_EXISTENCE } from '../../../constants';
 
 import css from './UserAffiliations.css';
 import { createErrorMessage } from './util';
@@ -36,6 +40,13 @@ const UserAffiliations = ({
   userName,
 }) => {
   const callout = useCallout();
+  const stripes = useStripes();
+  const [isKeycloakConfirmationOpen, setIsKeycloakConfirmationOpen] = useState(false);
+  const [keycloakMissingTenantNames, setKeycloakMissingTenantNames] = useState('');
+  const [keycloakMissingTenantCount, setKeycloakMissingTenantCount] = useState(0);
+  const pendingAssignmentRef = useRef(null);
+
+  const { checkUserInKeycloakForTenant } = useCheckUserInKeycloak(userId);
 
   const {
     affiliations,
@@ -51,7 +62,7 @@ const UserAffiliations = ({
 
   const isLoading = isFetching || isAffiliationsMutating;
 
-  const onUpdateAffiliations = useCallback(async ({ added, removed }) => {
+  const processAssignment = useCallback(async ({ added, removed }) => {
     try {
       const { success, errors } = await handleAssignment({ added, removed });
 
@@ -94,6 +105,47 @@ const UserAffiliations = ({
     }
   }, [callout, handleAssignment, refetch, userName]);
 
+  const onUpdateAffiliations = useCallback(async ({ added, removed }) => {
+    if (!added.length || !stripes.hasInterface('users-keycloak')) {
+      await processAssignment({ added, removed });
+      return;
+    }
+
+    // Check keycloak existence for each tenant being added.
+    const statuses = await Promise.all(
+      added.map(async ({ tenantId }) => {
+        const status = await checkUserInKeycloakForTenant(tenantId);
+        return { tenantId, status };
+      })
+    );
+
+    const missingTenants = statuses.filter(({ status }) => status === KEYCLOAK_USER_EXISTENCE.nonExist);
+
+    if (missingTenants.length) {
+      const userTenants = stripes.user?.user?.tenants || [];
+      const names = missingTenants
+        .map(({ tenantId }) => userTenants.find(t => t.id === tenantId)?.name || tenantId)
+        .join(', ');
+      setKeycloakMissingTenantNames(names);
+      setKeycloakMissingTenantCount(missingTenants.length);
+      pendingAssignmentRef.current = { added, removed };
+      setIsKeycloakConfirmationOpen(true);
+    } else {
+      await processAssignment({ added, removed });
+    }
+  }, [checkUserInKeycloakForTenant, processAssignment, stripes]);
+
+  const handleConfirmKeycloakCreation = useCallback(async () => {
+    setIsKeycloakConfirmationOpen(false);
+    await processAssignment(pendingAssignmentRef.current);
+    pendingAssignmentRef.current = null;
+  }, [processAssignment]);
+
+  const handleCancelKeycloakCreation = useCallback(() => {
+    setIsKeycloakConfirmationOpen(false);
+    pendingAssignmentRef.current = null;
+  }, []);
+
   const label = (
     <Headline size="large" tag="h3">
       <FormattedMessage id="ui-users.affiliations.section.label" />
@@ -127,16 +179,27 @@ const UserAffiliations = ({
   }, [affiliations]);
 
   return (
-    <Accordion
-      open={expanded}
-      id={accordionId}
-      onToggle={onToggle}
-      label={label}
-      displayWhenOpen={displayWhenOpen}
-      displayWhenClosed={displayWhenClosed}
-    >
-      {isLoading ? <Loading /> : affiliationsList}
-    </Accordion>
+    <>
+      <Accordion
+        open={expanded}
+        id={accordionId}
+        onToggle={onToggle}
+        label={label}
+        displayWhenOpen={displayWhenOpen}
+        displayWhenClosed={displayWhenClosed}
+      >
+        {isLoading ? <Loading /> : affiliationsList}
+      </Accordion>
+      <ConfirmationModal
+        id="affiliations-keycloak-confirmation"
+        heading={<FormattedMessage id="ui-users.keycloak.modal.confirmationHeading" />}
+        message={<FormattedMessage id="ui-users.keycloak.modal.creation" values={{ user: userName, tenants: keycloakMissingTenantNames, count: keycloakMissingTenantCount }} />}
+        onConfirm={handleConfirmKeycloakCreation}
+        onCancel={handleCancelKeycloakCreation}
+        open={isKeycloakConfirmationOpen}
+        confirmLabel={<FormattedMessage id="stripes-core.button.confirm" />}
+      />
+    </>
   );
 };
 

--- a/src/components/UserDetailSections/UserAffiliations/UserAffiliations.test.js
+++ b/src/components/UserDetailSections/UserAffiliations/UserAffiliations.test.js
@@ -11,7 +11,8 @@ import affiliations from 'fixtures/affiliations';
 import {
   useConsortiumTenants,
   useUserAffiliations,
-  useUserAffiliationsMutation
+  useUserAffiliationsMutation,
+  useCheckUserInKeycloak,
 } from '../../../hooks';
 import UserAffiliations from './UserAffiliations';
 import { getResponseErrors } from './util';
@@ -24,6 +25,7 @@ jest.mock('../../../hooks', () => ({
   useConsortiumTenants: jest.fn(),
   useUserAffiliations: jest.fn(),
   useUserAffiliationsMutation: jest.fn(),
+  useCheckUserInKeycloak: jest.fn(),
 }));
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
@@ -62,9 +64,13 @@ describe('UserAffiliations', () => {
   const handleAssignment = jest.fn(() => Promise.resolve([]));
 
   beforeEach(() => {
+    jest.clearAllMocks();
     useConsortiumTenants.mockClear().mockReturnValue({ tenants });
     useUserAffiliationsMutation.mockClear().mockReturnValue({ handleAssignment, isLoading: false });
-    useStripes.mockClear().mockReturnValue({ user: { user: { tenants } } });
+    useStripes.mockClear().mockReturnValue({ user: { user: { tenants } }, hasInterface: jest.fn(() => false) });
+    useCheckUserInKeycloak.mockClear().mockReturnValue({
+      checkUserInKeycloakForTenant: jest.fn(() => Promise.resolve('exist')),
+    });
     useUserAffiliations
       .mockClear()
       .mockReturnValue({ affiliations, totalRecords: affiliations.length, isLoading: false, handleAssignment: () => [{}], refetch: () => {} });
@@ -119,5 +125,102 @@ describe('UserAffiliations', () => {
 
     expect(handleAssignment).toHaveBeenCalled();
     expect(screen.queryByText(/saveAndClose/)).toBeNull();
+  });
+
+  describe('keycloak confirmation dialog', () => {
+    const mockCheckUserInKeycloakForTenant = jest.fn();
+    const mockHandleAssignment = jest.fn(() => Promise.resolve({ success: true, errors: [] }));
+
+    beforeEach(() => {
+      useStripes.mockReturnValue({
+        user: { user: { tenants } },
+        hasInterface: jest.fn((name) => name === 'users-keycloak'),
+      });
+      useCheckUserInKeycloak.mockReturnValue({
+        checkUserInKeycloakForTenant: mockCheckUserInKeycloakForTenant,
+      });
+      useUserAffiliationsMutation.mockReturnValue({
+        handleAssignment: mockHandleAssignment,
+        isLoading: false,
+      });
+      // Return only a subset of affiliations so some tenants appear as "unassigned"
+      // and can be toggled on to produce `added` entries.
+      useUserAffiliations.mockReturnValue({
+        affiliations: affiliations.slice(0, 1),
+        totalRecords: 1,
+        isFetching: false,
+        refetch: jest.fn(),
+      });
+    });
+
+    it('should show confirmation dialog when keycloak user does not exist for added tenant', async () => {
+      mockCheckUserInKeycloakForTenant.mockResolvedValue('nonExist');
+
+      renderUserAffiliations();
+
+      const assignButton = screen.getByText('ui-users.affiliations.section.action.edit');
+      await userEvent.click(assignButton);
+
+      // Toggle an unassigned tenant to be assigned
+      const uncheckedBoxes = await screen.findAllByRole('checkbox', {
+        name: 'ui-users.affiliations.manager.modal.aria.assign',
+        checked: false,
+      });
+      await userEvent.click(uncheckedBoxes[0]);
+
+      const saveAndCloseButton = screen.getByText(/saveAndClose/);
+      await userEvent.click(saveAndCloseButton);
+
+      expect(mockCheckUserInKeycloakForTenant).toHaveBeenCalled();
+      expect(screen.getByText('ui-users.keycloak.modal.confirmationHeading')).toBeInTheDocument();
+    });
+
+    it('should not show confirmation dialog when keycloak user exists for all added tenants', async () => {
+      mockCheckUserInKeycloakForTenant.mockResolvedValue('exist');
+
+      renderUserAffiliations();
+
+      const assignButton = screen.getByText('ui-users.affiliations.section.action.edit');
+      await userEvent.click(assignButton);
+
+      const uncheckedBoxes = await screen.findAllByRole('checkbox', {
+        name: 'ui-users.affiliations.manager.modal.aria.assign',
+        checked: false,
+      });
+      await userEvent.click(uncheckedBoxes[0]);
+
+      const saveAndCloseButton = screen.getByText(/saveAndClose/);
+      await userEvent.click(saveAndCloseButton);
+
+      expect(mockCheckUserInKeycloakForTenant).toHaveBeenCalled();
+      expect(mockHandleAssignment).toHaveBeenCalled();
+      expect(screen.queryByText('ui-users.keycloak.modal.confirmationHeading')).not.toBeInTheDocument();
+    });
+
+    it('should not check keycloak when users-keycloak interface is absent', async () => {
+      mockCheckUserInKeycloakForTenant.mockClear();
+      mockHandleAssignment.mockClear();
+      useStripes.mockClear().mockReturnValue({
+        user: { user: { tenants } },
+        hasInterface: jest.fn(() => false),
+      });
+
+      renderUserAffiliations();
+
+      const assignButton = screen.getByText('ui-users.affiliations.section.action.edit');
+      await userEvent.click(assignButton);
+
+      const uncheckedBoxes = await screen.findAllByRole('checkbox', {
+        name: 'ui-users.affiliations.manager.modal.aria.assign',
+        checked: false,
+      });
+      await userEvent.click(uncheckedBoxes[0]);
+
+      const saveAndCloseButton = screen.getByText(/saveAndClose/);
+      await userEvent.click(saveAndCloseButton);
+
+      expect(mockCheckUserInKeycloakForTenant).not.toHaveBeenCalled();
+      expect(mockHandleAssignment).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -199,7 +199,9 @@ const withUserRoles = (WrappedComponent) => (props) => {
     setAssignedRoleIds={setAssignedRoleIds}
     isCreateKeycloakUserConfirmationOpen={isCreateKeycloakUserConfirmationOpen}
     keycloakMissingTenantNames={keycloakMissingTenantNames}
+    setKeycloakMissingTenantNames={setKeycloakMissingTenantNames}
     keycloakMissingTenantCount={keycloakMissingTenantCount}
+    setKeycloakMissingTenantCount={setKeycloakMissingTenantCount}
     initialAssignedRoleIds={initialAssignedRoleIds}
     checkAndHandleKeycloakAuthUser={checkAndHandleKeycloakAuthUser}
     confirmCreateKeycloakUser={confirmCreateKeycloakUser}

--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from 'react-query';
 
 import {
@@ -9,15 +9,16 @@ import {
 } from '@folio/stripes/core';
 import isEqual from 'lodash/isEqual';
 import isEmpty from 'lodash/isEmpty';
-import { useCreateAuthUserKeycloak, useUserAffiliationRoles } from '../../hooks';
+import { useUserAffiliationRoles, useCheckUserInKeycloak } from '../../hooks';
 import {
-  KEYCLOAK_USER_EXISTANCE,
+  KEYCLOAK_USER_EXISTENCE,
   USER_AFFILIATION_ROLES_CACHE_KEY,
 } from '../../constants';
 import { showErrorCallout } from '../../views/UserEdit/UserEditHelpers';
 
 const withUserRoles = (WrappedComponent) => (props) => {
-  const { okapi } = useStripes();
+  const stripes = useStripes();
+  const { okapi } = stripes;
   const [namespace] = useNamespace({ key: USER_AFFILIATION_ROLES_CACHE_KEY });
   const queryClient = useQueryClient();
   // eslint-disable-next-line react/prop-types
@@ -27,17 +28,15 @@ const withUserRoles = (WrappedComponent) => (props) => {
   const { userRoleIds, isLoading: isLoadingAffiliationRoles } = useUserAffiliationRoles(userId, tenantId);
   const [assignedRoleIds, setAssignedRoleIds] = useState({});
   const [isCreateKeycloakUserConfirmationOpen, setIsCreateKeycloakUserConfirmationOpen] = useState(false);
+  const [keycloakMissingTenantNames, setKeycloakMissingTenantNames] = useState('');
+  const [keycloakMissingTenantCount, setKeycloakMissingTenantCount] = useState(0);
+  const tenantsWithoutKeycloakRef = useRef([]);
   const callout = useCallout();
   const sendErrorCallout = error => showErrorCallout(error, callout.sendCallout);
 
-  const { mutateAsync: createKeycloakUser } = useCreateAuthUserKeycloak(sendErrorCallout, { tenantId });
-
   const ky = useOkapiKy();
-  const api = ky.extend({
-    hooks: {
-      beforeRequest: [(req) => req.headers.set('X-Okapi-Tenant', tenantId)]
-    }
-  });
+
+  const { checkUserInKeycloakForTenant } = useCheckUserInKeycloak(userId, sendErrorCallout);
 
   useEffect(() => {
     // No need to set roles if there are empty or loading
@@ -99,58 +98,95 @@ const withUserRoles = (WrappedComponent) => (props) => {
     });
   };
 
-  const checkUserInKeycloak = async () => {
-    try {
-      await api.get(`users-keycloak/auth-users/${userId}`);
-      return KEYCLOAK_USER_EXISTANCE.exist;
-    } catch (error) {
-      if (error?.response?.status === 404) {
-        return KEYCLOAK_USER_EXISTANCE.nonExist;
+  const createKeycloakUserForTenant = async (targetTenantId) => {
+    const tenantApi = ky.extend({
+      hooks: {
+        beforeRequest: [(req) => req.headers.set('X-Okapi-Tenant', targetTenantId)]
       }
-      sendErrorCallout(error);
-      return KEYCLOAK_USER_EXISTANCE.error;
-    }
+    });
+
+    stripes.logger.log('users-keycloak', `creating keycloak record for ${userId} in tenant ${targetTenantId}`);
+    await tenantApi.post(`users-keycloak/auth-users/${userId}`);
   };
 
-  const submitCreateKeycloakUser = async () => {
-    await createKeycloakUser(userId);
+  const getTenantsWithChangedRoles = () => {
+    return Object.keys(assignedRoleIds).filter(
+      (tid) => !isEqual(assignedRoleIds[tid], initialAssignedRoleIds[tid])
+    );
   };
 
-  const handleKeycloakUserExists = async (onFinish, data) => {
-    await updateKeycloakUser(userId, data);
-
-    if (!isEqual(assignedRoleIds, initialAssignedRoleIds)) {
-      await updateUserRoles(assignedRoleIds);
-    }
-    await onFinish();
-  };
-
+  // After clicking Save&Close:
+  // 1. Check if the user record exists in Keycloak in the current/home tenant → decide save path (mod-users or mod-users-keycloak)
+  // 2. Save user data via the correct path
+  // 3. For each tenant with role changes, check if the user record exists in Keycloak
+  // 4. If any tenants are missing a Keycloak record → show confirmation dialog → on confirm, create Keycloak records for the missing tenants → save roles
+  // 5. If none missing → save roles directly
   const checkAndHandleKeycloakAuthUser = async (onFinish, data, mutator) => {
-    const userKeycloakStatus = await checkUserInKeycloak();
-    switch (userKeycloakStatus) {
-      case KEYCLOAK_USER_EXISTANCE.exist:
-        // Only save changes to mod-users-keycloak.
-        await handleKeycloakUserExists(onFinish, data);
-        break;
-      case KEYCLOAK_USER_EXISTANCE.nonExist:
-        // First, save changes to mod-users.
-        await mutator.selUser.PUT(data);
+    // 1. Check keycloak in the home tenant to determine the user data save path.
+    const homeKeycloakStatus = await checkUserInKeycloakForTenant(okapi.tenant);
 
-        // Only prompt and create Keycloak user if assigning roles.
-        // If user confirms, then changes will be copied over from mod-users to mod-users-keycloak.
-        if (!isEqual(assignedRoleIds, initialAssignedRoleIds)) {
-          setIsCreateKeycloakUserConfirmationOpen(true);
-        } else {
-          await onFinish();
-        }
-        break;
-      default:
-        break;
+    if (homeKeycloakStatus === KEYCLOAK_USER_EXISTENCE.error) return;
+
+    // 2. Save user data via the appropriate path.
+    if (homeKeycloakStatus === KEYCLOAK_USER_EXISTENCE.exist) {
+      await updateKeycloakUser(userId, data);
+    } else {
+      await mutator.selUser.PUT(data);
+    }
+
+    // 3. Find tenants where roles changed and check keycloak in each.
+    const tenantsWithChangedRoles = getTenantsWithChangedRoles();
+
+    if (!tenantsWithChangedRoles.length) {
+      await onFinish();
+      return;
+    }
+
+    // Include home tenant if it doesn't have a keycloak record
+    // and has changed roles, since role assignment requires it.
+    const tenantKeycloakStatuses = await Promise.all(
+      tenantsWithChangedRoles.map(async (tid) => {
+        // Reuse the home tenant check result to avoid a duplicate request.
+        if (tid === okapi.tenant) return { tid, status: homeKeycloakStatus };
+
+        const status = await checkUserInKeycloakForTenant(tid);
+        return { tid, status };
+      })
+    );
+
+    const missingKeycloakTenants = tenantKeycloakStatuses
+      .filter(({ status }) => status === KEYCLOAK_USER_EXISTENCE.nonExist)
+      .map(({ tid }) => tid);
+
+    if (tenantKeycloakStatuses.some(({ status }) => status === KEYCLOAK_USER_EXISTENCE.error)) return;
+
+    if (missingKeycloakTenants.length) {
+      // 4. Store which tenants need keycloak records and show the confirmation dialog.
+      tenantsWithoutKeycloakRef.current = missingKeycloakTenants;
+
+      const userTenants = stripes.user?.user?.tenants || [];
+      const names = missingKeycloakTenants
+        .map(id => userTenants.find(t => t.id === id)?.name || id)
+        .join(', ');
+      setKeycloakMissingTenantNames(names);
+      setKeycloakMissingTenantCount(missingKeycloakTenants.length);
+      setIsCreateKeycloakUserConfirmationOpen(true);
+    } else {
+      // 5. Save roles directly
+      await updateUserRoles(assignedRoleIds);
+      await onFinish();
     }
   };
 
   const confirmCreateKeycloakUser = async (onFinish) => {
-    await submitCreateKeycloakUser();
+    // Create keycloak records for all tenants that need them.
+    await Promise.all(
+      tenantsWithoutKeycloakRef.current.map((tid) => createKeycloakUserForTenant(tid).catch(sendErrorCallout))
+    );
+
+    // Invalidate cached keycloak auth-user checks used in stripes-authorization-components.
+    await queryClient.invalidateQueries(['jit-auth-role']);
+
     await updateUserRoles(assignedRoleIds);
     await onFinish();
   };
@@ -162,6 +198,8 @@ const withUserRoles = (WrappedComponent) => (props) => {
     assignedRoleIds={assignedRoleIds}
     setAssignedRoleIds={setAssignedRoleIds}
     isCreateKeycloakUserConfirmationOpen={isCreateKeycloakUserConfirmationOpen}
+    keycloakMissingTenantNames={keycloakMissingTenantNames}
+    keycloakMissingTenantCount={keycloakMissingTenantCount}
     initialAssignedRoleIds={initialAssignedRoleIds}
     checkAndHandleKeycloakAuthUser={checkAndHandleKeycloakAuthUser}
     confirmCreateKeycloakUser={confirmCreateKeycloakUser}

--- a/src/components/Wrappers/withUserRoles.test.js
+++ b/src/components/Wrappers/withUserRoles.test.js
@@ -1,10 +1,11 @@
 import { act } from 'react';
+import { useQueryClient } from 'react-query';
 
-import { cleanup, render, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import { render, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import { useStripes, useOkapiKy, useCallout } from '@folio/stripes/core';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import withUserRoles from './withUserRoles';
-import { useAllRolesData, useUserAffiliationRoles } from '../../hooks';
+import { useAllRolesData, useUserAffiliationRoles, useCheckUserInKeycloak } from '../../hooks';
 
 jest.mock('react-query', () => ({
   useQueryClient: jest.fn(() => ({ invalidateQueries: jest.fn() })),
@@ -18,11 +19,9 @@ jest.mock('@folio/stripes/core', () => ({
 }));
 
 jest.mock('../../hooks', () => ({
-  useCreateAuthUserKeycloak: jest.fn(() => ({
-    mutateAsync: jest.fn()
-  })),
   useAllRolesData: jest.fn(),
   useUserAffiliationRoles: jest.fn(),
+  useCheckUserInKeycloak: jest.fn(),
 }));
 
 const mockStripes = {
@@ -32,11 +31,25 @@ const mockStripes = {
   config: {
     maxUnpagedResourceCount: 1000,
   },
-  mutator: {
-    selUser: {
-      PUT: jest.fn().mockResolvedValue({ data: {} }),
+  logger: {
+    log: jest.fn(),
+  },
+  user: {
+    user: {
+      tenants: [
+        { id: 'consortium', name: 'Consortium' },
+        { id: 'college', name: 'College' },
+        { id: 'university', name: 'University' },
+        { id: 'school', name: 'School' },
+      ],
     },
-  }
+  },
+};
+
+const mockMutator = {
+  selUser: {
+    PUT: jest.fn().mockResolvedValue({ data: {} }),
+  },
 };
 
 const mockRolesData = {
@@ -57,53 +70,95 @@ const mockData = {
   username: 'testUser',
 };
 
+const mockApiGet = jest.fn().mockResolvedValue();
 const mockApiPut = jest.fn(() => Promise.resolve({
   json: () => Promise.resolve(),
 }));
-
-const mockKyPut = jest.fn();
+const mockApiPost = jest.fn().mockResolvedValue();
 
 const mockKy = {
-  extend: () => ({
-    get: jest.fn().mockImplementationOnce(() => ({
-      json: () => Promise.resolve({ userRoles: [{ roleId: 'role1' }, { roleId: 'role2' }] }),
-    })).mockImplementationOnce(() => Promise.resolve(true)),
+  extend: jest.fn(() => ({
+    get: mockApiGet,
     put: mockApiPut,
-  }),
-  put: mockKyPut,
+    post: mockApiPost,
+  })),
+  put: jest.fn().mockResolvedValue(),
 };
 
-const WrappedComponent = ({ assignedRoleIds,
+const mockOnFinish = jest.fn().mockResolvedValue();
+const mockCheckUserInKeycloakForTenant = jest.fn().mockResolvedValue('exist');
+const mockInvalidateQueries = jest.fn().mockResolvedValue();
+const mockSendCallout = jest.fn();
+
+const WrappedComponent = ({
+  assignedRoleIds,
   setAssignedRoleIds,
-  checkAndHandleKeycloakAuthUser, confirmCreateKeycloakUser }) => (
-    <div data-testid="assigned-role-ids">{assignedRoleIds.consortium?.join(', ')}
-      <button
-        type="submit"
-        data-testid="submit-form"
-        onClick={() => checkAndHandleKeycloakAuthUser(() => {}, mockData)}
-      >Submit
-      </button>
+  checkAndHandleKeycloakAuthUser,
+  confirmCreateKeycloakUser,
+  isCreateKeycloakUserConfirmationOpen,
+  keycloakMissingTenantNames,
+  keycloakMissingTenantCount,
+}) => (
+  <div data-testid="assigned-role-ids">{assignedRoleIds.consortium?.join(', ')}
+    <button
+      type="submit"
+      data-testid="submit-form"
+      onClick={() => checkAndHandleKeycloakAuthUser(mockOnFinish, mockData, mockMutator)}
+    >Submit
+    </button>
+    <button
+      data-testid="set-roles-for-college"
+      type="button"
+      onClick={() => setAssignedRoleIds(prev => ({
+        ...prev,
+        college: ['collegeRole1', 'collegeRole2'],
+      }))}
+    >
+      Set College Roles
+    </button>
+    <button
+      data-testid="set-roles-for-consortium"
+      type="button"
+      onClick={() => setAssignedRoleIds(prev => ({
+        ...prev,
+        consortium: ['consortiumRole1', 'consortiumRole2'],
+      }))}
+    >
+      Set Consortium Roles
+    </button>
+    <button
+      data-testid="set-roles-for-university"
+      type="button"
+      onClick={() => setAssignedRoleIds(prev => ({
+        ...prev,
+        university: ['universityRole1', 'universityRole2'],
+      }))}
+    >
+      Set University Roles
+    </button>
+    <button
+      data-testid="set-roles-for-school"
+      type="button"
+      onClick={() => setAssignedRoleIds(prev => ({
+        ...prev,
+        school: ['schoolRole1', 'schoolRole2'],
+      }))}
+    >
+      Set School Roles
+    </button>
+    <div>
+      <span data-testid="dialog-open">{String(isCreateKeycloakUserConfirmationOpen)}</span>
+      <span data-testid="missing-names">{keycloakMissingTenantNames}</span>
+      <span data-testid="missing-count">{keycloakMissingTenantCount}</span>
       <button
         type="button"
-        onClick={() => setAssignedRoleIds({
-          college: ['collegeRole1'],
-          consortium: ['role1', 'role2'],
-          university: ['universityRole1'],
-        })}
-        data-testid="assignRoles"
+        data-testid="confirm-create-keycloak-user"
+        onClick={() => confirmCreateKeycloakUser(mockOnFinish)}
       >
-        Assign roles
+        Confirm
       </button>
-      <div data-testid="confirmation-dialog">
-        <button
-          type="button"
-          data-testid="confirm-create-keycloak-user"
-          onClick={() => confirmCreateKeycloakUser(() => {
-          })}
-        >Confirm
-        </button>
-      </div>
     </div>
+  </div>
 );
 
 const CompWithUserRoles = withUserRoles(WrappedComponent);
@@ -117,15 +172,19 @@ const renderComponent = (props = {}) => render(
 );
 
 describe('withUserRoles HOC', () => {
-  afterAll(() => {
-    jest.clearAllMocks();
-    cleanup();
-  });
   beforeEach(() => {
+    jest.clearAllMocks();
     useStripes.mockReturnValue(mockStripes);
     useAllRolesData.mockReturnValue(mockRolesData);
     useUserAffiliationRoles.mockReturnValue(mockUserAffiliationRoles);
     useOkapiKy.mockReturnValue(mockKy);
+    useCheckUserInKeycloak.mockReturnValue({
+      checkUserInKeycloakForTenant: mockCheckUserInKeycloakForTenant,
+    });
+    useQueryClient.mockReturnValue({
+      invalidateQueries: mockInvalidateQueries,
+    });
+    useCallout.mockReturnValue({ sendCallout: mockSendCallout });
   });
 
   it('fetches and sets assigned role ids on mount and assignedRoleIds passed to wrapped component correctly', async () => {
@@ -134,30 +193,8 @@ describe('withUserRoles HOC', () => {
     await waitFor(() => expect(getByTestId('assigned-role-ids')).toHaveTextContent('role1, role2'));
   });
 
-  it('check keycloak user', async () => {
-    const { getByTestId } = renderComponent();
-
-    await userEvent.click(getByTestId('submit-form'));
-  });
-
-  it('submit form changing user role ids', async () => {
-    const { getByTestId } = renderComponent();
-
-    await act(() => userEvent.click(getByTestId('assignRoles')));
-    await userEvent.click(getByTestId('submit-form'));
-  });
-
-  it('submit form after changing user role ids', async () => {
-    const { getByTestId } = renderComponent();
-
-    await act(() => userEvent.click(getByTestId('assignRoles')));
-    await userEvent.click(getByTestId('confirm-create-keycloak-user'));
-  });
-
   describe('when assigning roles for other tenants', () => {
     beforeEach(async () => {
-      jest.clearAllMocks();
-
       useUserAffiliationRoles.mockReturnValue({
         userRoleIds: {
           college: [],
@@ -169,7 +206,9 @@ describe('withUserRoles HOC', () => {
 
       const { getByTestId } = renderComponent();
 
-      await act(() => userEvent.click(getByTestId('assignRoles')));
+      await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+      await act(() => userEvent.click(getByTestId('set-roles-for-university')));
+      await act(() => userEvent.click(getByTestId('set-roles-for-consortium')));
       await act(() => userEvent.click(getByTestId('submit-form')));
     });
 
@@ -177,25 +216,25 @@ describe('withUserRoles HOC', () => {
       expect(mockApiPut).toHaveBeenCalledWith('roles/users/user1', {
         json: {
           userId: 'user1',
-          roleIds: ['collegeRole1'],
+          roleIds: ['collegeRole1', 'collegeRole2'],
         },
       });
       expect(mockApiPut).toHaveBeenCalledWith('roles/users/user1', {
         json: {
           userId: 'user1',
-          roleIds: ['universityRole1'],
+          roleIds: ['universityRole1', 'universityRole2'],
         },
       });
       expect(mockApiPut).toHaveBeenCalledWith('roles/users/user1', {
         json: {
           userId: 'user1',
-          roleIds: ['role1', 'role2'],
+          roleIds: ['consortiumRole1', 'consortiumRole2'],
         },
       });
     });
 
     it('should save user data for the current tenant using `ky.put` rather than `api.put`', () => {
-      expect(mockKyPut).toHaveBeenCalledWith('users-keycloak/users/user1', {
+      expect(mockKy.put).toHaveBeenCalledWith('users-keycloak/users/user1', {
         json: mockData,
       });
     });
@@ -203,7 +242,6 @@ describe('withUserRoles HOC', () => {
 
   describe('when updateKeycloakUser fails (ky.put throws)', () => {
     const mockError = new Error('Keycloak update failed');
-    const mockSendCallout = jest.fn();
     let capturedError;
 
     // A dedicated component that captures errors thrown by checkAndHandleKeycloakAuthUser
@@ -227,13 +265,8 @@ describe('withUserRoles HOC', () => {
 
     beforeEach(() => {
       capturedError = undefined;
-
-      useCallout.mockReturnValue({ sendCallout: mockSendCallout });
       useOkapiKy.mockReturnValue({
-        extend: () => ({
-          get: jest.fn(() => Promise.resolve()),
-          put: jest.fn(),
-        }),
+        ...mockKy,
         put: jest.fn().mockRejectedValue(mockError),
       });
     });
@@ -262,6 +295,293 @@ describe('withUserRoles HOC', () => {
       });
 
       expect(mockSendCallout).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when calling checkAndHandleKeycloakAuthUser', () => {
+    it('should check if user exists in keycloak for the home/current tenant', async () => {
+      const { getByTestId } = renderComponent();
+
+      await act(() => userEvent.click(getByTestId('submit-form')));
+
+      expect(mockCheckUserInKeycloakForTenant).toHaveBeenCalledWith(mockStripes.okapi.tenant);
+    });
+
+    describe('and home tenant has keycloak record', () => {
+      it('should save the user data for the HOME! tenant using mod-users-keycloak API', async () => {
+        const checkUserInKeycloakForTenant = jest.fn().mockResolvedValueOnce('exist');
+        useCheckUserInKeycloak.mockReturnValue({
+          checkUserInKeycloakForTenant,
+        });
+
+        const { getByTestId } = renderComponent();
+
+        await act(() => userEvent.click(getByTestId('submit-form')));
+
+        expect(checkUserInKeycloakForTenant).toHaveBeenCalledWith('consortium');
+        expect(mockKy.put).toHaveBeenCalledWith('users-keycloak/users/user1', {
+          json: mockData,
+        });
+        expect(mockMutator.selUser.PUT).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('and home tenant has no keycloak record', () => {
+      it('should save the user data via mod-users API (selUser.PUT) and not mod-users-keycloak API', async () => {
+        useCheckUserInKeycloak.mockReturnValue({
+          checkUserInKeycloakForTenant: jest.fn().mockResolvedValueOnce('nonExist'),
+        });
+
+        const { getByTestId } = renderComponent();
+
+        await act(() => userEvent.click(getByTestId('submit-form')));
+
+        expect(mockMutator.selUser.PUT).toHaveBeenCalledWith(mockData);
+        expect(mockKy.put).not.toHaveBeenCalledWith('users-keycloak/users/user1', expect.anything());
+      });
+    });
+
+    describe('and no roles have changed', () => {
+      it('should call onFinish directly without checking keycloak for non-home tenants or saving roles', async () => {
+        const { getByTestId } = renderComponent();
+
+        await act(() => userEvent.click(getByTestId('submit-form')));
+
+        expect(mockCheckUserInKeycloakForTenant).toHaveBeenCalledWith('consortium');
+        expect(mockOnFinish).toHaveBeenCalled();
+        expect(mockCheckUserInKeycloakForTenant).not.toHaveBeenCalledWith('college');
+      });
+    });
+
+    describe('and there are roles changes', () => {
+      it('should check keycloak record existence for each tenant with changed roles', async () => {
+        const { getByTestId } = renderComponent();
+
+        await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+        await act(() => userEvent.click(getByTestId('set-roles-for-consortium')));
+        await act(() => userEvent.click(getByTestId('set-roles-for-school')));
+
+        await act(() => userEvent.click(getByTestId('submit-form')));
+
+        // Home (consortium) tenant is always checked first to determine the save path,
+        expect(mockCheckUserInKeycloakForTenant).toHaveBeenCalledWith('consortium');
+
+        // then only the tenants with changed roles are checked.
+        expect(mockCheckUserInKeycloakForTenant).toHaveBeenCalledWith('college');
+        expect(mockCheckUserInKeycloakForTenant).not.toHaveBeenCalledWith('university');
+        expect(mockCheckUserInKeycloakForTenant).toHaveBeenCalledWith('school');
+      });
+
+      describe('and keycloak user does not exist for any tenant with changed roles', () => {
+        it('should show confirmation dialog', async () => {
+          useCheckUserInKeycloak.mockReturnValue({
+            checkUserInKeycloakForTenant: jest.fn()
+              .mockResolvedValueOnce('exist') // home tenant has a record
+              .mockResolvedValue('nonExist'), // all other tenants with changed roles do not have records
+          });
+
+          const { getByTestId } = renderComponent();
+
+          await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+          await act(() => userEvent.click(getByTestId('submit-form')));
+
+          expect(getByTestId('dialog-open')).toHaveTextContent('true');
+        });
+
+        it('should list the tenant names in the confirmation dialog', async () => {
+          useCheckUserInKeycloak.mockReturnValue({
+            checkUserInKeycloakForTenant: jest.fn()
+              .mockResolvedValueOnce('nonExist') // home/Consortium tenant doesn't have a record
+              .mockResolvedValueOnce('exist') // College tenant has a record
+              .mockResolvedValueOnce('nonExist') // University tenant doesn't have a record
+              .mockResolvedValueOnce('exist'), // School tenant has a record
+          });
+
+          const { getByTestId } = renderComponent();
+
+          await act(() => userEvent.click(getByTestId('set-roles-for-consortium')));
+          await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+          await act(() => userEvent.click(getByTestId('set-roles-for-university')));
+          await act(() => userEvent.click(getByTestId('set-roles-for-school')));
+
+          await act(() => userEvent.click(getByTestId('submit-form')));
+
+          expect(getByTestId('missing-names')).toHaveTextContent('Consortium, University');
+          expect(getByTestId('missing-count')).toHaveTextContent('2');
+        });
+      });
+
+      describe('and keycloak user exists for all tenants with changed roles', () => {
+        it('should save roles and call onFinish without showing confirmation dialog', async () => {
+          const checkUserInKeycloakForTenant = jest.fn().mockResolvedValue('exist');
+          useCheckUserInKeycloak.mockReturnValue({
+            checkUserInKeycloakForTenant,
+          });
+
+          const { getByTestId } = renderComponent();
+
+          await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+          await act(() => userEvent.click(getByTestId('set-roles-for-university')));
+          await act(() => userEvent.click(getByTestId('submit-form')));
+
+          expect(checkUserInKeycloakForTenant).toHaveBeenCalledWith('college');
+          expect(checkUserInKeycloakForTenant).toHaveBeenCalledWith('university');
+          expect(mockOnFinish).toHaveBeenCalled();
+          expect(getByTestId('dialog-open')).toHaveTextContent('false');
+        });
+      });
+
+      describe('and there is an error checking keycloak for any tenant', () => {
+        it('should not proceed with saving roles', async () => {
+          const checkUserInKeycloakForTenant = jest.fn()
+            .mockResolvedValueOnce('exist') // home tenant has a record
+            .mockResolvedValueOnce('error'); // error occurs for a tenant with changed roles
+
+          useCheckUserInKeycloak.mockReturnValue({
+            checkUserInKeycloakForTenant,
+          });
+
+          const { getByTestId } = renderComponent();
+
+          await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+          await act(() => userEvent.click(getByTestId('submit-form')));
+
+          expect(checkUserInKeycloakForTenant).toHaveBeenCalledWith('college');
+          expect(mockApiPut).not.toHaveBeenCalledWith('roles/users/user1', expect.anything());
+          expect(mockOnFinish).not.toHaveBeenCalled();
+          expect(getByTestId('dialog-open')).toHaveTextContent('false');
+        });
+      });
+    });
+  });
+
+  describe('confirmation dialog', () => {
+    describe('when confirming creation of keycloak user for tenants missing keycloak records', () => {
+      it('should create keycloak users for the missing tenants', async () => {
+        useCheckUserInKeycloak.mockReturnValue({
+          checkUserInKeycloakForTenant: jest.fn()
+            .mockResolvedValueOnce('nonExist') // home/Consortium tenant doesn't have a record
+            .mockResolvedValueOnce('exist') // College tenant has a record
+            .mockResolvedValueOnce('nonExist') // University tenant doesn't have a record
+            .mockResolvedValueOnce('exist'), // School tenant has a record
+        });
+
+        const { getByTestId } = renderComponent();
+
+        await act(() => userEvent.click(getByTestId('set-roles-for-consortium')));
+        await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+        await act(() => userEvent.click(getByTestId('set-roles-for-university')));
+        await act(() => userEvent.click(getByTestId('set-roles-for-school')));
+
+        await act(() => userEvent.click(getByTestId('submit-form')));
+
+        expect(getByTestId('dialog-open')).toHaveTextContent('true');
+
+        await act(() => userEvent.click(getByTestId('confirm-create-keycloak-user')));
+
+        expect(mockApiPost).toHaveBeenCalledWith('users-keycloak/auth-users/user1');
+        // For consortium and university tenants which are missing keycloak records
+        expect(mockApiPost).toHaveBeenCalledTimes(2);
+        expect(mockKy.extend).toHaveBeenCalledWith({
+          hooks: {
+            beforeRequest: [expect.any(Function)],
+          },
+        });
+      });
+
+      it('should invalidate queries', async () => {
+        useCheckUserInKeycloak.mockReturnValue({
+          checkUserInKeycloakForTenant: jest.fn()
+            .mockResolvedValueOnce('nonExist') // home/Consortium tenant doesn't have a record
+        });
+
+        const { getByTestId } = renderComponent();
+
+        await act(() => userEvent.click(getByTestId('set-roles-for-consortium')));
+        await act(() => userEvent.click(getByTestId('submit-form')));
+
+        expect(getByTestId('dialog-open')).toHaveTextContent('true');
+
+        await act(() => userEvent.click(getByTestId('confirm-create-keycloak-user')));
+
+        expect(mockInvalidateQueries).toHaveBeenCalledWith(['jit-auth-role']);
+      });
+
+      it('should update the user roles after creating keycloak users', async () => {
+        useCheckUserInKeycloak.mockReturnValue({
+          checkUserInKeycloakForTenant: jest.fn()
+            .mockResolvedValueOnce('nonExist') // home/Consortium tenant doesn't have a record
+            .mockResolvedValueOnce('exist') // College tenant has a record
+            .mockResolvedValueOnce('nonExist') // University tenant doesn't have a record
+            .mockResolvedValueOnce('exist'), // School tenant has a record
+        });
+
+        const { getByTestId } = renderComponent();
+
+        await act(() => userEvent.click(getByTestId('set-roles-for-consortium')));
+        await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+        await act(() => userEvent.click(getByTestId('set-roles-for-university')));
+        await act(() => userEvent.click(getByTestId('set-roles-for-school')));
+
+        await act(() => userEvent.click(getByTestId('submit-form')));
+
+        expect(getByTestId('dialog-open')).toHaveTextContent('true');
+
+        await act(() => userEvent.click(getByTestId('confirm-create-keycloak-user')));
+
+        expect(mockApiPut).toHaveBeenCalledWith('roles/users/user1', expect.anything());
+        expect(mockApiPut).toHaveBeenCalledTimes(4);
+      });
+
+      it('should call onFinish', async () => {
+        useCheckUserInKeycloak.mockReturnValue({
+          checkUserInKeycloakForTenant: jest.fn()
+            .mockResolvedValueOnce('nonExist') // home/Consortium tenant doesn't have a record
+        });
+
+        const { getByTestId } = renderComponent();
+
+        await act(() => userEvent.click(getByTestId('set-roles-for-consortium')));
+        await act(() => userEvent.click(getByTestId('submit-form')));
+
+        expect(getByTestId('dialog-open')).toHaveTextContent('true');
+
+        await act(() => userEvent.click(getByTestId('confirm-create-keycloak-user')));
+
+        expect(mockOnFinish).toHaveBeenCalled();
+      });
+
+      describe('creation fails for any tenant', () => {
+        it('should call sendCallout with error message', async () => {
+          const post = jest.fn().mockRejectedValue('Keycloak user creation failed');
+
+          useOkapiKy.mockReturnValue({
+            ...mockKy,
+            extend: jest.fn(() => ({
+              get: mockApiGet,
+              put: mockApiPut,
+              post,
+            })),
+          });
+
+          useCheckUserInKeycloak.mockReturnValue({
+            checkUserInKeycloakForTenant: jest.fn()
+              .mockResolvedValueOnce('nonExist') // home/Consortium tenant doesn't have a record
+          });
+
+          const { getByTestId } = renderComponent();
+
+          await act(() => userEvent.click(getByTestId('set-roles-for-consortium')));
+          await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+          await act(() => userEvent.click(getByTestId('submit-form')));
+
+          expect(getByTestId('dialog-open')).toHaveTextContent('true');
+
+          await act(() => userEvent.click(getByTestId('confirm-create-keycloak-user')));
+
+          expect(mockSendCallout).toHaveBeenCalled();
+        });
+      });
     });
   });
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -395,7 +395,7 @@ export const USER_FIELDS_TO_CHECK = [USER_INFO.FIRST_NAME, USER_INFO.MIDDLE_NAME
 
 export const PATRON_PREREGISTRATION_RECORDS_NAME = 'patronPreRegistrationRecords';
 
-export const KEYCLOAK_USER_EXISTANCE = {
+export const KEYCLOAK_USER_EXISTENCE = {
   exist: 'exist',
   nonExist: 'nonExist',
   error: 'error',

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -10,6 +10,7 @@ export { default as useLocalizedCurrency } from './useLocalizedCurrency';
 export { default as useNumberGeneratorOptions } from './useNumberGeneratorOptions';
 export { default as useAllRolesData } from './useAllRolesData';
 export { default as useCreateAuthUserKeycloak } from './useCreateAuthUserKeycloak';
+export { default as useCheckUserInKeycloak } from './useCheckUserInKeycloak';
 export { default as usePatronGroups } from './usePatronGroups';
 export { default as useStagingUserMutation } from './useStagingUserMutation';
 export { default as useStagingUsersQuery } from './useStagingUsersQuery';

--- a/src/hooks/useCheckUserInKeycloak/index.js
+++ b/src/hooks/useCheckUserInKeycloak/index.js
@@ -1,0 +1,1 @@
+export { default } from './useCheckUserInKeycloak';

--- a/src/hooks/useCheckUserInKeycloak/useCheckUserInKeycloak.js
+++ b/src/hooks/useCheckUserInKeycloak/useCheckUserInKeycloak.js
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { KEYCLOAK_USER_EXISTENCE } from '../../constants';
+
+const useCheckUserInKeycloak = (userId, handleError) => {
+  const ky = useOkapiKy();
+
+  const checkUserInKeycloakForTenant = useCallback(async (targetTenantId) => {
+    const tenantApi = ky.extend({
+      hooks: {
+        beforeRequest: [(req) => req.headers.set('X-Okapi-Tenant', targetTenantId)]
+      }
+    });
+
+    try {
+      await tenantApi.get(`users-keycloak/auth-users/${userId}`);
+      return KEYCLOAK_USER_EXISTENCE.exist;
+    } catch (error) {
+      if (error?.response?.status === 404) {
+        return KEYCLOAK_USER_EXISTENCE.nonExist;
+      }
+      handleError?.(error);
+      return KEYCLOAK_USER_EXISTENCE.error;
+    }
+  }, [ky, userId, handleError]);
+
+  return { checkUserInKeycloakForTenant };
+};
+
+export default useCheckUserInKeycloak;

--- a/src/hooks/useCheckUserInKeycloak/useCheckUserInKeycloak.test.js
+++ b/src/hooks/useCheckUserInKeycloak/useCheckUserInKeycloak.test.js
@@ -1,0 +1,101 @@
+import { renderHook, act } from '@folio/jest-config-stripes/testing-library/react';
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { KEYCLOAK_USER_EXISTENCE } from '../../constants';
+import useCheckUserInKeycloak from './useCheckUserInKeycloak';
+
+describe('useCheckUserInKeycloak', () => {
+  const userId = 'test-user-id';
+  const tenantId = 'test-tenant';
+  let mockGet;
+  let mockExtend;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const setupMocks = (getMock) => {
+    mockGet = getMock;
+    mockExtend = jest.fn(() => ({ get: mockGet }));
+    useOkapiKy.mockReturnValue({ extend: mockExtend });
+  };
+
+  it('should return "exist" when keycloak user exists', async () => {
+    setupMocks(jest.fn(() => Promise.resolve()));
+
+    const { result } = renderHook(() => useCheckUserInKeycloak(userId));
+    let status;
+
+    await act(async () => {
+      status = await result.current.checkUserInKeycloakForTenant(tenantId);
+    });
+
+    expect(status).toBe(KEYCLOAK_USER_EXISTENCE.exist);
+    expect(mockExtend).toHaveBeenCalledWith({
+      hooks: {
+        beforeRequest: [expect.any(Function)],
+      },
+    });
+    expect(mockGet).toHaveBeenCalledWith(`users-keycloak/auth-users/${userId}`);
+  });
+
+  it('should return nonExist when keycloak user is not found (404)', async () => {
+    setupMocks(jest.fn().mockRejectedValue({ response: { status: 404 } }));
+
+    const { result } = renderHook(() => useCheckUserInKeycloak(userId));
+    let status;
+
+    await act(async () => {
+      status = await result.current.checkUserInKeycloakForTenant(tenantId);
+    });
+
+    expect(status).toBe(KEYCLOAK_USER_EXISTENCE.nonExist);
+  });
+
+  it('should return "error" and call handleError for non-404 errors', async () => {
+    const error = { response: { status: 500 } };
+    setupMocks(jest.fn().mockRejectedValue(error));
+    const handleError = jest.fn();
+
+    const { result } = renderHook(() => useCheckUserInKeycloak(userId, handleError));
+    let status;
+
+    await act(async () => {
+      status = await result.current.checkUserInKeycloakForTenant(tenantId);
+    });
+
+    expect(status).toBe(KEYCLOAK_USER_EXISTENCE.error);
+    expect(handleError).toHaveBeenCalledWith(error);
+  });
+
+  it('should return "error" without crashing when handleError is not provided', async () => {
+    const error = { response: { status: 500 } };
+    setupMocks(jest.fn().mockRejectedValue(error));
+
+    const { result } = renderHook(() => useCheckUserInKeycloak(userId));
+    let status;
+
+    await act(async () => {
+      status = await result.current.checkUserInKeycloakForTenant(tenantId);
+    });
+
+    expect(status).toBe(KEYCLOAK_USER_EXISTENCE.error);
+  });
+
+  it('should set X-Okapi-Tenant header for the target tenant', async () => {
+    setupMocks(jest.fn().mockResolvedValue());
+
+    const { result } = renderHook(() => useCheckUserInKeycloak(userId));
+
+    await act(async () => {
+      await result.current.checkUserInKeycloakForTenant(tenantId);
+    });
+
+    const extendArg = mockExtend.mock.calls[0][0];
+    const beforeRequestHook = extendArg.hooks.beforeRequest[0];
+    const mockReq = { headers: { set: jest.fn() } };
+    beforeRequestHook(mockReq);
+
+    expect(mockReq.headers.set).toHaveBeenCalledWith('X-Okapi-Tenant', tenantId);
+  });
+});

--- a/src/views/UserDetail/UserDetail.js
+++ b/src/views/UserDetail/UserDetail.js
@@ -839,6 +839,7 @@ class UserDetail extends React.Component {
                           onToggle={this.handleSectionToggle}
                           userId={user?.id}
                           userName={user?.username}
+                          user={user}
                         />
                       )
                     }

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -63,6 +63,8 @@ class UserEdit extends React.Component {
     isCreateKeycloakUserConfirmationOpen: PropTypes.bool,
     initialAssignedRoleIds: PropTypes.object,
     isLoadingAffiliationRoles: PropTypes.bool.isRequired,
+    keycloakMissingTenantNames: PropTypes.string,
+    keycloakMissingTenantCount: PropTypes.number,
     checkAndHandleKeycloakAuthUser: PropTypes.func,
     confirmCreateKeycloakUser: PropTypes.func,
     setIsCreateKeycloakUserConfirmationOpen: PropTypes.func.isRequired,
@@ -531,6 +533,8 @@ class UserEdit extends React.Component {
       tenantId,
       setAssignedRoleIds,
       isLoadingAffiliationRoles,
+      keycloakMissingTenantNames,
+      keycloakMissingTenantCount,
       assignedRoleIds
     } = this.props;
     const { isLoading } = this.state;
@@ -575,6 +579,8 @@ class UserEdit extends React.Component {
         setAssignedRoleIds={setAssignedRoleIds}
         assignedRoleIds={assignedRoleIds}
         isLoadingAffiliationRoles={isLoadingAffiliationRoles}
+        keycloakMissingTenantNames={keycloakMissingTenantNames}
+        keycloakMissingTenantCount={keycloakMissingTenantCount}
       />
     );
   }

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -287,7 +287,6 @@ class UserEdit extends React.Component {
     } = this.props;
     const isMemberTenant = checkIfUserInMemberTenant(stripes);
     const centralTenantId = getCentralTenantId(stripes);
-    // const isMemberTenant = centralTenantId && centralTenantId !== stripes.okapi.tenant;
 
     if (isMemberTenant && stripes.hasInterface('users-keycloak')) {
       this.pendingCreateRecord = record;

--- a/src/views/UserEdit/UserEdit.js
+++ b/src/views/UserEdit/UserEdit.js
@@ -18,10 +18,14 @@ import {
 import {
   CalloutContext,
   withOkapiKy,
+  checkIfUserInMemberTenant,
 } from '@folio/stripes/core';
 
 import { getProfilePictureConfig } from '../../utils';
-import { getRecordObject } from '../../components/util';
+import {
+  getRecordObject,
+  getCentralTenantId,
+} from '../../components/util';
 
 import UserForm from './UserForm';
 import { toUserAddresses, getFormAddressList } from '../../components/data/converters/address';
@@ -64,7 +68,9 @@ class UserEdit extends React.Component {
     initialAssignedRoleIds: PropTypes.object,
     isLoadingAffiliationRoles: PropTypes.bool.isRequired,
     keycloakMissingTenantNames: PropTypes.string,
+    setKeycloakMissingTenantNames: PropTypes.func,
     keycloakMissingTenantCount: PropTypes.number,
+    setKeycloakMissingTenantCount: PropTypes.func,
     checkAndHandleKeycloakAuthUser: PropTypes.func,
     confirmCreateKeycloakUser: PropTypes.func,
     setIsCreateKeycloakUserConfirmationOpen: PropTypes.func.isRequired,
@@ -91,6 +97,7 @@ class UserEdit extends React.Component {
   }
 
   updateSP = null;
+  pendingCreateRecord = null;
 
   getUser() {
     const { resources, match: { params: { id } } } = this.props;
@@ -246,7 +253,7 @@ class UserEdit extends React.Component {
     return departments.map(({ value }) => value);
   }
 
-  create = ({ requestPreferences, ...userFormData }) => {
+  performCreate = ({ requestPreferences, ...userFormData }) => {
     const { mutator, history, location: { search }, stripes } = this.props;
     const userData = cloneDeep(userFormData);
     const user = { ...userData, id: uuidv4() };
@@ -269,6 +276,44 @@ class UserEdit extends React.Component {
       .then(() => {
         history.push(`/users/preview/${user.id}${search}`);
       }).catch((e) => showErrorCallout(e, this.context.sendCallout));
+  }
+
+  create = (record) => {
+    const {
+      stripes,
+      setIsCreateKeycloakUserConfirmationOpen,
+      setKeycloakMissingTenantNames,
+      setKeycloakMissingTenantCount,
+    } = this.props;
+    const isMemberTenant = checkIfUserInMemberTenant(stripes);
+    const centralTenantId = getCentralTenantId(stripes);
+    // const isMemberTenant = centralTenantId && centralTenantId !== stripes.okapi.tenant;
+
+    if (isMemberTenant && stripes.hasInterface('users-keycloak')) {
+      this.pendingCreateRecord = record;
+      const centralTenantName = stripes.user?.user?.tenants?.find(t => t.id === centralTenantId)?.name || centralTenantId;
+      setKeycloakMissingTenantNames(centralTenantName);
+      setKeycloakMissingTenantCount(1);
+      setIsCreateKeycloakUserConfirmationOpen(true);
+      return undefined;
+    }
+
+    return this.performCreate(record);
+  }
+
+  handleConfirmKeycloakCreate = () => {
+    const { setIsCreateKeycloakUserConfirmationOpen } = this.props;
+
+    setIsCreateKeycloakUserConfirmationOpen(false);
+    this.performCreate(this.pendingCreateRecord);
+    this.pendingCreateRecord = null;
+  }
+
+  handleCancelKeycloakCreate = () => {
+    const { setIsCreateKeycloakUserConfirmationOpen } = this.props;
+
+    setIsCreateKeycloakUserConfirmationOpen(false);
+    this.pendingCreateRecord = null;
   }
 
   formatCustomFieldsPayload(customFields) {
@@ -556,7 +601,11 @@ class UserEdit extends React.Component {
 
     // data is information that the form needs, mostly to populate options lists
     const formData = this.getUserFormData();
-    const onSubmit = params.id ? (record) => this.update(record) : (record) => this.create(record);
+    const isCreating = !params.id;
+
+    const onSubmit = isCreating
+      ? (record) => this.create(record)
+      : (record) => this.update(record);
 
     return (
       <UserForm
@@ -572,8 +621,8 @@ class UserEdit extends React.Component {
         stripes={this.props.stripes}
         profilePictureConfig={profilePictureConfig}
         isCreateKeycloakUserConfirmationOpen={isCreateKeycloakUserConfirmationOpen}
-        onCancelKeycloakConfirmation={this.afterUpdate}
-        confirmCreateKeycloakUser={() => this.props.confirmCreateKeycloakUser(this.afterUpdate)}
+        onCancelKeycloakConfirmation={isCreating ? this.handleCancelKeycloakCreate : this.afterUpdate}
+        confirmCreateKeycloakUser={isCreating ? this.handleConfirmKeycloakCreate : () => this.props.confirmCreateKeycloakUser(this.afterUpdate)}
         setTenantId={setTenantId}
         tenantId={tenantId}
         setAssignedRoleIds={setAssignedRoleIds}

--- a/src/views/UserEdit/UserEdit.test.js
+++ b/src/views/UserEdit/UserEdit.test.js
@@ -488,6 +488,10 @@ describe('UserEdit', () => {
           selUser: { records: [] }
         },
         match: { params: { id: '' } },
+        stripes: {
+          ...props.stripes,
+          hasInterface: jest.fn().mockReturnValue(false),
+        },
       });
 
       const submitButton = container.querySelector('#clickable-save');
@@ -865,6 +869,8 @@ describe('UserEdit', () => {
       onCancelKeycloakConfirmation: jest.fn(),
       confirmCreateKeycloakUser: jest.fn(),
       setIsCreateKeycloakUserConfirmationOpen: jest.fn(),
+      setKeycloakMissingTenantNames: jest.fn(),
+      setKeycloakMissingTenantCount: jest.fn(),
     };
 
     it('cancel confirmation', async () => {
@@ -1026,6 +1032,125 @@ describe('UserEdit', () => {
 
         expect(historyPush).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('Keycloak confirmation modal on user creation (member tenant)', () => {
+    const createProps = {
+      ...props,
+      stripes: {
+        ...props.stripes,
+        okapi: { tenant: 'memberTenantId' },
+        hasInterface: jest.fn((name) => ['users-keycloak', 'roles', 'consortia'].includes(name)),
+        user: {
+          user: {
+            id: 'current-user-id',
+            consortium: { centralTenantId: 'centralTenantId' },
+            tenants: [
+              { id: 'centralTenantId', name: 'Central' },
+              { id: 'memberTenantId', name: 'Member' },
+            ],
+          },
+        },
+      },
+      resources: {
+        ...props.resources,
+        selUser: { records: [], isPending: false },
+      },
+      history: { push: jest.fn() },
+      location: { search: '', pathname: '/users/create' },
+      match: { params: {} },
+      setKeycloakMissingTenantNames: jest.fn(),
+      setKeycloakMissingTenantCount: jest.fn(),
+    };
+
+    it('should show keycloak confirmation dialog when creating user on member tenant', async () => {
+      const { container } = await renderUserEdit(createProps);
+      const submitButton = container.querySelector('#clickable-save');
+      await userEvent.click(submitButton);
+
+      expect(createProps.setKeycloakMissingTenantNames).toHaveBeenCalledWith('Central');
+      expect(createProps.setKeycloakMissingTenantCount).toHaveBeenCalledWith(1);
+      expect(createProps.setIsCreateKeycloakUserConfirmationOpen).toHaveBeenCalledWith(true);
+      expect(createProps.mutator.records.POST).not.toHaveBeenCalled();
+    });
+
+    it('should proceed with user creation when confirmation is accepted', async () => {
+      UserForm.mockImplementation(({ onSubmit, confirmCreateKeycloakUser }) => (
+        <>
+          <button type="button" id="clickable-save" onClick={() => onSubmit(userFormData)}>
+            Submit Form
+          </button>
+          <button type="button" id="submit-confirmation" onClick={confirmCreateKeycloakUser}>
+            Confirm
+          </button>
+        </>
+      ));
+
+      const { container } = await renderUserEdit(createProps);
+      await userEvent.click(container.querySelector('#clickable-save'));
+
+      expect(createProps.mutator.records.POST).not.toHaveBeenCalled();
+
+      await userEvent.click(container.querySelector('#submit-confirmation'));
+
+      expect(createProps.setIsCreateKeycloakUserConfirmationOpen).toHaveBeenCalledWith(false);
+      expect(createProps.mutator.records.POST).toHaveBeenCalled();
+    });
+
+    it('should not create user when confirmation is cancelled', async () => {
+      UserForm.mockImplementation(({ onSubmit, onCancelKeycloakConfirmation }) => (
+        <>
+          <button type="button" id="clickable-save" onClick={() => onSubmit(userFormData)}>
+            Submit Form
+          </button>
+          <button type="button" id="cancel-confirmation" onClick={onCancelKeycloakConfirmation}>
+            Cancel
+          </button>
+        </>
+      ));
+
+      const { container } = await renderUserEdit(createProps);
+      await userEvent.click(container.querySelector('#clickable-save'));
+      await userEvent.click(container.querySelector('#cancel-confirmation'));
+
+      expect(createProps.setIsCreateKeycloakUserConfirmationOpen).toHaveBeenCalledWith(false);
+      expect(createProps.mutator.records.POST).not.toHaveBeenCalled();
+      expect(createProps.history.push).not.toHaveBeenCalled();
+    });
+
+    it('should skip keycloak dialog when creating user on central tenant', async () => {
+      const centralProps = {
+        ...createProps,
+        stripes: {
+          ...createProps.stripes,
+          okapi: { tenant: 'centralTenantId' },
+        },
+      };
+
+      const { container } = await renderUserEdit(centralProps);
+      const submitButton = container.querySelector('#clickable-save');
+      await userEvent.click(submitButton);
+
+      expect(centralProps.setIsCreateKeycloakUserConfirmationOpen).not.toHaveBeenCalled();
+      expect(centralProps.mutator.records.POST).toHaveBeenCalled();
+    });
+
+    it('should skip keycloak dialog when users-keycloak interface is not available', async () => {
+      const noKeycloakProps = {
+        ...createProps,
+        stripes: {
+          ...createProps.stripes,
+          hasInterface: jest.fn().mockReturnValue(false),
+        },
+      };
+
+      const { container } = await renderUserEdit(noKeycloakProps);
+      const submitButton = container.querySelector('#clickable-save');
+      await userEvent.click(submitButton);
+
+      expect(noKeycloakProps.setIsCreateKeycloakUserConfirmationOpen).not.toHaveBeenCalled();
+      expect(noKeycloakProps.mutator.records.POST).toHaveBeenCalled();
     });
   });
 });

--- a/src/views/UserEdit/UserEdit.test.js
+++ b/src/views/UserEdit/UserEdit.test.js
@@ -7,7 +7,7 @@ import renderWithRouter from '../../../test/jest/helpers/renderWithRouter';
 import UserEdit from './UserEdit';
 import UserForm from './UserForm';
 
-import { KEYCLOAK_USER_EXISTANCE } from '../../constants';
+import { KEYCLOAK_USER_EXISTENCE } from '../../constants';
 
 const userFormData = {
   departments: [{
@@ -925,7 +925,7 @@ describe('UserEdit', () => {
         const alteredProps = { ...defaultProps,
           submitCreateKeycloakUser: mockSubmitCreateKeycloakUser,
           updateUserRoles: mockUpdateRoles,
-          checkUserInKeycloak: jest.fn().mockReturnValue(KEYCLOAK_USER_EXISTANCE.exist),
+          checkUserInKeycloak: jest.fn().mockReturnValue(KEYCLOAK_USER_EXISTENCE.exist),
           assignedRoleIds: { 1: true, 2: true, 3: true } };
 
         const { container } = renderWithRouter(<UserEdit {...alteredProps} />);

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -551,7 +551,7 @@ class UserForm extends React.Component {
             <ConfirmationModal
               id="JIT-user"
               heading={<FormattedMessage id="ui-users.keycloak.modal.confirmationHeading" />}
-              message={<FormattedMessage id="ui-users.keycloak.modal.creation" values={{ user:getFullName(form.getState().values), tenants: keycloakMissingTenantNames, count: keycloakMissingTenantCount }} />}
+              message={<FormattedMessage id="ui-users.keycloak.modal.creationMessage" values={{ user:getFullName(form.getState().values), tenants: keycloakMissingTenantNames, count: keycloakMissingTenantCount }} />}
               onConfirm={this.handleConfirmCreateKeycloakUser}
               onCancel={onCancelKeycloakConfirmation}
               open={isCreateKeycloakUserConfirmationOpen}

--- a/src/views/UserEdit/UserForm.js
+++ b/src/views/UserEdit/UserForm.js
@@ -125,6 +125,8 @@ class UserForm extends React.Component {
     intl: PropTypes.object,
     profilePictureConfig: PropTypes.object,
     isCreateKeycloakUserConfirmationOpen: PropTypes.bool,
+    keycloakMissingTenantNames: PropTypes.string,
+    keycloakMissingTenantCount: PropTypes.number,
     isLoadingAffiliationRoles: PropTypes.bool.isRequired,
     onCancelKeycloakConfirmation: PropTypes.func,
     confirmCreateKeycloakUser: PropTypes.func,
@@ -353,6 +355,8 @@ class UserForm extends React.Component {
       uniquenessValidator,
       profilePictureConfig,
       isCreateKeycloakUserConfirmationOpen,
+      keycloakMissingTenantNames,
+      keycloakMissingTenantCount,
       isLoadingAffiliationRoles,
       onCancelKeycloakConfirmation
     } = this.props;
@@ -547,7 +551,7 @@ class UserForm extends React.Component {
             <ConfirmationModal
               id="JIT-user"
               heading={<FormattedMessage id="ui-users.keycloak.modal.confirmationHeading" />}
-              message={<FormattedMessage id="ui-users.keycloak.modal.creation" values={{ user:getFullName(form.getState().values) }} />}
+              message={<FormattedMessage id="ui-users.keycloak.modal.creation" values={{ user:getFullName(form.getState().values), tenants: keycloakMissingTenantNames, count: keycloakMissingTenantCount }} />}
               onConfirm={this.handleConfirmCreateKeycloakUser}
               onCancel={onCancelKeycloakConfirmation}
               open={isCreateKeycloakUserConfirmationOpen}

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -1258,7 +1258,7 @@
   "stagingRecords.minor.yes": "Yes",
   "stagingUser.createUser": "FOLIO user record <b>{name}</b> has been successfully created.",
   "keycloak.modal.confirmationHeading": "Keycloak user record",
-  "keycloak.modal.creation": "This operation will create new record in Keycloak for <b>{user}</b>",
+  "keycloak.modal.creation": "This operation will create a new record in Keycloak for <b>{user}</b> in {count, plural, one {the <b>{tenants}</b> tenant} other {the following tenants: <b>{tenants}</b>}}.",
 
   "title.patronBlock.create": "Users - Create a new patron block",
   "title.patronBlock.edit": "Users - Edit a patron block",

--- a/translations/ui-users/en.json
+++ b/translations/ui-users/en.json
@@ -1258,7 +1258,7 @@
   "stagingRecords.minor.yes": "Yes",
   "stagingUser.createUser": "FOLIO user record <b>{name}</b> has been successfully created.",
   "keycloak.modal.confirmationHeading": "Keycloak user record",
-  "keycloak.modal.creation": "This operation will create a new record in Keycloak for <b>{user}</b> in {count, plural, one {the <b>{tenants}</b> tenant} other {the following tenants: <b>{tenants}</b>}}.",
+  "keycloak.modal.creationMessage": "This operation will create a new record in Keycloak for <b>{user}</b> in {count, plural, one {the <b>{tenants}</b> tenant} other {the following tenants: <b>{tenants}</b>}}.",
 
   "title.patronBlock.create": "Users - Create a new patron block",
   "title.patronBlock.edit": "Users - Edit a patron block",

--- a/translations/ui-users/en_US.json
+++ b/translations/ui-users/en_US.json
@@ -1191,7 +1191,7 @@
     "permission.patron-pre-registrations.execute": "Users: Can merge patron preregistration data",
     "permission.patron-pre-registrations.view": "Users: Can view patron pre-registration data",
     "keycloak.modal.confirmationHeading": "Keycloak user record",
-    "keycloak.modal.creation": "This operation will create new record in Keycloak for <b>{user}</b>",
+    "keycloak.modal.creation": "This operation will create a new record in Keycloak for <b>{user}</b> in {count, plural, one {the <b>{tenants}</b> tenant} other {the following tenants: <b>{tenants}</b>}}.",
     "stagingRecords.merge": "Merge",
     "permission.reading-room-access.view": "Users: Can view reading room access",
     "permission.reading-room-access.edit": "Users: Can view, and edit reading room access",

--- a/translations/ui-users/en_US.json
+++ b/translations/ui-users/en_US.json
@@ -1191,7 +1191,7 @@
     "permission.patron-pre-registrations.execute": "Users: Can merge patron preregistration data",
     "permission.patron-pre-registrations.view": "Users: Can view patron pre-registration data",
     "keycloak.modal.confirmationHeading": "Keycloak user record",
-    "keycloak.modal.creation": "This operation will create a new record in Keycloak for <b>{user}</b> in {count, plural, one {the <b>{tenants}</b> tenant} other {the following tenants: <b>{tenants}</b>}}.",
+    "keycloak.modal.creation": "This operation will create new record in Keycloak for <b>{user}</b>",
     "stagingRecords.merge": "Merge",
     "permission.reading-room-access.view": "Users: Can view reading room access",
     "permission.reading-room-access.edit": "Users: Can view, and edit reading room access",


### PR DESCRIPTION
## Purpose

Whenever a keycloak user record is created, we need to show the confirmation dialog.

Fix the keycloak user record confirmation dialog not appearing:
1. When assigning authorization **roles**.
2. When assigning **affiliations**.
3. When creating a new user on a **member** tenant.

## Description

Three separate bugs were addressed:

1. **Role assignment flow (User Edit):** The keycloak existence check used a single `tenantId` state variable (the last selected tenant in the role-assignment UI) for all decisions. This caused the check to target the wrong tenant when roles were changed across multiple tenants, leading to the confirmation dialog being skipped and potential save errors.

4. **Affiliation assignment flow (User Detail):** No keycloak confirmation dialog existed. When affiliations are added, the backend creates keycloak records as a side effect, but the user was never informed.

5. **User creation flow (User Edit, member tenant):** When creating a user on a member tenant, the backend automatically assigns the central tenant affiliation and creates a keycloak record for the central tenant. No confirmation dialog was shown to inform the user about this.

## Approach

**Role assignment (`withUserRoles`):**
- Split the keycloak check into two concerns: (1) check the home tenant to decide the user data save path (`mod-users-keycloak` vs `mod-users`), and (2) check every tenant with changed roles for keycloak existence.
- Show the confirmation dialog if any tenant with changed roles is missing a keycloak record.
- On confirm, create keycloak records for all missing tenants, then save roles.
- Replaced the single-tenant `useCreateAuthUserKeycloak` hook with inline `createKeycloakUserForTenant` that targets a specific tenant.

**Affiliation assignment (`UserAffiliations`):**
- Before processing affiliation additions, check keycloak existence for each tenant being added.
- Show the confirmation dialog if any tenant lacks a keycloak record.
- On confirm, proceed with the affiliation assignment (BE creates keycloak records).
- On cancel, discard the pending changes.

**User creation on member tenant (`UserEdit`):**
- When creating a user on a member tenant (detected via `checkIfUserInMemberTenant`), show the keycloak confirmation dialog before proceeding.
- The dialog informs the user that a keycloak record will be created for the central tenant.
- On confirm, proceed with user creation; on cancel, stay on the form.

**Shared hook (`useCheckUserInKeycloak`):**
- Extracted the keycloak existence check into a reusable hook used by both the role assignment and affiliation flows.

## Issues

[UIU-3586](https://folio-org.atlassian.net/browse/UIU-3586)

## Screencasts
1, 2. Role and Affiliation assignment flow

https://github.com/user-attachments/assets/e4cad1cd-3fb0-4e35-bdf3-1e9155529209



3. User creation on member tenant

https://github.com/user-attachments/assets/717f93f6-9301-4485-ab8e-ca26cc27b396

