### PR TITLE
UIU-3586: Fix JIT AuthUser creation dialog closing on error (follow up).

### DIFF
--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -181,7 +181,10 @@ const withUserRoles = (WrappedComponent) => (props) => {
   const confirmCreateKeycloakUser = async (onFinish) => {
     // Create keycloak records for all tenants that need them.
     const results = await Promise.allSettled(
-      tenantsWithoutKeycloakRef.current.map((tid) => createKeycloakUserForTenant(tid).then(() => tid))
+      tenantsWithoutKeycloakRef.current.map(async (tid) => {
+        await createKeycloakUserForTenant(tid);
+        return tid;
+      })
     );
 
     const succeeded = results.filter(r => r.status === 'fulfilled').map(r => r.value);

--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -181,9 +181,7 @@ const withUserRoles = (WrappedComponent) => (props) => {
   const confirmCreateKeycloakUser = async (onFinish) => {
     // Create keycloak records for all tenants that need them.
     const results = await Promise.allSettled(
-      tenantsWithoutKeycloakRef.current.map((tid) =>
-        createKeycloakUserForTenant(tid).then(() => tid)
-      )
+      tenantsWithoutKeycloakRef.current.map((tid) => createKeycloakUserForTenant(tid).then(() => tid))
     );
 
     const succeeded = results.filter(r => r.status === 'fulfilled').map(r => r.value);

--- a/src/components/Wrappers/withUserRoles.js
+++ b/src/components/Wrappers/withUserRoles.js
@@ -180,12 +180,27 @@ const withUserRoles = (WrappedComponent) => (props) => {
 
   const confirmCreateKeycloakUser = async (onFinish) => {
     // Create keycloak records for all tenants that need them.
-    await Promise.all(
-      tenantsWithoutKeycloakRef.current.map((tid) => createKeycloakUserForTenant(tid).catch(sendErrorCallout))
+    const results = await Promise.allSettled(
+      tenantsWithoutKeycloakRef.current.map((tid) =>
+        createKeycloakUserForTenant(tid).then(() => tid)
+      )
     );
 
+    const succeeded = results.filter(r => r.status === 'fulfilled').map(r => r.value);
+    const failures = results.filter(r => r.status === 'rejected');
+
     // Invalidate cached keycloak auth-user checks used in stripes-authorization-components.
-    await queryClient.invalidateQueries(['jit-auth-role']);
+    if (succeeded.length) {
+      await queryClient.invalidateQueries(['jit-auth-role']);
+    }
+
+    if (failures.length) {
+      failures.forEach(f => sendErrorCallout(f.reason));
+      // Remove succeeded tenants so retry only attempts the failed ones
+      tenantsWithoutKeycloakRef.current = tenantsWithoutKeycloakRef.current
+        .filter(tid => !succeeded.includes(tid));
+      return; // keep dialog open
+    }
 
     await updateUserRoles(assignedRoleIds);
     await onFinish();

--- a/src/components/Wrappers/withUserRoles.test.js
+++ b/src/components/Wrappers/withUserRoles.test.js
@@ -552,7 +552,7 @@ describe('withUserRoles HOC', () => {
       });
 
       describe('creation fails for any tenant', () => {
-        it('should call sendCallout with error message', async () => {
+        it('should show error callout and keep dialog open without calling onFinish', async () => {
           const post = jest.fn().mockRejectedValue('Keycloak user creation failed');
 
           useOkapiKy.mockReturnValue({
@@ -580,6 +580,82 @@ describe('withUserRoles HOC', () => {
           await act(() => userEvent.click(getByTestId('confirm-create-keycloak-user')));
 
           expect(mockSendCallout).toHaveBeenCalled();
+          expect(getByTestId('dialog-open')).toHaveTextContent('true');
+          expect(mockOnFinish).not.toHaveBeenCalled();
+          expect(mockApiPut).not.toHaveBeenCalledWith('roles/users/user1', expect.anything());
+        });
+
+        it('should invalidate queries for successfully created tenants', async () => {
+          const post = jest.fn()
+            .mockResolvedValueOnce() // first tenant succeeds
+            .mockRejectedValueOnce('Keycloak user creation failed'); // second tenant fails
+
+          useOkapiKy.mockReturnValue({
+            ...mockKy,
+            extend: jest.fn(() => ({
+              get: mockApiGet,
+              put: mockApiPut,
+              post,
+            })),
+          });
+
+          useCheckUserInKeycloak.mockReturnValue({
+            checkUserInKeycloakForTenant: jest.fn()
+              .mockResolvedValueOnce('nonExist') // home/Consortium
+              .mockResolvedValueOnce('nonExist'), // College
+          });
+
+          const { getByTestId } = renderComponent();
+
+          await act(() => userEvent.click(getByTestId('set-roles-for-consortium')));
+          await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+          await act(() => userEvent.click(getByTestId('submit-form')));
+
+          await act(() => userEvent.click(getByTestId('confirm-create-keycloak-user')));
+
+          expect(mockInvalidateQueries).toHaveBeenCalledWith(['jit-auth-role']);
+          expect(mockOnFinish).not.toHaveBeenCalled();
+        });
+
+        it('should only retry failed tenants on subsequent confirm', async () => {
+          const post = jest.fn()
+            .mockResolvedValueOnce() // first confirm: consortium succeeds
+            .mockRejectedValueOnce('fail') // first confirm: college fails
+            .mockResolvedValueOnce(); // second confirm: college succeeds
+
+          useOkapiKy.mockReturnValue({
+            ...mockKy,
+            extend: jest.fn(() => ({
+              get: mockApiGet,
+              put: mockApiPut,
+              post,
+            })),
+          });
+
+          useCheckUserInKeycloak.mockReturnValue({
+            checkUserInKeycloakForTenant: jest.fn()
+              .mockResolvedValueOnce('nonExist') // Consortium
+              .mockResolvedValueOnce('nonExist'), // College
+          });
+
+          const { getByTestId } = renderComponent();
+
+          await act(() => userEvent.click(getByTestId('set-roles-for-consortium')));
+          await act(() => userEvent.click(getByTestId('set-roles-for-college')));
+          await act(() => userEvent.click(getByTestId('submit-form')));
+
+          // First confirm: consortium succeeds, college fails
+          await act(() => userEvent.click(getByTestId('confirm-create-keycloak-user')));
+
+          expect(post).toHaveBeenCalledTimes(2);
+          expect(mockOnFinish).not.toHaveBeenCalled();
+          expect(getByTestId('dialog-open')).toHaveTextContent('true');
+
+          // Second confirm: only college is retried
+          await act(() => userEvent.click(getByTestId('confirm-create-keycloak-user')));
+
+          expect(post).toHaveBeenCalledTimes(3); // 2 from first + 1 retry
+          expect(mockOnFinish).toHaveBeenCalled();
         });
       });
     });


### PR DESCRIPTION
## Purpose

Fix the keycloak (JIT AuthUser) confirmation dialog closing and navigating away from the Edit pane when keycloak user creation fails (e.g. for a user without a username).

## Description

When clicking Confirm in the "Keycloak user record" modal and the POST to `users-keycloak/auth-users` fails, the error toast was shown but the dialog was closed and the user was navigated away. The dialog should remain open so the user can cancel or retry.

## Approach

- Replaced `Promise.all` with `.catch(sendErrorCallout)` with `Promise.allSettled` to track succeeded vs failed keycloak creations independently.
- On failure: show error callout, remove successfully created tenants from the retry list, and return early — keeping the dialog open.
- On retry: only the previously failed tenants are reattempted.
- Invalidate `jit-auth-role` cache queries only if at least one creation succeeded, to keep the cache consistent.

## Issues

[UIU-3593](https://folio-org.atlassian.net/browse/UIU-3593)

## Screencasts


https://github.com/user-attachments/assets/397368e0-ddb3-4408-ab7a-b817ebd416e9




