### PR TITLE
UIU-3592: Fix Reading Room Access Last Updated column sorting by date instead of id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@
 * Add Settings > Users > Version history page to configure retention, anonymization, and excluded fields. Refs UIU-3385.
 * Add a Version history pane on the user detail view, gated on the mod-audit interface. Refs UIU-3388.
 * Send bulk override renewal requests sequentially to prevent race conditions. Refs UIU-3561.
+* In the "Last Updated" column in the "Reading Room Access" accordion, sort by date, not by id. Fixes UIU-3592.
 
 ## [13.0.1] (https://github.com/folio-org/ui-users/tree/v13.0.1) (2026-06-03)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v13.0.0...v13.0.1)
 
 * Remove extra character from `Expired time` in Lost items requiring actual cost table. Refs UIU-3580.
-* Fix Reading Room Access "Last Updated" column sorting by date instead of id. Refs UIU-3592.
 
 ## [13.0.0] (https://github.com/folio-org/ui-users/tree/v13.0.0) (2026-04-16)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.16...v13.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add a Version history pane on the user detail view, gated on the mod-audit interface. Refs UIU-3388.
 * Send bulk override renewal requests sequentially to prevent race conditions. Refs UIU-3561.
 * Remove extra character from `Expired time` in Lost items requiring actual cost table. Refs UIU-3580.
+* Fix Reading Room Access "Last Updated" column sorting by date instead of id. Refs UIU-3592.
 
 ## [13.0.0] (https://github.com/folio-org/ui-users/tree/v13.0.0) (2026-04-16)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v12.1.16...v13.0.0)

