### PR TITLE
UIU-3549: Fix Refund button disabled on Fee/Fine History page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * In the "Last Updated" column in the "Reading Room Access" accordion, sort by date, not by id. Fixes UIU-3592.
 * Add localization for payment status in accounts and reports. Fixes UIU-3517.
 * Translate known item statuses while preserving backend values for unknown statuses. Fixes UIU-3529.
+* Fix Refund button disabled on Fee/Fine History page. Refs UIU-3549.
 
 ## [13.0.2] (https://github.com/folio-org/ui-users/tree/v13.0.2) (2026-06-12)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v13.0.1...v13.0.2)

--- a/src/components/Accounts/accountFunctions.js
+++ b/src/components/Accounts/accountFunctions.js
@@ -107,9 +107,10 @@ export function loadServicePoints(values) {
 
 export function accountRefundInfo(account, feeFineActions = []) {
   const accountFeeFinesActions = feeFineActions.filter(({ accountId }) => accountId === account.id);
-  const hasBeenPaid = accountFeeFinesActions.some(({ typeAction }) => {
+  const hasBeenPaidByActions = accountFeeFinesActions.some(({ typeAction }) => {
     return paymentStatusesAllowedToRefund.includes(typeAction);
   });
+  const hasBeenPaid = hasBeenPaidByActions || paymentStatusesAllowedToRefund.includes(account?.paymentStatus?.name);
   const paidAmount = (parseFloat(account.amount - account.remaining) * 100) / 100;
   const isCanceledAfterRefund = account.remaining === 0 && account.paymentStatus.name === cancelledStatus;
 

--- a/src/components/Accounts/accountFunctions.test.js
+++ b/src/components/Accounts/accountFunctions.test.js
@@ -151,6 +151,107 @@ describe('Account Functions', () => {
         expect(result).toEqual(expectedResult);
       });
     });
+
+    describe('hasBeenPaid via account.paymentStatus.name', () => {
+      it.each(paymentStatusesAllowedToRefund)(
+        'should set hasBeenPaid to true when paymentStatus.name is "%s" and feeFineActions is empty',
+        (statusName) => {
+          const result = accountRefundInfo({
+            ...userAccount,
+            paymentStatus: { name: statusName },
+          });
+
+          expect(result.hasBeenPaid).toBe(true);
+        }
+      );
+
+      it('should set hasBeenPaid to true when paymentStatus.name is in the allowed list and feeFineActions have no matching typeAction', () => {
+        const feeFineActions = [{
+          accountId: userAccount.id,
+          typeAction: 'Waived fully',
+        }];
+        const result = accountRefundInfo({
+          ...userAccount,
+          paymentStatus: { name: paymentStatusesAllowedToRefund[1] },
+        }, feeFineActions);
+
+        expect(result.hasBeenPaid).toBe(true);
+      });
+
+      it('should set hasBeenPaid to false when paymentStatus.name is not in the allowed list and feeFineActions is empty', () => {
+        const result = accountRefundInfo({
+          ...userAccount,
+          paymentStatus: { name: 'Outstanding' },
+        });
+
+        expect(result.hasBeenPaid).toBe(false);
+      });
+
+      it('should set hasBeenPaid to false when paymentStatus is undefined', () => {
+        const result = accountRefundInfo({
+          ...userAccount,
+          paymentStatus: undefined,
+        });
+
+        expect(result.hasBeenPaid).toBe(false);
+      });
+    });
+
+    describe('hasBeenPaid via feeFineActions (hasBeenPaidByActions)', () => {
+      it.each(paymentStatusesAllowedToRefund)(
+        'should set hasBeenPaid to true when feeFineAction typeAction is "%s"',
+        (typeAction) => {
+          const feeFineActions = [{ accountId: userAccount.id, typeAction }];
+          const result = accountRefundInfo(userAccount, feeFineActions);
+
+          expect(result.hasBeenPaid).toBe(true);
+        }
+      );
+
+      it('should set hasBeenPaid to false when feeFineAction typeAction is not in the allowed list', () => {
+        const feeFineActions = [{
+          accountId: userAccount.id,
+          typeAction: 'Waived fully',
+        }];
+        const result = accountRefundInfo(userAccount, feeFineActions);
+
+        expect(result.hasBeenPaid).toBe(false);
+      });
+
+      it('should not count feeFineActions that belong to a different accountId', () => {
+        const feeFineActions = [{
+          accountId: 'different-account-id',
+          typeAction: paymentStatusesAllowedToRefund[0],
+        }];
+        const result = accountRefundInfo(userAccount, feeFineActions);
+
+        expect(result.hasBeenPaid).toBe(false);
+      });
+
+      it('should set hasBeenPaid to true when at least one feeFineAction matches typeAction among multiple actions', () => {
+        const feeFineActions = [
+          { accountId: userAccount.id, typeAction: 'Waived fully' },
+          { accountId: userAccount.id, typeAction: paymentStatusesAllowedToRefund[2] },
+          { accountId: userAccount.id, typeAction: 'Refunded fully' },
+        ];
+        const result = accountRefundInfo(userAccount, feeFineActions);
+
+        expect(result.hasBeenPaid).toBe(true);
+      });
+
+      it('should set hasBeenPaid to true when both hasBeenPaidByActions and paymentStatus.name indicate payment', () => {
+        const feeFineActions = [{
+          accountId: userAccount.id,
+          typeAction: paymentStatusesAllowedToRefund[0],
+        }];
+        const result = accountRefundInfo({
+          ...userAccount,
+          paymentStatus: { name: paymentStatusesAllowedToRefund[3] },
+        }, feeFineActions);
+
+        expect(result.hasBeenPaid).toBe(true);
+      });
+    });
   });
 
   it('If calculateTotalPaymentAmount works', async () => {

--- a/src/views/AccountsListing/AccountsListing.js
+++ b/src/views/AccountsListing/AccountsListing.js
@@ -473,7 +473,8 @@ class AccountsHistory extends React.Component {
       'dueDate': intl.formatMessage({ id: 'ui-users.accounts.history.columns.due' }),
       'returnedDate': intl.formatMessage({ id: 'ui-users.accounts.history.columns.returned' }),
     };
-    const selectedAccounts = this.state.selectedAccounts.map(a => this.accounts.find(ac => ac.id === a.id) || {});
+    const allAccounts = resources?.feefineshistory?.records || [];
+    const selectedAccounts = this.state.selectedAccounts.map(a => allAccounts.find(ac => ac.id === a.id) || {});
     const feeFineActions = resources?.comments?.records || [];
     const canRefund = selectedAccounts.some((a) => isRefundAllowed(a, feeFineActions));
     const showActionMenu = this.props.stripes.hasPerm('ui-users.feesfines.actions.all') ||

--- a/src/views/AccountsListing/AccountsListing.test.js
+++ b/src/views/AccountsListing/AccountsListing.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { act } from 'react';
 import { createMemoryHistory } from 'history';
 
 import '__mock__/stripesCore.mock';
@@ -6,9 +6,31 @@ import renderWithRouter from 'helpers/renderWithRouter';
 import account from 'fixtures/account';
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
 
+import isRefundAllowed from '../../components/util/isRefundAllowed';
 import AccountsHistory from './AccountsListing';
 
 jest.mock('../../components/Accounts/Actions/FeeFineActions', () => () => <></>);
+
+// Captures onChangeSelected / onChangeActions from the rendered ViewFeesFines instance.
+// The `callbacks` object lives inside the factory closure so it is accessible via _getCallbacks()
+// without any module-level variable that would conflict with Jest's hoisting rules.
+jest.mock('../../components/Accounts', () => {
+  const callbacks = {};
+
+  return {
+    // eslint-disable-next-line react/prop-types
+    ViewFeesFines: ({ onChangeSelected, onChangeActions }) => {
+      callbacks.onChangeSelected = onChangeSelected;
+      callbacks.onChangeActions = onChangeActions;
+      return null;
+    },
+    Filters: () => null,
+    Menu: () => null,
+    _getCallbacks: () => callbacks,
+  };
+});
+
+jest.mock('../../components/util/isRefundAllowed', () => jest.fn());
 
 jest.unmock('@folio/stripes/components');
 
@@ -91,5 +113,107 @@ describe('Checking Action Menu', () => {
   test('Section show columns should be present', () => {
     renderAccountsListing({ account });
     expect(document.querySelector('#sectionShowColumns')).toBeInTheDocument();
+  });
+});
+
+describe('getActionMenu - allAccounts lookup for canRefund (refund button state)', () => {
+  // Access the callback store exposed by the ../../components/Accounts mock.
+  // require() is used because the mock module is not an ES-module default export.
+  // eslint-disable-next-line global-require
+  const { _getCallbacks } = require('../../components/Accounts');
+
+  const accountId = 'test-account-id-123';
+  const selectedAccount = { id: accountId };
+
+  // Render with params.accountstatus = 'all' so ViewFeesFines renders and captures callbacks.
+  const propsWithStatus = {
+    ...props,
+    match: { params: { accountstatus: 'all', id: '123' } },
+  };
+
+  beforeEach(() => {
+    // Reset mock implementation and call history before each test.
+    isRefundAllowed.mockReset();
+  });
+
+  it('maps selectedAccounts to {} (fallback) and disables refund button when feefineshistory is undefined', async () => {
+    // allAccounts = [] (resources?.feefineshistory?.records || [] fallback)
+    // find() returns undefined → selectedAccount becomes {}
+    // isRefundAllowed({}) → false → canRefund = false → button disabled
+    isRefundAllowed.mockReturnValue(false);
+
+    renderAccountsListing({
+      ...propsWithStatus,
+      resources: { ...props.resources, feefineshistory: undefined },
+    });
+
+    await act(async () => {
+      _getCallbacks().onChangeSelected(90, [selectedAccount]);
+      _getCallbacks().onChangeActions({ refund: true });
+    });
+
+    expect(document.querySelector('#open-closed-all-refund-button')).toBeDisabled();
+    // Verify isRefundAllowed was called with the {} fallback, not real account data
+    expect(isRefundAllowed).toHaveBeenCalledWith({}, []);
+  });
+
+  it('maps selectedAccount to {} (fallback) and disables refund button when id is not found in feefineshistory records', async () => {
+    // allAccounts has a record with a DIFFERENT id → find() returns undefined → fallback {}
+    isRefundAllowed.mockReturnValue(false);
+
+    renderAccountsListing({
+      ...propsWithStatus,
+      resources: {
+        ...props.resources,
+        feefineshistory: {
+          records: [{
+            id: 'different-id',
+            paymentStatus: { name: 'Paid fully' },
+            amount: 100,
+            remaining: 0,
+            status: { name: 'Closed' },
+          }],
+        },
+      },
+    });
+
+    await act(async () => {
+      _getCallbacks().onChangeSelected(90, [selectedAccount]);
+      _getCallbacks().onChangeActions({ refund: true });
+    });
+
+    expect(document.querySelector('#open-closed-all-refund-button')).toBeDisabled();
+    // find() returned undefined → fallback {} is passed to isRefundAllowed
+    expect(isRefundAllowed).toHaveBeenCalledWith({}, []);
+  });
+
+  it('maps selectedAccount to the matching record from feefineshistory and enables refund button', async () => {
+    // allAccounts contains the record whose id matches selectedAccount.id
+    // find() returns the real account → isRefundAllowed(realAccount) = true → canRefund = true → button enabled
+    const existingAccount = {
+      id: accountId,
+      paymentStatus: { name: 'Paid fully' },
+      amount: 100,
+      remaining: 0,
+      status: { name: 'Closed' },
+    };
+    isRefundAllowed.mockReturnValue(true);
+
+    renderAccountsListing({
+      ...propsWithStatus,
+      resources: {
+        ...props.resources,
+        feefineshistory: { records: [existingAccount] },
+      },
+    });
+
+    await act(async () => {
+      _getCallbacks().onChangeSelected(90, [selectedAccount]);
+      _getCallbacks().onChangeActions({ refund: true });
+    });
+
+    expect(document.querySelector('#open-closed-all-refund-button')).not.toBeDisabled();
+    // Verify isRefundAllowed was called with the real account data (not {})
+    expect(isRefundAllowed).toHaveBeenCalledWith(existingAccount, []);
   });
 });


### PR DESCRIPTION
## Purpose
Fix Refund button disabled on Fee/Fine History page

# Refs
https://issues.folio.org/browse/UIU-3549
