### PR TITLE
UIU-3585: Prevent server requests when filling in other fields after filling in Username/Barcode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Translate known item statuses while preserving backend values for unknown statuses. Fixes UIU-3529.
 * Fix Refund button disabled on Fee/Fine History page. Refs UIU-3549.
 * Add `ui-users.loans.view` to `ui-users.loans-renew.create` to also see loans with this permission. Fixes UIU-1140.
+* Prevent server requests when filling in other fields after filling in Username/Barcode. Fixes UIU-3585.
 
 ## [13.0.2] (https://github.com/folio-org/ui-users/tree/v13.0.2) (2026-06-12)
 [Full Changelog](https://github.com/folio-org/ui-users/compare/v13.0.1...v13.0.2)

--- a/src/components/AsyncValidateField/AsyncValidateField.js
+++ b/src/components/AsyncValidateField/AsyncValidateField.js
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import { Field } from 'react-final-form';
+import debounce from 'lodash/debounce';
+
+import memoize from '../util/memoize';
+
+export const AsyncValidateField = ({
+  validate,
+  children,
+  wait = 300,
+  // Async validation hits the server, so by default this field should only be
+  // revalidated when its own value changes, not whenever any other field changes.
+  // Consumers can still override this by explicitly passing their own `validateFields`.
+  validateFields = [],
+  ...props
+}) => {
+  // `validateFields` only controls cascading validation triggered by *this* field's
+  // own changes - it does NOT stop this field from being revalidated when an
+  // unrelated field changes (final-form falls back to validating every field
+  // whenever a field with no `validateFields` setting changes). `memoize` guards
+  // against that: it skips calling `debounce`/`validate` again (and thus avoids
+  // firing another server request) when this field's own value hasn't changed.
+  const asyncValidate = useMemo(() => memoize(debounce(validate, wait)), [validate, wait]);
+
+  return (
+    <Field
+      {...props}
+      validate={asyncValidate}
+      validateFields={validateFields}
+    >
+      {children}
+    </Field>
+  );
+};

--- a/src/components/AsyncValidateField/index.js
+++ b/src/components/AsyncValidateField/index.js
@@ -1,0 +1,1 @@
+export * from './AsyncValidateField';

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.js
@@ -33,6 +33,7 @@ import CreateResetPasswordControl from './CreateResetPasswordControl';
 import RequestPreferencesEdit from './RequestPreferencesEdit';
 import DepartmentsNameEdit from './DepartmentsNameEdit';
 import EditCustomFieldsSection from '../EditCustomFieldsSection';
+import { AsyncValidateField } from '../../AsyncValidateField';
 import { CUSTOM_FIELDS_SECTION } from '../../../constants';
 
 class EditExtendedInfo extends Component {
@@ -52,6 +53,12 @@ class EditExtendedInfo extends Component {
     disabled: PropTypes.bool,
     stripes: stripesShape,
   };
+
+  validateUsername = (value) => {
+    const { username, uniquenessValidator } = this.props;
+
+    return asyncValidateField(value, 'username', username, uniquenessValidator);
+  }
 
   buildAccordionHeader = () => {
     return (
@@ -93,7 +100,6 @@ class EditExtendedInfo extends Component {
       addressTypes,
       departments,
       change,
-      uniquenessValidator,
       disabled,
       values,
       stripes,
@@ -196,7 +202,7 @@ class EditExtendedInfo extends Component {
             xs={12}
             md={3}
           >
-            <Field
+            <AsyncValidateField
               label={<FormattedMessage id="ui-users.information.username" />}
               name="username"
               id="adduser_username"
@@ -205,7 +211,7 @@ class EditExtendedInfo extends Component {
               validStylesEnabled
               disabled={disabled}
               required={isUsernameFieldRequired}
-              validate={asyncValidateField('username', username, uniquenessValidator)}
+              validate={this.validateUsername}
             />
           </Col>
           <IfPermission perm="ui-users.reset.password">

--- a/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.test.js
+++ b/src/components/EditSections/EditExtendedInfo/EditExtendedInfo.test.js
@@ -1,4 +1,5 @@
-import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { Form } from 'react-final-form';
 import PropTypes from 'prop-types';
 
@@ -174,6 +175,115 @@ describe('Render Extended User Information component', () => {
       );
 
       expect(screen.getByRole('textbox', { name: 'ui-users.information.username' })).not.toBeRequired();
+    });
+  });
+
+  describe('Username uniqueness validation', () => {
+    let uniquenessValidator;
+    let user;
+
+    // The username field's async validation is debounced (see AsyncValidateField,
+    // default wait = 300ms). Fake timers let us fast-forward past that window
+    // instead of waiting in real time. `advanceTimersByTimeAsync` also flushes
+    // the microtasks in between, so the mocked `GET` promise gets a chance to
+    // resolve. Because the debounced/memoized validator only re-evaluates when
+    // the field's value actually changes, briefly appending then removing a
+    // character forces it to pick up the (by-then-resolved) async result.
+    // Finally, blur the field so final-form marks it `touched` - TextField only
+    // renders an error once touched.
+    const triggerRevalidation = async () => {
+      await jest.advanceTimersByTimeAsync(400);
+      const usernameField = screen.getByRole('textbox', { name: 'ui-users.information.username' });
+      await user.type(usernameField, 'X{backspace}');
+      await user.tab();
+    };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      user = userEvent.setup({ delay: null, advanceTimers: jest.advanceTimersByTime });
+      uniquenessValidator = {
+        GET: jest.fn(),
+        reset: jest.fn(),
+      };
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should show an error message when the entered username already exists', async () => {
+      uniquenessValidator.GET.mockResolvedValue([{ username: 'newUsername' }]);
+
+      renderEditExtendedInfo({
+        ...props,
+        uniquenessValidator,
+      }, { username: 'testName' });
+
+      const usernameField = screen.getByRole('textbox', { name: 'ui-users.information.username' });
+
+      await user.clear(usernameField);
+      await user.type(usernameField, 'newUsername');
+
+      await triggerRevalidation();
+
+      await waitFor(() => {
+        expect(screen.getByText('ui-users.errors.usernameUnavailable')).toBeInTheDocument();
+      });
+
+      expect(uniquenessValidator.reset).toHaveBeenCalled();
+      expect(uniquenessValidator.GET).toHaveBeenCalledWith({ params: { query: '(username=="newUsername")' } });
+    });
+
+    it('should NOT show an error message when the entered username is available', async () => {
+      uniquenessValidator.GET.mockResolvedValue([]);
+
+      renderEditExtendedInfo({
+        ...props,
+        uniquenessValidator,
+      }, { username: 'testName' });
+
+      const usernameField = screen.getByRole('textbox', { name: 'ui-users.information.username' });
+
+      await user.clear(usernameField);
+      await user.type(usernameField, 'availableUsername');
+
+      await triggerRevalidation();
+
+      await waitFor(() => {
+        expect(uniquenessValidator.GET).toHaveBeenCalled();
+      });
+
+      expect(screen.queryByText('ui-users.errors.usernameUnavailable')).not.toBeInTheDocument();
+    });
+
+    it('should NOT call the validator when the username is empty', async () => {
+      renderEditExtendedInfo({
+        ...props,
+        uniquenessValidator,
+      }, { username: 'testName' });
+
+      const usernameField = screen.getByRole('textbox', { name: 'ui-users.information.username' });
+
+      await user.clear(usernameField);
+
+      await triggerRevalidation();
+
+      expect(uniquenessValidator.GET).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call the validator when the username matches its initial value', async () => {
+      renderEditExtendedInfo({
+        ...props,
+        uniquenessValidator,
+      }, { username: 'testName' });
+
+      const usernameField = screen.getByRole('textbox', { name: 'ui-users.information.username' });
+
+      await user.click(usernameField);
+
+      await triggerRevalidation();
+
+      expect(uniquenessValidator.GET).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.js
@@ -32,6 +32,7 @@ import validateMinDate from '../../validators/validateMinDate';
 
 import { ChangeUserTypeModal, EditUserProfilePicture } from './components';
 import EditCustomFieldsSection from '../EditCustomFieldsSection';
+import { AsyncValidateField } from '../../AsyncValidateField';
 
 import css from './EditUserInfo.css';
 import { validateLength } from '../../validators/validateLength';
@@ -130,6 +131,15 @@ class EditUserInfo extends React.Component {
       : expirationDate;
   };
 
+  validateBarcode = (value) => {
+    const {
+      initialValues: { barcode },
+      uniquenessValidator,
+    } = this.props;
+
+    return asyncValidateField(value, 'barcode', barcode, uniquenessValidator);
+  }
+
   render() {
     const {
       patronGroups,
@@ -139,7 +149,6 @@ class EditUserInfo extends React.Component {
       accordionId,
       intl,
       stripes,
-      uniquenessValidator,
       disabled,
       profilePictureConfig,
       form,
@@ -147,7 +156,6 @@ class EditUserInfo extends React.Component {
     } = this.props;
 
     const isConsortium = isConsortiumEnabled(stripes);
-    const { barcode } = initialValues;
 
     const isUserExpired = () => {
       const expirationDate = new Date(initialValues.expirationDate);
@@ -384,12 +392,12 @@ class EditUserInfo extends React.Component {
                   )}
                 </Col>
                 <Col xs={12} md={3}>
-                  <Field
+                  <AsyncValidateField
                     label={<FormattedMessage id="ui-users.information.barcode" />}
                     name="barcode"
                     id="adduser_barcode"
                     component={TextField}
-                    validate={asyncValidateField('barcode', barcode, uniquenessValidator)}
+                    validate={this.validateBarcode}
                     fullWidth
                     disabled={disabled || isBarcodeDisabled}
                   />

--- a/src/components/validators/asyncValidateField.js
+++ b/src/components/validators/asyncValidateField.js
@@ -3,22 +3,18 @@ import { FormattedMessage } from 'react-intl';
 
 import { escapeCqlWildcards } from '@folio/stripes/util';
 
-import memoize from '../util/memoize';
+export default async function asyncValidateField(value, fieldName, initValue, validator) {
+  // Don't validate if value is empty or matches initial value
+  if (!value || value === initValue) return '';
 
-// validate field asynchronously
-export default function asyncValidateField(fieldName, initValue, validator) {
-  return memoize(async (value) => {
-    if (!value || value === initValue) return '';
+  const query = `(${fieldName}=="${escapeCqlWildcards(value.trim())}")`;
 
-    const query = `(${fieldName}=="${escapeCqlWildcards(value.trim())}")`;
+  validator.reset();
+  const records = await validator.GET({ params: { query } });
 
-    validator.reset();
-    const records = await validator.GET({ params: { query } });
+  if (records.length > 0) {
+    return <FormattedMessage id={`ui-users.errors.${fieldName}Unavailable`} />;
+  }
 
-    if (records.length > 0) {
-      return <FormattedMessage id={`ui-users.errors.${fieldName}Unavailable`} />;
-    }
-
-    return '';
-  });
+  return '';
 }

--- a/src/components/validators/asyncValidateField.test.js
+++ b/src/components/validators/asyncValidateField.test.js
@@ -12,6 +12,7 @@ const mockValidator = {
   GET: jest.fn(() => Promise.resolve([])),
   reset: jest.fn(),
 };
+const value = 'foo';
 
 describe('Async Validate Field component', () => {
   beforeEach(() => {
@@ -24,7 +25,7 @@ describe('Async Validate Field component', () => {
       reset: jest.fn(),
       GET: jest.fn(() => new Promise(res => res(mockReponse))),
     };
-    const data = await waitFor(() => asyncValidateField(fieldName, initValue, validator));
+    const data = await waitFor(() => asyncValidateField(value, fieldName, initValue, validator));
     expect(data.props.id).toBe('ui-users.errors.usernameUnavailable');
   });
   it('if initValue and memoize function has same data', async () => {
@@ -34,7 +35,7 @@ describe('Async Validate Field component', () => {
       reset: jest.fn(),
       GET: jest.fn(() => new Promise(res => res(mockReponse))),
     };
-    const data = await waitFor(() => asyncValidateField(fieldName, initValue, validator));
+    const data = await waitFor(() => asyncValidateField(initValue, fieldName, initValue, validator));
     expect(data).toBe('');
   });
   it('if no validator data is passed', async () => {
@@ -44,7 +45,7 @@ describe('Async Validate Field component', () => {
       reset: jest.fn(),
       GET: jest.fn(() => new Promise(res => res([]))),
     };
-    const data = await waitFor(() => asyncValidateField(fieldName, initValue, validator));
+    const data = await waitFor(() => asyncValidateField(value, fieldName, initValue, validator));
     expect(data).toBe('');
   });
 
@@ -54,27 +55,27 @@ describe('Async Validate Field component', () => {
     });
 
     it('should escape *', async () => {
-      await asyncValidateField('username', '', mockValidator)('foo*');
+      await asyncValidateField('foo*', 'username', '', mockValidator);
       expect(mockValidator.GET).toHaveBeenCalledWith({ params: { query: '(username=="foo\\*")' } });
     });
 
     it('should escape ?', async () => {
-      await asyncValidateField('barcode', '', mockValidator)('foo?');
+      await asyncValidateField('foo?', 'barcode', '', mockValidator);
       expect(mockValidator.GET).toHaveBeenCalledWith({ params: { query: '(barcode=="foo\\?")' } });
     });
 
     it('should escape ^', async () => {
-      await asyncValidateField('username', '', mockValidator)('foo^');
+      await asyncValidateField('foo^', 'username', '', mockValidator);
       expect(mockValidator.GET).toHaveBeenCalledWith({ params: { query: '(username=="foo\\^")' } });
     });
 
     it('should escape "', async () => {
-      await asyncValidateField('username', '', mockValidator)('foo"');
+      await asyncValidateField('foo"', 'username', '', mockValidator);
       expect(mockValidator.GET).toHaveBeenCalledWith({ params: { query: '(username=="foo\\"")' } });
     });
 
     it('should escape \\', async () => {
-      await asyncValidateField('username', '', mockValidator)('foo\\');
+      await asyncValidateField('foo\\', 'username', '', mockValidator);
       expect(mockValidator.GET).toHaveBeenCalledWith({ params: { query: '(username=="foo\\\\")' } });
     });
   });


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
1. Prevent server requests when filling in other fields after filling in Username/Barcode (video recording is in the ticket).
2. Add debounce for fields with server requests validation (username and barcode).

## Description

Created `AsyncValidateField` with debounce and memoization. 
Memoized the debounced async validator in `AsyncValidateField` to skip re-invoking validate/debounce when a field's own value hasn't changed. Without this, editing an unrelated field (e.g. Pronouns, Phone) still re-triggered the Username/Barcode server-side uniqueness check, since final-form validates every registered field whenever any field changes and none of them declare `validateFields`. Also default `validateFields` to `[]` on `AsyncValidateField` so a field's own change doesn't cascade validation to unrelated fields.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Issues
https://folio-org.atlassian.net/browse/UIU-3463

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