--- a/src/components/UserDetailSections/ReadingRoomAccess/ReadingRoomAccess.js
+++ b/src/components/UserDetailSections/ReadingRoomAccess/ReadingRoomAccess.js
@@ -34,7 +34,7 @@ const ReadingRoomAccess = (props) => {
     [rraColumns.ACCESS]: <FormattedMessage id="ui-users.readingRoom.access" />,
     [rraColumns.READING_ROOM_NAME]: <FormattedMessage id="ui-users.readingRoom.name" />,
     [rraColumns.NOTES]: <FormattedMessage id="ui-users.readingRoom.note" />,
-    [rraColumns.ID]: <FormattedMessage id="ui-users.readingRoom.lastUpdated" />,
+    [rraColumns.UPDATED_DATE]: <FormattedMessage id="ui-users.readingRoom.lastUpdated" />,
   };
   const visibleColumns = Object.keys(columnMapping);
   const sortInitialState = {

--- a/src/components/UserDetailSections/ReadingRoomAccess/constant.js
+++ b/src/components/UserDetailSections/ReadingRoomAccess/constant.js
@@ -3,7 +3,7 @@ export const rraColumns = {
   ACCESS: 'access',
   READING_ROOM_NAME: 'readingRoomName',
   NOTES: 'notes',
-  ID: 'id'
+  UPDATED_DATE: 'metadata.updatedDate'
 };
 
 export const DEFAULT_SORT_ORDER = rraColumns.ACCESS;

--- a/src/components/UserDetailSections/ReadingRoomAccess/getFormatter.js
+++ b/src/components/UserDetailSections/ReadingRoomAccess/getFormatter.js
@@ -15,7 +15,7 @@ export const getFormatter = (lastUpdatedDetails) => ({
   ),
   [rraColumns.READING_ROOM_NAME]: ({ readingRoomName }) => readingRoomName,
   [rraColumns.NOTES]: ({ notes }) => notes,
-  [rraColumns.ID]: rra => (
+  [rraColumns.UPDATED_DATE]: rra => (
     rra?.metadata?.updatedDate ? (
       <ViewMetaData
         metadata={rra.metadata}

--- a/src/components/UserDetailSections/ReadingRoomAccess/getFormatter.test.js
+++ b/src/components/UserDetailSections/ReadingRoomAccess/getFormatter.test.js
@@ -1,0 +1,116 @@
+import { screen, render } from '@folio/jest-config-stripes/testing-library/react';
+
+import { getFormatter } from './getFormatter';
+import { rraColumns } from './constant';
+
+jest.unmock('@folio/stripes/components');
+jest.unmock('@folio/stripes/smart-components');
+
+jest.mock('@folio/stripes/smart-components', () => ({
+  ...jest.requireActual('@folio/stripes/smart-components'),
+  ViewMetaData: ({ children }) => {
+    if (children) {
+      return children({
+        lastUpdatedBy: {
+          personal: {
+            lastName: 'Smith',
+            firstName: 'John',
+          },
+        },
+      });
+    }
+    return null;
+  },
+}));
+
+const lastUpdatedDetailsMock = jest.fn((lastUpdatedBy, date) => (
+  <span data-testid="last-updated-details">{`${date}`}</span>
+));
+
+describe('getFormatter', () => {
+  let formatter;
+
+  beforeEach(() => {
+    lastUpdatedDetailsMock.mockClear();
+    formatter = getFormatter(lastUpdatedDetailsMock);
+  });
+
+  describe(`${rraColumns.ACCESS} column`, () => {
+    it('renders FormattedMessage for ALLOWED access', () => {
+      render(formatter[rraColumns.ACCESS]({ access: 'ALLOWED' }));
+      expect(screen.getByText('Allowed')).toBeDefined();
+    });
+
+    it('renders FormattedMessage for NOT_ALLOWED access', () => {
+      render(formatter[rraColumns.ACCESS]({ access: 'NOT_ALLOWED' }));
+      expect(screen.getByText('Not allowed')).toBeDefined();
+    });
+  });
+
+  describe(`${rraColumns.READING_ROOM_NAME} column`, () => {
+    it('returns the readingRoomName value', () => {
+      const result = formatter[rraColumns.READING_ROOM_NAME]({ readingRoomName: 'Room A' });
+      expect(result).toBe('Room A');
+    });
+  });
+
+  describe(`${rraColumns.NOTES} column`, () => {
+    it('returns the notes value', () => {
+      const result = formatter[rraColumns.NOTES]({ notes: 'some note' });
+      expect(result).toBe('some note');
+    });
+
+    it('returns undefined when notes is absent', () => {
+      const result = formatter[rraColumns.NOTES]({});
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe(`${rraColumns.UPDATED_DATE} column`, () => {
+    it('renders NoValue when metadata is absent', () => {
+      const { container } = render(formatter[rraColumns.UPDATED_DATE]({}));
+      expect(container.querySelector('[data-testid="last-updated-details"]')).toBeNull();
+      // NoValue renders a dash or similar placeholder
+      expect(container.firstChild).toBeTruthy();
+    });
+
+    it('renders NoValue when updatedDate is absent', () => {
+      const { container } = render(formatter[rraColumns.UPDATED_DATE]({ metadata: {} }));
+      expect(container.querySelector('[data-testid="last-updated-details"]')).toBeNull();
+    });
+
+    it('calls lastUpdatedDetails with updatedByUserId and updatedDate when metadata is present', () => {
+      const rra = {
+        metadata: {
+          updatedDate: '2024-05-07T06:15:38.838042',
+          updatedByUserId: '21457ab5-4635-4e56-906a-908f05e9233b',
+          createdDate: '2024-05-07T06:15:17.005013',
+          createdByUserId: '21457ab5-4635-4e56-906a-908f05e9233b',
+        },
+      };
+
+      render(formatter[rraColumns.UPDATED_DATE](rra));
+
+      expect(lastUpdatedDetailsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          personal: expect.objectContaining({ lastName: 'Smith', firstName: 'John' }),
+        }),
+        rra.metadata.updatedDate,
+      );
+
+      expect(screen.getByTestId('last-updated-details').textContent).toBe(rra.metadata.updatedDate);
+    });
+
+    it('renders the value returned by lastUpdatedDetails', () => {
+      const rra = {
+        metadata: {
+          updatedDate: '2026-06-04T11:38:49.000Z',
+          updatedByUserId: 'user-id',
+        },
+      };
+
+      render(formatter[rraColumns.UPDATED_DATE](rra));
+      expect(screen.getByTestId('last-updated-details').textContent).toBe(rra.metadata.updatedDate);
+    });
+  });
+});

--- a/src/components/util/util.js
+++ b/src/components/util/util.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { every, orderBy } from 'lodash';
+import { every, get, orderBy } from 'lodash';
 import queryString from 'query-string';
 
 import { NoValue } from '@folio/stripes/components';
@@ -249,7 +249,9 @@ export const getReadingRoomSortedData = (e, meta, { data, order, direction }) =>
     newSortDirection = direction === sortTypes.ASC ? sortTypes.DESC : sortTypes.ASC;
   }
   const sortedData = orderBy(data,
-    [sortedRecord => sortedRecord[meta.name]?.toLowerCase()], newSortDirection);
+    // Use get(sortedRecord, meta.name) instead of sortedRecord[meta.name]
+    // so lodash resolves the nested metadata.updatedDate path correctly.
+    [sortedRecord => get(sortedRecord, meta.name)?.toLowerCase()], newSortDirection);
 
   return {
     data: sortedData,


### PR DESCRIPTION
## Purpose

The "Last Updated" column in the Reading Room Access accordion was sorting records by the record UUID (`id`) instead of the actual `metadata.updatedDate` timestamp, producing meaningless sort order.

## Approach

- Renamed `rraColumns.ID` -> `rraColumns.UPDATED_DATE` with value `'metadata.updatedDate'` in `constant.js`.
- Updated `getReadingRoomSortedData` in `util.js` to use lodash `get()` so it resolves nested dot-notation paths when sorting.
- Updated `getFormatter.js` and `ReadingRoomAccess.js` to use the renamed constant.
- Added unit tests for `getFormatter` covering all column formatters.

## Issues

[UIU-3592](https://folio-org.atlassian.net/browse/UIU-3592)
