### PR TITLE
UIU-3463: Enhance `AsyncValidateField` to ensure debounced validation returns a Promise (follow-up).

### DIFF
--- a/src/components/AsyncValidateField/AsyncValidateField.js
+++ b/src/components/AsyncValidateField/AsyncValidateField.js
@@ -20,15 +20,6 @@ export const AsyncValidateField = ({
   // whenever a field with no `validateFields` setting changes). `memoize` guards
   // against that: it skips calling `debounce`/`validate` again (and thus avoids
   // firing another server request) when this field's own value hasn't changed.
-  //
-  // `debounce` on its own can't be used as the field-level `validate` function:
-  // since it only invokes `validate` on the trailing edge, calling the debounced
-  // function returns `undefined` synchronously instead of a Promise. final-form
-  // relies on the return value being a Promise to know the validation is async
-  // and to wait for it, so with a plain debounce the eventual (delayed) result
-  // is simply discarded and no error is ever shown. Wrapping it in a `Promise`
-  // that is resolved by the debounced call fixes this: every invocation now
-  // returns a real Promise that final-form can await.
   const debouncedValidate = useMemo(() => debounce((value, resolve) => {
     resolve(validate(value));
   }, wait), [validate, wait]);

--- a/src/components/AsyncValidateField/AsyncValidateField.js
+++ b/src/components/AsyncValidateField/AsyncValidateField.js
@@ -20,7 +20,22 @@ export const AsyncValidateField = ({
   // whenever a field with no `validateFields` setting changes). `memoize` guards
   // against that: it skips calling `debounce`/`validate` again (and thus avoids
   // firing another server request) when this field's own value hasn't changed.
-  const asyncValidate = useMemo(() => memoize(debounce(validate, wait)), [validate, wait]);
+  //
+  // `debounce` on its own can't be used as the field-level `validate` function:
+  // since it only invokes `validate` on the trailing edge, calling the debounced
+  // function returns `undefined` synchronously instead of a Promise. final-form
+  // relies on the return value being a Promise to know the validation is async
+  // and to wait for it, so with a plain debounce the eventual (delayed) result
+  // is simply discarded and no error is ever shown. Wrapping it in a `Promise`
+  // that is resolved by the debounced call fixes this: every invocation now
+  // returns a real Promise that final-form can await.
+  const debouncedValidate = useMemo(() => debounce((value, resolve) => {
+    resolve(validate(value));
+  }, wait), [validate, wait]);
+
+  const asyncValidate = useMemo(() => memoize((value) => new Promise((resolve) => {
+    debouncedValidate(value, resolve);
+  })), [debouncedValidate]);
 
   return (
     <Field

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
@@ -362,6 +362,22 @@ describe('Render Edit User Information component', () => {
       await waitFor(() => expect(uniquenessValidator.GET).toHaveBeenCalled());
       expect(screen.queryByText('ui-users.errors.barcodeUnavailable')).not.toBeInTheDocument();
     });
+
+    it('should debounce validation requests and only send a single request while typing', async () => {
+      const uniquenessValidator = {
+        ...props.uniquenessValidator,
+        GET: jest.fn().mockResolvedValue([]),
+      };
+
+      renderEditUserInfo({ ...props, uniquenessValidator });
+
+      const barcodeField = screen.getByRole('textbox', { name: 'ui-users.information.barcode' });
+
+      await userEvent.clear(barcodeField);
+      await userEvent.type(barcodeField, '9999999999');
+
+      await waitFor(() => expect(uniquenessValidator.GET).toHaveBeenCalledTimes(1));
+    });
   });
 
   describe('when profilePicture configuration is not enabled', () => {

--- a/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
+++ b/src/components/EditSections/EditUserInfo/EditUserInfo.test.js
@@ -1,7 +1,7 @@
 import { act } from 'react';
 
 import okapiCurrentUser from 'fixtures/okapiCurrentUser';
-import { screen } from '@folio/jest-config-stripes/testing-library/react';
+import { screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { Form } from 'react-final-form';
 
@@ -325,6 +325,43 @@ describe('Render Edit User Information component', () => {
 
     expect(screen.getByRole('textbox', { name: 'ui-users.information.barcode' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'NumberGeneratorModalButton' })).toBeInTheDocument();
+  });
+
+  describe('barcode uniqueness validation', () => {
+    it('should show an error when an already taken barcode is entered and the field loses focus', async () => {
+      const uniquenessValidator = {
+        ...props.uniquenessValidator,
+        GET: jest.fn().mockResolvedValue([{ id: 'existing-user' }]),
+      };
+
+      renderEditUserInfo({ ...props, uniquenessValidator });
+
+      const barcodeField = screen.getByRole('textbox', { name: 'ui-users.information.barcode' });
+
+      await userEvent.clear(barcodeField);
+      await userEvent.type(barcodeField, '9999999999');
+      await userEvent.tab();
+
+      expect(await screen.findByText('ui-users.errors.barcodeUnavailable')).toBeInTheDocument();
+    });
+
+    it('should not show an error when a unique barcode is entered and the field loses focus', async () => {
+      const uniquenessValidator = {
+        ...props.uniquenessValidator,
+        GET: jest.fn().mockResolvedValue([]),
+      };
+
+      renderEditUserInfo({ ...props, uniquenessValidator });
+
+      const barcodeField = screen.getByRole('textbox', { name: 'ui-users.information.barcode' });
+
+      await userEvent.clear(barcodeField);
+      await userEvent.type(barcodeField, '9999999999');
+      await userEvent.tab();
+
+      await waitFor(() => expect(uniquenessValidator.GET).toHaveBeenCalled());
+      expect(screen.queryByText('ui-users.errors.barcodeUnavailable')).not.toBeInTheDocument();
+    });
   });
 
   describe('when profilePicture configuration is not enabled', () => {


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
When entering a non-unique barcode/username, an inline error message should be displayed on the edit user page.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Description
**Root cause**
lodash/debounce doesn't return a Promise - since the debounce is trailing-edge, calling the debounced function returns undefined synchronously (the actual validate() call only happens after the wait timer fires, long after the wrapper has already returned).

## Approach
Wrap the debounce so every call to the outer function returns a genuine Promise that resolves once the debounced/delayed call actually runs (the standard pattern used in the final-form async-validation recipes).
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Issues
https://folio-org.atlassian.net/browse/UIU-3463

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
