### PR TITLE
UIU-3463: Resolve each Promise's `resolve` in `AsyncValidateField` to allow saving the user record (follow-up).

### DIFF
--- a/src/components/AsyncValidateField/AsyncValidateField.js
+++ b/src/components/AsyncValidateField/AsyncValidateField.js
@@ -1,6 +1,5 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Field } from 'react-final-form';
-import debounce from 'lodash/debounce';
 
 import memoize from '../util/memoize';
 
@@ -18,15 +17,26 @@ export const AsyncValidateField = ({
   // own changes - it does NOT stop this field from being revalidated when an
   // unrelated field changes (final-form falls back to validating every field
   // whenever a field with no `validateFields` setting changes). `memoize` guards
-  // against that: it skips calling `debounce`/`validate` again (and thus avoids
-  // firing another server request) when this field's own value hasn't changed.
-  const debouncedValidate = useMemo(() => debounce((value, resolve) => {
-    resolve(validate(value));
-  }, wait), [validate, wait]);
+  // against that: it skips calling `validate` again (and thus avoids firing another
+  // server request) when this field's own value hasn't changed.
+  const timeoutRef = useRef(null);
+  const pendingResolve = useRef();
 
-  const asyncValidate = useMemo(() => memoize((value) => new Promise((resolve) => {
-    debouncedValidate(value, resolve);
-  })), [debouncedValidate]);
+  useEffect(() => () => {
+    clearTimeout(timeoutRef.current);
+    pendingResolve.current?.();
+  }, []);
+
+  const asyncValidate = useMemo(() => memoize((value, allValues, meta) => new Promise((resolve) => {
+    pendingResolve.current?.();
+    clearTimeout(timeoutRef.current);
+
+    timeoutRef.current = setTimeout(() => {
+      resolve(validate(value, allValues, meta));
+    }, wait);
+
+    pendingResolve.current = resolve;
+  })), [validate, wait]);
 
   return (
     <Field

--- a/src/components/AsyncValidateField/AsyncValidateField.js
+++ b/src/components/AsyncValidateField/AsyncValidateField.js
@@ -1,36 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Field } from 'react-final-form';
+import debounce from 'lodash/debounce';
 
 import memoize from '../util/memoize';
-
-// Debounces `validate`, ensuring every Promise returned to final-form eventually
-// settles - even one belonging to an earlier, superseded call - since final-form
-// waits for all of them before considering the form done validating (see
-// `AsyncValidateField` below for the full explanation).
-const useDebouncedValidate = (validate, wait) => {
-  const timeoutRef = useRef(null);
-  const pendingResolve = useRef();
-
-  useEffect(() => () => {
-    clearTimeout(timeoutRef.current);
-    pendingResolve.current?.();
-  }, []);
-
-  const scheduleValidate = useCallback((value, allValues, meta, resolve) => {
-    pendingResolve.current?.();
-    clearTimeout(timeoutRef.current);
-
-    timeoutRef.current = setTimeout(() => {
-      resolve(validate(value, allValues, meta));
-    }, wait);
-
-    pendingResolve.current = resolve;
-  }, [validate, wait]);
-
-  return useMemo(() => memoize((value, allValues, meta) => new Promise((resolve) => {
-    scheduleValidate(value, allValues, meta, resolve);
-  })), [scheduleValidate]);
-};
 
 export const AsyncValidateField = ({
   validate,
@@ -46,9 +18,34 @@ export const AsyncValidateField = ({
   // own changes - it does NOT stop this field from being revalidated when an
   // unrelated field changes (final-form falls back to validating every field
   // whenever a field with no `validateFields` setting changes). `memoize` guards
-  // against that: it skips calling `validate` again (and thus avoids firing another
-  // server request) when this field's own value hasn't changed.
-  const asyncValidate = useDebouncedValidate(validate, wait);
+  // against that: it skips calling `debounce`/`validate` again (and thus avoids
+  // firing another server request) when this field's own value hasn't changed.
+  //
+  // `pendingResolve` tracks the resolver of the most recent (not-yet-settled) Promise.
+  // final-form waits for every Promise it's ever given before considering the form
+  // done validating, but `lodash/debounce` only invokes its wrapped function once
+  // per burst (the trailing call) - so without resolving the previous Promise first,
+  // every superseded keystroke would leave its Promise dangling forever, permanently
+  // blocking submission (e.g. "Save & close").
+  const pendingResolve = useRef();
+
+  const debouncedValidate = useMemo(() => debounce((value, allValues, meta, resolve) => {
+    resolve(validate(value, allValues, meta));
+  }, wait), [validate, wait]);
+
+  // If the field unmounts (e.g. it's conditionally rendered) while its own debounce
+  // timer is still pending, the surrounding <Form> may still be mounted - so cancel
+  // the timer and resolve the dangling Promise instead of leaving it hanging.
+  useEffect(() => () => {
+    debouncedValidate.cancel();
+    pendingResolve.current?.();
+  }, [debouncedValidate]);
+
+  const asyncValidate = useMemo(() => memoize((value, allValues, meta) => new Promise((resolve) => {
+    pendingResolve.current?.();
+    pendingResolve.current = resolve;
+    debouncedValidate(value, allValues, meta, resolve);
+  })), [debouncedValidate]);
 
   return (
     <Field

--- a/src/components/AsyncValidateField/AsyncValidateField.js
+++ b/src/components/AsyncValidateField/AsyncValidateField.js
@@ -1,7 +1,36 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Field } from 'react-final-form';
 
 import memoize from '../util/memoize';
+
+// Debounces `validate`, ensuring every Promise returned to final-form eventually
+// settles - even one belonging to an earlier, superseded call - since final-form
+// waits for all of them before considering the form done validating (see
+// `AsyncValidateField` below for the full explanation).
+const useDebouncedValidate = (validate, wait) => {
+  const timeoutRef = useRef(null);
+  const pendingResolve = useRef();
+
+  useEffect(() => () => {
+    clearTimeout(timeoutRef.current);
+    pendingResolve.current?.();
+  }, []);
+
+  const scheduleValidate = useCallback((value, allValues, meta, resolve) => {
+    pendingResolve.current?.();
+    clearTimeout(timeoutRef.current);
+
+    timeoutRef.current = setTimeout(() => {
+      resolve(validate(value, allValues, meta));
+    }, wait);
+
+    pendingResolve.current = resolve;
+  }, [validate, wait]);
+
+  return useMemo(() => memoize((value, allValues, meta) => new Promise((resolve) => {
+    scheduleValidate(value, allValues, meta, resolve);
+  })), [scheduleValidate]);
+};
 
 export const AsyncValidateField = ({
   validate,
@@ -19,24 +48,7 @@ export const AsyncValidateField = ({
   // whenever a field with no `validateFields` setting changes). `memoize` guards
   // against that: it skips calling `validate` again (and thus avoids firing another
   // server request) when this field's own value hasn't changed.
-  const timeoutRef = useRef(null);
-  const pendingResolve = useRef();
-
-  useEffect(() => () => {
-    clearTimeout(timeoutRef.current);
-    pendingResolve.current?.();
-  }, []);
-
-  const asyncValidate = useMemo(() => memoize((value, allValues, meta) => new Promise((resolve) => {
-    pendingResolve.current?.();
-    clearTimeout(timeoutRef.current);
-
-    timeoutRef.current = setTimeout(() => {
-      resolve(validate(value, allValues, meta));
-    }, wait);
-
-    pendingResolve.current = resolve;
-  })), [validate, wait]);
+  const asyncValidate = useDebouncedValidate(validate, wait);
 
   return (
     <Field

--- a/src/components/AsyncValidateField/AsyncValidateField.test.js
+++ b/src/components/AsyncValidateField/AsyncValidateField.test.js
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import { Form } from 'react-final-form';
+
+import { render, screen, waitFor } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+
+import { AsyncValidateField } from './AsyncValidateField';
+
+const WAIT = 300;
+
+// Renders the field behind a toggle so it can be unmounted independently of the
+// surrounding <Form>, to reproduce the scenario where the field unmounts while its
+// own debounce timer is still pending.
+const renderForm = ({ onSubmit, validate, initialValues }) => {
+  const Wrapper = () => {
+    const [showField, setShowField] = useState(true);
+
+    return (
+      <Form
+        onSubmit={onSubmit}
+        initialValues={initialValues}
+        render={({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            {showField && (
+              <AsyncValidateField
+                name="barcode"
+                id="barcode"
+                component="input"
+                validate={validate}
+                wait={WAIT}
+              />
+            )}
+            <button type="button" onClick={() => setShowField(false)}>Hide field</button>
+            <button type="submit">Save</button>
+          </form>
+        )}
+      />
+    );
+  };
+
+  return render(<Wrapper />);
+};
+
+describe('AsyncValidateField', () => {
+  let user;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    user = userEvent.setup({ delay: null, advanceTimers: jest.advanceTimersByTime });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // Regression test for a bug where typing multiple characters before the debounce
+  // window elapsed left the form permanently stuck "validating", so clicking
+  // "Save & close" did nothing. Each keystroke produces a new (memoized) Promise,
+  // but `lodash/debounce` only invokes its wrapped function once per burst (the
+  // trailing call) - any earlier keystroke's Promise must still resolve, otherwise
+  // final-form's internal async-validation counter never returns to zero and
+  // submission is blocked forever.
+  it('does not permanently block form submission after typing several characters quickly', async () => {
+    const onSubmit = jest.fn();
+    const validate = jest.fn(() => undefined);
+
+    renderForm({ onSubmit, validate });
+
+    const input = screen.getByRole('textbox');
+
+    await user.type(input, '123456');
+
+    // Let the debounced validator fire and its Promise resolve.
+    await jest.advanceTimersByTimeAsync(WAIT + 100);
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+  });
+
+  it('still surfaces a validation error produced by the final keystroke', async () => {
+    const onSubmit = jest.fn();
+    const validate = jest.fn((value) => (value === '123456' ? 'error' : undefined));
+
+    renderForm({ onSubmit, validate });
+
+    const input = screen.getByRole('textbox');
+
+    await user.type(input, '123456');
+
+    await jest.advanceTimersByTimeAsync(WAIT + 100);
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(validate).toHaveBeenCalledWith('123456', { barcode: '123456' }, undefined));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('forwards allValues to the validate function, alongside value', async () => {
+    const onSubmit = jest.fn();
+    const validate = jest.fn(() => undefined);
+
+    renderForm({ onSubmit, validate, initialValues: { username: 'jdoe' } });
+
+    const input = screen.getByRole('textbox');
+
+    await user.type(input, '123456');
+
+    await jest.advanceTimersByTimeAsync(WAIT + 100);
+
+    await waitFor(() => expect(validate).toHaveBeenCalledWith(
+      '123456',
+      { username: 'jdoe', barcode: '123456' },
+      undefined,
+    ));
+  });
+
+  // Regression test: if the field unmounts (e.g. it's conditionally rendered) while
+  // its own debounce timer is still pending, the surrounding <Form> can still be
+  // mounted. Simply clearing the timeout on unmount without resolving the pending
+  // Promise would leave the form permanently stuck "validating".
+  it('does not permanently block form submission when the field unmounts before its debounced validation fires', async () => {
+    const onSubmit = jest.fn();
+    const validate = jest.fn(() => undefined);
+
+    renderForm({ onSubmit, validate });
+
+    const input = screen.getByRole('textbox');
+
+    await user.type(input, '123456');
+
+    // Unmount the field before its debounce timer has a chance to fire.
+    await user.click(screen.getByRole('button', { name: 'Hide field' }));
+
+    await jest.advanceTimersByTimeAsync(WAIT + 100);
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+  });
+});

--- a/src/components/util/memoize.js
+++ b/src/components/util/memoize.js
@@ -6,10 +6,13 @@ export default function memoize(fn) {
   let lastArg;
   let lastResult;
 
-  return arg => {
+  // Only the first argument is used as the memoization key (e.g. a field's own
+  // value), but every argument the caller passes (e.g. final-form's `allValues`
+  // and `meta` for field-level validators) is still forwarded to `fn`.
+  return (arg, ...rest) => {
     if (arg !== lastArg) {
       lastArg = arg;
-      lastResult = fn(arg);
+      lastResult = fn(arg, ...rest);
     }
 
     return lastResult;


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIU-2 Status of new users defaults to 'active'.
-->

## Purpose
Be able to save a user record after entering a barcode/username (the Save button does nothing).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIU-2
 -->

## Approach
The root cause is that not all Promise's `resolve` were resolved in `AsyncValidateField`. 
The fix is to resolve the previous `resolve` on each entered character.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Issues
https://folio-org.atlassian.net/browse/UIU-3463
https://folio-org.atlassian.net/browse/UIU-3604

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
